### PR TITLE
Add input range preconditions in the default mathjs interface.

### DIFF
--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -334,6 +334,7 @@ function onload() {
     hide_and_delete_later('#formula textarea')
     hide_and_delete_later('#formula .extra-links')
     hide_and_delete_later('#formula .extra-fields')
+    hide_and_delete_later('#lisp-instructions')
 
     // Only records ranges the user intentionally set.
     const known_input_ranges = { /* "x" : [-1, 1] */ }
@@ -468,6 +469,12 @@ function onload() {
 
     document.body.appendChild(html(`
     <style>
+
+        #mathjs-instructions-test {
+            width: 100%;
+            font-size: 125%;
+        }
+
         input.input-range {
             width: auto !important;
         }

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -211,8 +211,8 @@ function get_errors() {
 
 function check_errors() {
     var input = document.querySelector("[name=formula-math]");
-    var pre = document.querySelector("[name=pre]");
-    var errors = get_errors([input.value, "real"], [pre.value || "TRUE", "bool"]);
+    
+    var errors = get_errors([input.value, "real"]);
 
     if (!input.value) {
         document.getElementById("errors").innerHTML = "";
@@ -373,7 +373,6 @@ function onload() {
 
     function hide(selector) { document.querySelector(selector).style.display = 'none' }
     hide('#formula textarea')
-    hide('#formula .extra-fields')
 
     var form = new Form(document.getElementById("formula"));
 

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -478,11 +478,16 @@ function onload() {
     
     update_run_button_mathjs(form)
 
-    let current_timeout = undefined  // used to debounce the input box
+    let current_timeout = undefined  // can be used to debounce the input box
     function check_errors_and_draw_ranges() {
         if (form.math.value === "") document.querySelector('#input-ranges').innerHTML=''
-        if (!check_errors()) { return }
-        const varnames = get_varnames_mathjs(form.math.value)
+        let varnames;
+        try {
+            varnames = get_varnames_mathjs(form.math.value)
+        } catch (e) {
+            check_errors()
+            return
+        }
         const range_div = document.querySelector('#input-ranges')
         range_div.replaceChildren(...varnames.map(range_inputs))
     }
@@ -490,7 +495,7 @@ function onload() {
     
     form.math.addEventListener("input", function () {
         clearTimeout(current_timeout)
-        current_timeout = setTimeout(check_errors_and_draw_ranges, 400)
+        current_timeout = setTimeout(check_errors_and_draw_ranges, 0)  // turn off debouncing
         update_run_button_mathjs(form)
     })
     form.math.setAttribute('autocomplete', 'off')  // (because it hides the error output)

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -280,7 +280,7 @@ function get_precondition_from_input_ranges(formula) {
     .filter(([_, range]) => get_input_range_errors(range).length == 0)
     .map(([name, [start, end]]) => `(<= ${start} ${name} ${end})`)
     .join(' ')
-    return checks.length == 0 ? "" : `(and ${checks}`
+    return checks.length == 0 ? "" : `(and ${checks})`
 }
 
 function setup_state(state, form) {

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -466,8 +466,10 @@ function onload() {
 
     let current_timeout = undefined  // used to debounce the input box
     function check_errors_and_draw_ranges() {
+        if (form.math.value === "") document.querySelector('#input-ranges').innerHTML=''
         if (!check_errors()) { return }
         const varnames = get_varnames_mathjs(form.math.value)
+        const range_div = document.querySelector('#input-ranges')
         const range_prompt = varnames.length > 0 ? html(`<div>Please specify the approximate range of each input so that Herbie can optimize for your use case.</div>`) : ``
         range_div.replaceChildren(range_prompt, ...varnames.map(range_inputs))
     }
@@ -494,7 +496,8 @@ function onload() {
 
 
     // TODO move submit button to end
-    document.querySelector('#formula').appendChild(document.querySelector('#formula').removeChild(document.querySelector('#formula button')))
+
+    //document.querySelector('#formula').appendChild(document.querySelector('#formula').removeChild(document.querySelector('#formula button')))
 
     document.body.appendChild(html(`
     <style>

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -495,7 +495,7 @@ function onload() {
     
     form.math.addEventListener("input", function () {
         clearTimeout(current_timeout)
-        current_timeout = setTimeout(check_errors_and_draw_ranges, 0)  // turn off debouncing
+        current_timeout = setTimeout(check_errors_and_draw_ranges, 400)
         update_run_button_mathjs(form)
     })
     form.math.setAttribute('autocomplete', 'off')  // (because it hides the error output)

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -251,7 +251,6 @@ function hide_extra_fields() {
     $a.textContent = "Advanced options »";
     $a.classList.add("show-extra");
     $extra.parentNode.insertBefore($a, $extra.nextSibling);
-    //$extra.style.display = "none";
     $a.addEventListener("click", function() {
         $extra.style.display = "block";
         $a.style.display = "none";
@@ -289,50 +288,33 @@ function setup_state(state, form) {
     form.fpcore.removeAttribute("disabled");
     form.math.removeAttribute("disabled");
 
-    if (!form.a_fpcore) {
-        form.a_fpcore = document.createElement("a");
-        form.a_fpcore.textContent = "Convert to FPCore input";
-        form.a_fpcore.addEventListener("click", function(evt) {
-            if (form.math.value) {
-                if (!check_errors()) {
-                    alert("Please fix all errors before attempting to use FPCore input.")
-                    return evt.preventDefault();
-                }
-                var fpcore = dump_fpcore(form.math.value)
-                form.fpcore.value = fpcore;
+    document.querySelector('#use-fpcore-input a').onclick = function(evt) {
+        if (form.math.value) {
+            if (!check_errors()) {
+                alert("Please fix all errors before attempting to use FPCore input.")
+                return evt.preventDefault();
             }
-            setup_state("fpcore", form);
-        });
-        
+            var fpcore = dump_fpcore(form.math.value)
+            form.fpcore.value = fpcore;
+        }
+        setup_state("fpcore", form);
     }
-    form.extra_links.appendChild(form.a_fpcore);
 
-    // if (!form.a_mathjs) {
-    //     form.a_mathjs = document.createElement("a");
-    //     form.a_mathjs.textContent = "back to MathJS input";
-    //     form.a_mathjs.addEventListener("click", function(evt) {
-    //         setup_state("math", form);
-    //     });
-        
-    // }
-    // form.extra_links.appendChild(form.a_mathjs);
-    
     if (state == "math") {
         form.fpcore.style.display = "none";
         form.math.style.display = "block";
         form.input_ranges.style.display = "table";
+        document.querySelector('#use-fpcore-input').style.display = 'block';
         document.querySelector("#lisp-instructions").style.display = "none";
         document.querySelector("#mathjs-instructions").style.display = "block";
-        //form.extra_links.removeChild(form.a_mathjs)
         update_run_button_mathjs(form)
     } else {
+        document.querySelector('#use-fpcore-input').style.display = 'none';
         form.fpcore.style.display = "block";
         form.math.style.display = "none";
         form.input_ranges.style.display = "none";
         document.querySelector("#lisp-instructions").style.display = "block";
         document.querySelector("#mathjs-instructions").style.display = "none";
-        form.extra_links.removeChild(form.a_fpcore)
-        //form.extra_links.removeChild(form.a_mathjs)  // (we can't reverse the formula; could throw it out?)
         form.button.classList.remove("hidden");
         form.button.removeAttribute("disabled");
     }
@@ -453,20 +435,10 @@ function onload() {
 
 
         function show_errors(root=document) {
-            //const error_msgs = get_input_range_errors(KNOWN_INPUT_RANGES[varname], true)
             root.querySelectorAll(`#${varname}_input input`).forEach(input => {
                 input.style['background-color'] = input.value === '' ? '#a6ffff3d' : 'initial'
             })
-            // const e = root.querySelector(`#${varname}_input #errors`)
-            // e.innerHTML = error_msgs.map(msg => `<li>${msg}</li>`).join('')
-            // e.style.display = error_msgs.length > 0 ? 'block' : 'none'
         }
-        // function show_warnings(root=document) {
-        //     // const warning_msgs = get_input_range_warnings(KNOWN_INPUT_RANGES[varname])
-        //     // const e = root.querySelector(`#${varname}_input #warnings`)
-        //     // e.innerHTML = warning_msgs.map(msg => `<li>${msg}</li>`).join('')
-        //     // e.style.display = warning_msgs.length > 0 ? 'block' : 'none'
-        // }
         function set_input_range({ low, high }) {
             if (low !== undefined) low_el.value = low
             if (high !== undefined) high_el.value = high
@@ -475,7 +447,6 @@ function onload() {
             KNOWN_INPUT_RANGES[varname] = [low ?? old_low, high ?? old_high]
             check_errors()
             show_errors()
-            //show_warnings()
             update_run_button_mathjs(form)
         }
         low_el.addEventListener('input', () => set_input_range({ low: low_el.value }))
@@ -513,7 +484,6 @@ function onload() {
         if (!check_errors()) { return }
         const varnames = get_varnames_mathjs(form.math.value)
         const range_div = document.querySelector('#input-ranges')
-        //const range_prompt = varnames.length > 0 ? html(`<div>Please specify the approximate range of each input so that Herbie can optimize for your use case.</div>`) : ``
         range_div.replaceChildren(...varnames.map(range_inputs))
     }
     check_errors_and_draw_ranges()

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -306,6 +306,7 @@ function setup_state(state, form) {
         document.querySelector("#lisp-instructions").style.display = "none";
         document.querySelector("#mathjs-instructions").style.display = "block";
         form.extra_links.removeChild(form.a_mathjs)
+        update_run_button_mathjs()
     } else {
         form.fpcore.style.display = "block";
         form.math.style.display = "none";
@@ -327,6 +328,22 @@ function get_varnames_mathjs(mathjs_text) {
         if (dnames.indexOf(names[i]) === -1) dnames.push(names[i]);
     }
     return dnames
+}
+
+function update_run_button_mathjs() {
+    const button = document.querySelector('#run_herbie')
+    let varnames;
+    try {
+        varnames = get_varnames_mathjs(form.math.value)
+    } catch (e) {
+        button.setAttribute('disabled', 'true')
+        return;
+    }
+    if (form.math.value && varnames.every(varname => no_range_errors(KNOWN_INPUT_RANGES[varname]))) {
+        button.removeAttribute('disabled')
+    } else {
+        button.setAttribute('disabled', 'true')
+    }
 }
 
 function get_input_range_errors([low, high] = [undefined, undefined], empty_if_missing=false) {
@@ -438,7 +455,7 @@ function onload() {
             KNOWN_INPUT_RANGES[varname] = [low ?? old_low, high ?? old_high]
             show_errors()
             show_warnings()
-            update_run_button()
+            update_run_button_mathjs()
         }
         low_el.addEventListener('input', () => set_input_range({ low: low_el.value }))
         view.querySelectorAll(`#${low_id}_dropdown .dropdown-content div`).forEach((e, i) => {
@@ -467,22 +484,8 @@ function onload() {
         return low !== '' && high !== '' && !isNaN(Number(low)) && !isNaN(Number(high)) && Number(low) <= Number(high) 
     }
 
-    function update_run_button() {
-        const button = document.querySelector('#run_herbie')
-        let varnames;
-        try {
-            varnames = get_varnames_mathjs(form.math.value)
-        } catch (e) {
-            button.setAttribute('disabled', 'true')
-            return;
-        }
-        if (form.math.value && varnames.every(varname => no_range_errors(KNOWN_INPUT_RANGES[varname]))) {
-            button.removeAttribute('disabled')
-        } else {
-            button.setAttribute('disabled', 'true')
-        }
-    }
-    update_run_button()
+    
+    update_run_button_mathjs()
 
     let current_timeout = undefined  // used to debounce the input box
     function check_errors_and_draw_ranges() {
@@ -498,7 +501,7 @@ function onload() {
     form.math.addEventListener("input", function () {
         clearTimeout(current_timeout)
         current_timeout = setTimeout(check_errors_and_draw_ranges, 400)
-        update_run_button()
+        update_run_button_mathjs()
     })
     form.math.setAttribute('autocomplete', 'off')  // (because it hides the error output)
 

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -371,6 +371,9 @@ function get_input_range_errors([low, high] = [undefined, undefined], empty_if_m
 
 function onload() {
 
+    // Only records ranges the user intentionally set.
+    window.KNOWN_INPUT_RANGES = { /* "x" : [-1, 1] */ }
+
     function hide(selector) { document.querySelector(selector).style.display = 'none' }
     hide('#formula textarea')
 
@@ -387,9 +390,6 @@ function onload() {
     else STATE = "math";
 
     setup_state(STATE, form);
-
-    // Only records ranges the user intentionally set.
-    window.KNOWN_INPUT_RANGES = { /* "x" : [-1, 1] */ }
 
     function html(string) {
         const t = document.createElement('template');

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -352,7 +352,7 @@ function onload() {
         
         const low_id = `${varname}_low`
         const high_id = `${varname}_high`
-        const default_options = ['-1e9', '-1e3', '-1', '0', '1', '1e3', '1e9']
+        const default_options = ['-1.79e308', '-1e9', '-1e3', '-1', '0', '1', '1e3', '1e9', '1.79e308']
         function input_view(id, value) {
             return `
                 <div id="${id}_dropdown" class="dropdown">
@@ -366,7 +366,9 @@ function onload() {
         const error_msgs = get_errors(known_input_ranges[varname])
         const view = html(`
             <div id="${varname}_input" class="input-range-view">
-                <div>${input_view(low_id, low)} <span class="varname"> &le; ${varname} &leq; </span> ${input_view(high_id, high)}</div>
+                <div>
+                <span class="varname"> ${varname}: </span> 
+                ${input_view(low_id, low)} to ${input_view(high_id, high)}</div>
                 <ul id="errors" style="display: ${error_msgs.length > 0 ? 'block' : 'none'}">${error_msgs.map(msg => `<li>${msg}</li>`).join('')}</ul>
             </div>`)
 
@@ -439,7 +441,7 @@ function onload() {
     function check_errors_and_draw_ranges() {
         if (!check_errors()) { return }
         const varnames = get_varnames_mathjs(form.math.value)
-        const range_prompt = varnames.length > 0 ? html(`<div>Please specify the range of each input so that Herbie can optimize for your use case.</div>`) : ``
+        const range_prompt = varnames.length > 0 ? html(`<div>Please specify the approximate range of each input so that Herbie can optimize for your use case.</div>`) : ``
         range_div.replaceChildren(range_prompt, ...varnames.map(range_inputs))
     }
     check_errors_and_draw_ranges()

--- a/src/web/demo.js
+++ b/src/web/demo.js
@@ -306,7 +306,7 @@ function setup_state(state, form) {
         document.querySelector("#lisp-instructions").style.display = "none";
         document.querySelector("#mathjs-instructions").style.display = "block";
         form.extra_links.removeChild(form.a_mathjs)
-        update_run_button_mathjs()
+        update_run_button_mathjs(form)
     } else {
         form.fpcore.style.display = "block";
         form.math.style.display = "none";
@@ -330,7 +330,10 @@ function get_varnames_mathjs(mathjs_text) {
     return dnames
 }
 
-function update_run_button_mathjs() {
+function update_run_button_mathjs(form) {
+    function no_range_errors([low, high] = [undefined, undefined]) {
+        return low !== '' && high !== '' && !isNaN(Number(low)) && !isNaN(Number(high)) && Number(low) <= Number(high) 
+    }
     const button = document.querySelector('#run_herbie')
     let varnames;
     try {
@@ -455,7 +458,7 @@ function onload() {
             KNOWN_INPUT_RANGES[varname] = [low ?? old_low, high ?? old_high]
             show_errors()
             show_warnings()
-            update_run_button_mathjs()
+            update_run_button_mathjs(form)
         }
         low_el.addEventListener('input', () => set_input_range({ low: low_el.value }))
         view.querySelectorAll(`#${low_id}_dropdown .dropdown-content div`).forEach((e, i) => {
@@ -480,12 +483,10 @@ function onload() {
     const range_div = document.createElement('DIV')
     document.querySelector('#formula').appendChild(range_div)
 
-    function no_range_errors([low, high] = [undefined, undefined]) {
-        return low !== '' && high !== '' && !isNaN(Number(low)) && !isNaN(Number(high)) && Number(low) <= Number(high) 
-    }
+    
 
     
-    update_run_button_mathjs()
+    update_run_button_mathjs(form)
 
     let current_timeout = undefined  // used to debounce the input box
     function check_errors_and_draw_ranges() {
@@ -501,7 +502,7 @@ function onload() {
     form.math.addEventListener("input", function () {
         clearTimeout(current_timeout)
         current_timeout = setTimeout(check_errors_and_draw_ranges, 400)
-        update_run_button_mathjs()
+        update_run_button_mathjs(form)
     })
     form.math.setAttribute('autocomplete', 'off')  // (because it hides the error output)
 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -110,8 +110,9 @@
              (select ([name "precision"] [id "precision"])
                (option ([value "binary64"]) "Double-precision floats")
                (option ([value "binary32"]) "Single-precision floats")))
-           (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
            (ul ([id "errors"]))
+           (div ([id "input-ranges"]))
+           (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
            (pre ([id "progress"] [style "display: none;"])))
 
     (if (*demo?*)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -97,7 +97,7 @@
     #:title (if (*demo?*) "Herbie web demo" "Herbie")
     #:show-title (*demo?*)
     #:scripts '("//cdnjs.cloudflare.com/ajax/libs/mathjs/1.6.0/math.min.js" "demo.js")
-    `(p "Enter a formula below, hit " (kbd "Enter") ", and Herbie will try to improve it.")
+    `(p "Enter a formula below, and Herbie will try to improve it.")
     `(form ([action ,(url improve)] [method "post"] [id "formula"]
             [data-progress ,(url improve-start)])
            (textarea ([name "formula"] [autofocus "true"] [placeholder "(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
@@ -139,9 +139,7 @@
         " and the "
         (a ([href ,(format "https://herbie.uwplse.org/doc/~a/input.html" *herbie-version*)])
         "standard functions")
-        " listed at the bottom of this page. If you're not sure how to use a function, try writing an expression without variables in the box below.")
-      `(div ( )
-        (input ([id "mathjs-instructions-test"] [name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"])))
+        " listed at the bottom of this page.")
     
     (function-list
      '((+ - * / abs) "The usual arithmetic functions")

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -97,16 +97,18 @@
     #:title (if (*demo?*) "Herbie web demo" "Herbie")
     #:show-title (*demo?*)
     #:scripts '("//cdnjs.cloudflare.com/ajax/libs/mathjs/1.6.0/math.min.js" "demo.js")
-    `(p "Enter a formula below, and Herbie will try to improve it.")
+    `(p "Write a formula below, and Herbie will try to improve it. Enter approximate ranges for inputs.")
     `(form ([action ,(url improve)] [method "post"] [id "formula"]
             [data-progress ,(url improve-start)])
-           (textarea ([name "formula"] [autofocus "true"] [placeholder "(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
-           (input ([name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"]))
-           (div ([class "extra-links"]))
-           (ul ([id "errors"]))
-           (div ([id "input-ranges"]))
-           (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
-           (pre ([id "progress"] [style "display: none;"])))
+          
+        (textarea ([name "formula"] [autofocus "true"] [placeholder "(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
+        (input ([name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"]))
+        (table ([id "input-ranges"]))
+        (ul ([id "errors"]))
+        (ul ([id "warnings"]))
+        (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
+        (span ([class "extra-links"]))
+        (pre ([id "progress"] [style "display: none;"])))
 
     (if (*demo?*)
         `(p "To handle the high volume of requests, web requests are queued; "

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -98,6 +98,9 @@
     #:show-title (*demo?*)
     #:scripts '("//cdnjs.cloudflare.com/ajax/libs/mathjs/1.6.0/math.min.js" "demo.js")
     `(p "Write a formula below, and Herbie will try to improve it. Enter approximate ranges for inputs.")
+    `(p ([id "use-fpcore-input"]) "You can also "
+       (a "use FPCore")
+       ".")
     `(form ([action ,(url improve)] [method "post"] [id "formula"]
             [data-progress ,(url improve-start)])
           
@@ -107,7 +110,6 @@
         (ul ([id "errors"]))
         (ul ([id "warnings"]))
         (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
-        (span ([class "extra-links"]))
         (pre ([id "progress"] [style "display: none;"])))
 
     (if (*demo?*)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -103,13 +103,6 @@
            (textarea ([name "formula"] [autofocus "true"] [placeholder "(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
            (input ([name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"]))
            (div ([class "extra-links"]))
-           (div ([class "extra-fields"])
-             (label ([for "pre"]) "Precondition")
-             (input ([name "pre"] [id "pre"] [placeholder "TRUE"]))
-             (label ([for "precision"]) "Precision")
-             (select ([name "precision"] [id "precision"])
-               (option ([value "binary64"]) "Double-precision floats")
-               (option ([value "binary32"]) "Single-precision floats")))
            (ul ([id "errors"]))
            (div ([id "input-ranges"]))
            (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
@@ -134,13 +127,6 @@
         (a ([href ,(format "https://herbie.uwplse.org/doc/~a/input.html" *herbie-version*)])
            "standard functions")
         " like:")
-      `(p ([id "mathjs-instructions"] )
-        "Herbie supports ordinary mathematical syntax (parsed by "
-        (a ([href "https://mathjs.org"]) "math.js") ")"
-        " and the "
-        (a ([href ,(format "https://herbie.uwplse.org/doc/~a/input.html" *herbie-version*)])
-        "standard functions")
-        " listed at the bottom of this page.")
     
     (function-list
      '((+ - * / abs) "The usual arithmetic functions")

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -110,7 +110,7 @@
              (select ([name "precision"] [id "precision"])
                (option ([value "binary64"]) "Double-precision floats")
                (option ([value "binary32"]) "Single-precision floats")))
-           (button ([type "submit"] [tabindex "-1"]) "Improve with Herbie")
+           (button ([id "run_herbie"] [type "submit"] [tabindex "-1"]) "Improve with Herbie")
            (ul ([id "errors"]))
            (pre ([id "progress"] [style "display: none;"])))
 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -133,6 +133,15 @@
         (a ([href ,(format "https://herbie.uwplse.org/doc/~a/input.html" *herbie-version*)])
            "standard functions")
         " like:")
+      `(p ([id "mathjs-instructions"] )
+        "Herbie supports ordinary mathematical syntax (parsed by "
+        (a ([href "https://mathjs.org"]) "math.js") ")"
+        " and the "
+        (a ([href ,(format "https://herbie.uwplse.org/doc/~a/input.html" *herbie-version*)])
+        "standard functions")
+        " listed at the bottom of this page. If you're not sure how to use a function, try writing an expression without variables in the box below.")
+      `(div ( )
+        (input ([id "mathjs-instructions-test"] [name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"])))
     
     (function-list
      '((+ - * / abs) "The usual arithmetic functions")

--- a/src/web/main.css
+++ b/src/web/main.css
@@ -46,11 +46,13 @@ ul {padding-left: 1em;}
 a {color: #2A6496; text-decoration: none}
 a:hover {text-decoration: underline; color: #295785}
 
-#formula textarea, #formula input { width: 100%; font-size: 125%; }
+#formula textarea, #formula input { width: 100%; font-size: 125%; background-color: white; border: 1px solid rgba(222, 229, 231, 1); border-radius: 2px; }
 #formula textarea { font-family: monospace; height: 7em; }
+#input-ranges { margin-top: .1em; }
+#input-ranges td {padding-top: .4em; }
 .extra-fields { margin-top: 1em; }
 .extra-links {
-    display: block; text-align: right; margin-top: .5em; cursor: pointer;
+    float: right; margin-top: .2em; cursor: pointer;
 }
 .extra-links a:after {
      content: "•"; color: black; display: inline-block; padding: 0 1ex;
@@ -74,7 +76,7 @@ input.input-range { width: auto !important; }
 .dropdown-content div:hover {background-color: #f1f1f1}
 .dropdown-content:hover { display: block; }
 .dropdown:focus-within .dropdown-content { display: block; }
-#warnings li { background: #fd0; width: fit-content; }
+#warnings li { color: orange; }
 
 #progress {
     font-size: 14px; font-family: sans-serif; background-color: #f1f1f1;

--- a/src/web/main.css
+++ b/src/web/main.css
@@ -60,6 +60,22 @@ a:hover {text-decoration: underline; color: #295785}
 #formula .extra-fields input, .extra-fields select { width: 80%; font-size: 100%; }
 #errors li { color: #800; }
 #formula button[type=submit].hidden { visibility: hidden; height: 0; }
+
+#mathjs-instructions-test { width: 100%; font-size: 125%; }
+input.input-range { width: auto !important; }
+.input-range-view { margin-top: 15px; margin-bottom: 15px; }
+.input-range-view .varname { font-size: 125%; }
+.dropdown { position: relative; display: inline-block; }
+.dropdown-content { 
+    display: none; position: absolute; background-color: #f9f9f9; 
+    min-width: 160px; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1; }
+.dropdown-content div { padding: 5px; }
+.dropdown-content div:hover {background-color: #f1f1f1}
+.dropdown-content:hover { display: block; }
+.dropdown:focus-within .dropdown-content { display: block; }
+#warnings li { background: #fd0; width: fit-content; }
+
 #progress {
     font-size: 14px; font-family: sans-serif; background-color: #f1f1f1;
     padding-left: 0; overflow: scroll; overflow-y: auto;

--- a/src/web/main.css
+++ b/src/web/main.css
@@ -62,7 +62,7 @@ a:hover {text-decoration: underline; color: #295785}
 #formula .extra-fields input, .extra-fields select { width: 80%; font-size: 100%; }
 #errors li { color: #800; }
 #formula button[type=submit].hidden { visibility: hidden; height: 0; }
-
+#mathjs-instructions, #lis { margin-top: 3em;}
 #mathjs-instructions-test { width: 100%; font-size: 125%; }
 input.input-range { width: auto !important; }
 .input-range-view { margin-top: 15px; margin-bottom: 15px; }

--- a/src/web/main.css
+++ b/src/web/main.css
@@ -76,7 +76,7 @@ input.input-range { width: auto !important; }
 .dropdown-content div:hover {background-color: #f1f1f1}
 .dropdown-content:hover { display: block; }
 .dropdown:focus-within .dropdown-content { display: block; }
-#warnings li { color: orange; }
+#warnings li { color: #cc5a2a; }
 
 #progress {
     font-size: 14px; font-family: sans-serif; background-color: #f1f1f1;


### PR DESCRIPTION
This PR modifies `src/web/demo.js`, `src/web/demo.rkt`, and `src/web/main.css` to allow users to specify input range preconditions in the default mathjs interface.

Ranges appear for each parsed input variable and are specified through pairs of input boxes. If users enter incorrect values in the ranges (non-numbers, numbers outside the ranges, out-of-order ranges), appropriate error messages are displayed. To avoid showing errors while users are working, no errors are displayed for legitimate partial ranges, but users must specify both sides of each range in order to submit the form. Unfilled ranges are highlighted with light blue. Single-point ranges show a yellow-highlighted warning message, but still allow form submission. Once input, values for the range of a particular variable name are remembered on the window object and can be reused if the user happens to change the expression. Submitting the form turns the ranges into a valid precondition.

The FPCore input interface is still accessible via the extra-links and loads on the same page with the expression and precondition from the mathjs interface. (Internally, the setup_state() function is still used for this.)

A few other interface changes are included.
* Submission using the "Enter" key was removed since it no longer makes sense. 
* The "extra options" inputs were removed, since users who would like to use a more advanced interface can just use the FPCore input box or the command line tool.
* Parsing of input to the mathjs input was debounced with a 400ms delay to avoid showing errors and partial ranges as the user is typing.