### PR TITLE
Make infinite floating-point values ordinary

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -5,10 +5,10 @@
 CORES=4
 
 set -e -x
+SEED=$(date "+%Y%j")
 
 function output_error {
     NAME="$2"
-    SEED="$3"
     DATE=`date +%s`
     COMMIT=`git rev-parse HEAD`
     BRANCH=`git rev-parse --abbrev-ref HEAD`
@@ -24,7 +24,6 @@ EOF
 function run {
   bench="$1"; shift
   name="$1"; shift
-  seed=$(date "+%Y%j")
   
   echo "Running $name test with flags $@"
   rm -rf "reports/$name"
@@ -32,11 +31,11 @@ function run {
       --note "$name" \
       --profile \
       --debug \
-      --seed "$seed" \
+      --seed "$SEED" \
       --threads "$CORES" \
       "$@" \
       "$bench" "reports/$name" \
-      || output_error "reports/$name/results.json" "$name" "$seed"
+      || output_error "reports/$name/results.json" "$name"
 }
 
 DIR="$1"

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -87,11 +87,9 @@
   (define binary64 (get-representation 'binary64))
   (check-true (ordinary-value? 2.5 binary64))
   (check-false (ordinary-value? +nan.0 binary64))
-  (check-false (ordinary-value? -inf.0 binary64))
   (define binary32 (get-representation 'binary32))
   (check-true (ordinary-value? 2.5f0 binary32))
-  (check-false (ordinary-value? +nan.f binary32))
-  (check-false (ordinary-value? -inf.f binary32)))
+  (check-false (ordinary-value? +nan.f binary32)))
 
 (define (=-or-nan? x1 x2 repr)
   (define ->ordinal (representation-repr->ordinal repr))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -79,7 +79,7 @@
   (define ->bf (representation-repr->bf repr))
   (define total-pts (length pt))
   (for* ([ex exs])
-    (define inf-pts (count (compose bfrational? ->bf) ex))
+    (define inf-pts (count (compose (disjoin boolean? bfrational?) ->bf) ex))
     (timeline-push! 'infinite inf-pts total-pts)
     (when (> inf-pts (* total-pts 0.20)) ; Warn on > 20% infinite points
       (warn 'inf-points #:url "faq.html#inf-points"

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -73,4 +73,16 @@
   (define sampler 
     (parameterize ([ground-truth-require-convergence #f])
       (make-sampler repr precondition progs how fn)))
-  (batch-prepare-points how fn repr sampler))
+  (match-define (pt exs ...) (batch-prepare-points how fn repr sampler))
+
+  ;; Count infinite points
+  (define ->bf (representation-repr->bf repr))
+  (define total-pts (length pt))
+  (for* ([ex exs])
+    (define inf-pts (count (compose bfrational? ->bf) ex))
+    (timeline-push! 'infinite inf-pts total-pts)
+    (when (> inf-pts (* total-pts 0.20)) ; Warn on > 20% infinite points
+      (warn 'inf-points #:url "faq.html#inf-points"
+            "Infinite outputs for ~a% of points. You may want to add a precondition.")))
+
+  (list* pt exs))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -31,7 +31,7 @@
 (define ground-truth-require-convergence (make-parameter #t))
 
 (define (valid-result? repr out)
-  (ival-and (ival-not (is-infinite-interval repr out))
+  (ival-and #;(ival-not (is-infinite-interval repr out))
             (if (ground-truth-require-convergence)
                 (is-samplable-interval repr out)
                 (ival (ival-hi (is-samplable-interval repr out))))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -73,7 +73,7 @@
   (define sampler 
     (parameterize ([ground-truth-require-convergence #f])
       (make-sampler repr precondition progs how fn)))
-  (match-define (pt exs ...) (batch-prepare-points how fn repr sampler))
+  (match-define (list pt exs ...) (batch-prepare-points how fn repr sampler))
 
   ;; Count infinite points
   (define ->bf (representation-repr->bf repr))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -31,11 +31,15 @@
 (define ground-truth-require-convergence (make-parameter #t))
 
 (define (valid-result? repr out)
-  (ival-and #;(ival-not (is-infinite-interval repr out))
-            (if (ground-truth-require-convergence)
+  (define is-samplable
+    (if (ground-truth-require-convergence)
                 (is-samplable-interval repr out)
-                (ival (ival-hi (is-samplable-interval repr out))))
-            (ival-not (ival-error? out))))
+                (ival (ival-hi (is-samplable-interval repr out)))))
+  (when (not (ival-hi is-samplable))
+    (warn 'ground-truth #:url "faq.html#ground-truth"
+          "unable to evaluate ground truth for some inputs"))
+  (define is-domain (ival-not (ival-error? out)))
+  (ival-and is-samplable is-domain))
 
 (define (eval-prog-wrapper progs repr)
   (match (filter (compose not (curryr expr-supports? 'ival) program-body) progs)

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -72,7 +72,7 @@
   (define ->bf (representation-repr->bf repr))
   (define total-pts (length pt))
   (for* ([ex exs])
-    (define inf-pts (count (compose (disjoin boolean? bfrational?) ->bf) ex))
+    (define inf-pts (count (compose not (disjoin boolean? bfrational?) ->bf) ex))
     (timeline-push! 'infinite inf-pts total-pts)
     (when (> inf-pts (* total-pts 0.20)) ; Warn on > 20% infinite points
       (warn 'inf-points #:url "faq.html#inf-points"

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require math/bigfloat rival)
-(require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt")
+(require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt" "timeline.rkt")
 
 (provide make-search-func prepare-points sample-points ground-truth-require-convergence)
 

--- a/src/reprs/binary32.rkt
+++ b/src/reprs/binary32.rkt
@@ -119,7 +119,7 @@
   (shift 31 ordinal->float32)
   (unshift 31 float32->ordinal)
   32
-  (disjoin nan? infinite?))
+  nan?)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/reprs/binary64.rkt
+++ b/src/reprs/binary64.rkt
@@ -21,7 +21,7 @@
   (shift 63 ordinal->flonum)
   (unshift 63 flonum->ordinal)
   64
-  (disjoin nan? infinite?))
+  nan?)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -13,6 +13,8 @@
 (define *conditions*
   `([asinh-2_binary64       . (>=.f64 x 0)]
     [asinh-2_binary32       . (>=.f32 x 0)]
+    [pow-base-0_binary64    . (>=.f64 x 0)]
+    [pow-base-0_binary32    . (>=.f32 x 0)]
     ;; These next three approximate pi so that range analysis will work
     [asin-sin-s_binary64    . (<=.f64 (fabs.f64 x) 1.5708)]
     [asin-sin-s_binary32    . (<=.f32 (fabs.f32 x) 1.5708)]

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -13,8 +13,10 @@
 (define *conditions*
   `([asinh-2_binary64       . (>=.f64 x 0)]
     [asinh-2_binary32       . (>=.f32 x 0)]
-    [pow-base-0_binary64    . (>=.f64 x 0)]
-    [pow-base-0_binary32    . (>=.f32 x 0)]
+    [pow-base-0_binary64    . (>=.f64 a 0)]
+    [pow-base-0_binary32    . (>=.f32 a 0)]
+    [pow-pow1_binary64      . (>=.f64 x 0)]
+    [pow-pow1_binary32      . (>=.f32 x 0)]
     ;; These next three approximate pi so that range analysis will work
     [asin-sin-s_binary64    . (<=.f64 (fabs.f64 x) 1.5708)]
     [asin-sin-s_binary32    . (<=.f32 (fabs.f32 x) 1.5708)]

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -120,6 +120,7 @@
 (define-timeline kept #:unmergable)
 (define-timeline min-error #:unmergable)
 (define-timeline egraph #:unmergable)
+(define-timeline infinite [count +] [total +])
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -160,7 +160,8 @@
   (match-define (list inf total) (first info))
   (if (> total 0)
       `((dt ,"Infinites")
-        (dd ,(format-percent inf total) " of outputs are infinite."))))
+        (dd ,(format-percent inf total) " of outputs are infinite."))
+      ""))
 
 (define (render-phase-accuracy accuracy oracle baseline name link)
   (define rows

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -71,6 +71,7 @@
          ,@(dict-call curr render-phase-bstep 'bstep)
          ,@(dict-call curr render-phase-egraph 'egraph)
          ,@(dict-call curr render-phase-sampling 'sampling)
+         ,@(dict-call curr render-phase-sampling 'infinite)
          ,@(dict-call curr (curryr simple-render-phase "Symmetry") 'symmetry)
          ,@(dict-call curr (curryr simple-render-phase "Remove") 'remove-preprocessing)
          ,@(dict-call curr render-phase-outcomes 'outcomes)
@@ -154,6 +155,12 @@
   `((dt ,name)
     (dd ,@(map (lambda (s) `(p ,(~a s))) (first info))))
   empty))
+
+(define (render-phase-infinite info)
+  (match-define (list inf total) (first info))
+  (if (> total 0)
+      `((dt ,"Infinites")
+        (dd ,(format-percent inf total) " of outputs are infinite."))))
 
 (define (render-phase-accuracy accuracy oracle baseline name link)
   (define rows

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -71,7 +71,7 @@
          ,@(dict-call curr render-phase-bstep 'bstep)
          ,@(dict-call curr render-phase-egraph 'egraph)
          ,@(dict-call curr render-phase-sampling 'sampling)
-         ,@(dict-call curr render-phase-sampling 'infinite)
+         ,@(dict-call curr render-phase-infinite 'infinite)
          ,@(dict-call curr (curryr simple-render-phase "Symmetry") 'symmetry)
          ,@(dict-call curr (curryr simple-render-phase "Remove") 'remove-preprocessing)
          ,@(dict-call curr render-phase-outcomes 'outcomes)

--- a/www/doc/1.5/faq.html
+++ b/www/doc/1.5/faq.html
@@ -78,6 +78,17 @@
   <p>Herbie warnings refer to this section for explanations and common
   actions to take.</p>
 
+  <h3 id="inf-points">Infinite outputs for too many points</h3>
+  
+  <p>
+    Some computations, like <code>exp(1000.0)</code>, produce an
+    answer so large that its best floating-point representation is
+    infinity. While Herbie can handle programs like this fine, often
+    these aren't points you want Herbie to focus on. In that case,
+    you'll want to give Herbie a precondition that defines what values
+    are valid inputs to your program.
+  </p>
+
   <h3 id="ground-truth">Could not determine a ground truth</h3>
 
   <p>
@@ -89,7 +100,7 @@
     this warning, you should add a restrictive precondition, such
     as <code>:pre (&lt; -100 x 100)</code>, to prevent large inputs.
   </p>
-
+  
   <h3 id="native-ops">Native <var>operation</var> not supported on your system</h3>
 
   <p>
@@ -128,7 +139,16 @@
     Herbie will automatically compensate for this, and in most cases nothing needs to be done.
     However, Herbie may have failed to simplify the output.
   </p>
+  
+  <h3 id="no-ival-operator">Using unsound ground truth evaluation</h3>
 
+  <p>
+    This warning occurs when certain rare operators such
+    as <code>lgamma</code> or <code>y1</code> are passed to Herbie.
+    These operators are only partially supported, and Herbie's results
+    on programs that use those operators are more likely to be
+    incorrect. Please check over Herbie's output before using it.
+  </p>
 
   <h2>Known bugs</h2>
 


### PR DESCRIPTION
This is a big change to how Herbie measures error.

**Background**: Herbie measures error by averaging over *valid, samplable* points. A point can be invalid for three reasons: it can fail the user's precondition; it can cause a domain error; or, it can produce an output that rounds to floating-point infinity. This PR removes this last condition; those points are now valid.

**Why do it?**: This is part of trying to make Herbie handle different representations, like float, posit, and fixed-point uniformly. It's hard to see how to make infinity work uniformly. Meanwhile the logic for treating it like an ordinary value is pretty strong. Basically: we think of `+inf` as the floating-point representation of real numbers like `1e400`. This way we don't need to define a semantics for extended real numbers.

**Effects**: The effects of this are going to be hard to assess. We can't just look at the effect on Herbie's bits recovered, since we're changing the definition of error. Instead, we need to make sure that this change doesn't trigger any Herbie bugs, but we also need to make sure that the solutions Herbie produces stay high quality.

So far, it looks like the effect is positive. Specifically, for a transformation like `exp(x) - 1 ~> x + x^2/2 + x^3/6`, allowing infinite outputs allows inputs `700 < x < inf`. This reveals that the transformation is actually bad for `1 < x < 1e100`, and since this is now a huge fraction of points Herbie is forced to add a regime—which is actually good because that regime is valuable for users.