### PR TITLE
Fixes

### DIFF
--- a/infra/nightly.rkt
+++ b/infra/nightly.rkt
@@ -53,5 +53,6 @@
    (apply merge-reports outdir dirs)
    (apply merge-timelines outdir dirs)
    (apply merge-profiles outdir dirs)
+   (copy-file (web-resource "arrow-chart.js") (build-path outdir "arrow-chart.js") #t)
    (copy-file (web-resource "report.js") (build-path outdir "report.js") #t)
    (copy-file (web-resource "report.css") (build-path outdir "report.css") #t)))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -210,9 +210,11 @@
   (unless (or (^series^) (^rewrites^))
     (raise-user-error 'simplify! "No candidates generated. Run (gen-series!) or (gen-rewrites!)"))
 
+  ; load final in case simplify is disabled
+  (^final^ (append (or (^series^) '()) (or (^rewrites^) '())))
   (when (flag-set? 'generate 'simplify)
     (timeline-event! 'simplify)
-    (define children (append (or (^series^) empty) (or (^rewrites^) empty)))
+    (define children (^final^))
 
     ;; We want to avoid simplifying if possible, so we only
     ;; simplify things produced by function calls in the rule

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -83,14 +83,15 @@
     ))
 
 (define (render-preprocess preprocess-structs)
-  `(div ([id "preprocess"] [class "program math"])
-        "\\["
+  `(div ([id "preprocess"])
+    (div ([class "program math"])
+        "\\[ \\begin{array}{c}"
         ,@(for/list ([preprocess preprocess-structs])
             (match preprocess
               [`(sort ,vars ...)
                (define varstring (format "[~a]" (string-join (map ~a vars) ", ")))
-               (format "~a = \\mathsf{sort}(~a) \\" varstring varstring)]))
-        "\\]"))
+               (format "~a = \\mathsf{sort}(~a)\\\\ " varstring varstring)]))
+        "\\end{array} \\]")))
 
 (define (render-program #:to [result #f] preprocess test)
   (define identifier (test-identifier test))


### PR DESCRIPTION
A trio of uncontroversial fixes:
- simplify can be disabled without crashing
- properly renders preprocess variables in report
- actually renders arrow chart in merged report