### PR TITLE
Penalize `pow` with fractional (odd denominator) exponents

### DIFF
--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egg-herbie"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2018"
 
@@ -14,6 +14,7 @@ libc = "0.2.71"
 smallvec = "1.4.0"
 
 num-rational = "0.3.0"
+num-integer = "0.1.42"
 num-bigint = "0.3.0"
 num-traits = "0.2.12"
 env_logger = { version = "0.7", default-features = false }

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -39,31 +39,21 @@ impl<'a> CostFunction<Math> for AltCost<'a> {
     where
         C: FnMut(Id) -> Self::Cost,
     {
-        match enode {
-            Math::Pow([_, _, i]) => {
-                if self.egraph[*i].nodes.iter().any(|n| match n {
-                    Math::Constant(x) => !x.denom().is_one() && x.denom().is_odd(),
-                    _ => false,
-                }) {
-                    usize::MAX
-                } else {
-                    enode.fold(1, |sum, id| {
-                        if self.ignore.contains(&id) {
-                            usize::MAX
-                        } else {
-                            usize::saturating_add(sum, costs(id))
-                        }
-                    })
+        if let Math::Pow([_, _, i]) = enode {
+            if let Some(n) = &self.egraph[*i].data {
+                if !n.denom().is_one() && n.denom().is_odd() {
+                    return usize::MAX;
                 }
             }
-            _ => enode.fold(1, |sum, id| {
-                if self.ignore.contains(&id) {
-                    usize::MAX
-                } else {
-                    usize::saturating_add(sum, costs(id))
-                }
-            }),
         }
+
+        enode.fold(1, |sum, id| {
+            if self.ignore.contains(&id) {
+                usize::MAX
+            } else {
+                usize::saturating_add(sum, costs(id))
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Change `egg-herbie` cost function: do not extract `pow` nodes with fractional (odd denominator) exponents. This should clean up some of Herbie's output and seems to help the soon-to-be-merged `egg-rr` branch.