### PR TITLE
Rename the repo to herbie-fp/herbie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![Herbie](logo.png)
 
 
-[![Build Status](https://travis-ci.org/uwplse/herbie.svg?branch=master)](https://travis-ci.org/uwplse/herbie)
-
 Herbie automatically improves the error of floating point expressions.
 Visit [our website](https://herbie.uwplse.org) for tutorials,
 documentation, and an online demo. Herbie has semi-regular releases
@@ -63,7 +61,7 @@ Herbie development is organized on our
 where we discuss work in progress and announce major improvements.
 [Email us](mailto:herbie@cs.washington.edu) to get involved!
 
-We use [Github](https://github.com/uwplse/herbie) and
+We use [Github](https://github.com/herbie-fp/herbie) and
 [Trello](https://trello.com/b/lh7b33Dr/herbie) to organize development
 goals.
 

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -186,7 +186,7 @@
     (h1 "Reproduce")
     ,(if bug?
          `(p "Please include this information when filing a "
-             (a ((href "https://github.com/uwplse/herbie/issues")) "bug report") ":")
+             (a ((href "https://github.com/herbie-fp/herbie/issues")) "bug report") ":")
          "")
     (pre ((class "shell"))
          (code

--- a/www/index.html
+++ b/www/index.html
@@ -57,10 +57,10 @@
     <div>
       <h3>Contribute</h3>
       <ul>
-        <li><a href="https://github.com/uwplse/herbie/issues">Report a Bug</a></li>
+        <li><a href="https://github.com/herbie-fp/herbie/issues">Report a Bug</a></li>
         <li><a href="https://mailman.cs.washington.edu/mailman/listinfo/herbie">Mailing List</a></li>
-        <li><a href="https://github.com/uwplse/herbie">Source Code</a></li>
-        <li><a href="https://github.com/uwplse/herbie/blob/master/LICENSE.md">License</a></li>
+        <li><a href="https://github.com/herbie-fp/herbie">Source Code</a></li>
+        <li><a href="https://github.com/herbie-fp/herbie/blob/master/LICENSE.md">License</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This changes some of the README and web files, but not documentation for older versions. Github will continue redirecting those links, so I think it's not a problem.