### PR TITLE
egg-RR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
-.PHONY: help install nightly index start-server deploy
+.PHONY: help install egg-herbie nightly index start-server deploy
 
 help:
 	@echo "Type 'make install' to install Herbie"
 	@echo "Then type 'racket src/herbie.rkt web' to run it."
 
-install:
+install: egg-herbie
+	raco pkg install --skip-installed --auto --name herbie src/
+	raco pkg update --name herbie src/
+
+egg-herbie:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml
 	raco pkg remove --force egg-herbie && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg remove --force egg-herbie-linux && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg remove --force egg-herbie-windows && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg remove --force egg-herbie-osx && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg install ./egg-herbie
-	raco pkg install --skip-installed --auto --name herbie src/
-	raco pkg update --name herbie src/
 
 distribution: minimal-distribution
 	cp -r bench herbie-compiled/

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egg-herbie"
-version = "0.2.1"
+version = "0.2.2"
 authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2018"
 

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -76,8 +76,9 @@
 
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants (_fun _egraph-pointer
-                                          _uint ;; node id
-                                          -> _pointer)) ;; string pointer
+                                          _uint           ;; node id
+                                          _string/utf-8   ;; original expr
+                                          -> _pointer))   ;; string pointer
 
 (define-eggmath egraph_get_cost (_fun _egraph-pointer
                                       _uint ;; node id

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -73,6 +73,13 @@
                                          _uint ;; iteration
                                          -> _pointer)) ;; string pointer
 
+;; TODO egg-rr
+;; node number -> (s-expr string) string
+(define-eggmath egraph_get_variants (_fun _egraph-pointer
+                                         _uint ;; node id
+                                         _uint ;; iteration
+                                         -> _pointer)) ;; string pointer
+
 (define-eggmath egraph_get_cost (_fun _egraph-pointer
                                      _uint ;; node id
                                      _uint ;; iteration
@@ -81,4 +88,4 @@
 (define-eggmath egraph_get_times_applied (_fun _egraph-pointer
                                                _pointer ;; name of the rule
                                                -> _uint))
-                                               
+

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -77,6 +77,7 @@
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants (_fun _egraph-pointer
                                           _uint ;; node id
+                                          _uint ;; iter
                                           _uint ;; fuel
                                           -> _pointer)) ;; string pointer
 

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -77,8 +77,6 @@
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants (_fun _egraph-pointer
                                           _uint ;; node id
-                                          _uint ;; iter
-                                          _uint ;; fuel
                                           -> _pointer)) ;; string pointer
 
 (define-eggmath egraph_get_cost (_fun _egraph-pointer

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -1,11 +1,12 @@
 #lang racket
 
 (require ffi/unsafe
-         ffi/unsafe/define)
-(require racket/runtime-path)
+         ffi/unsafe/define
+         racket/runtime-path)
 
 (provide egraph_create egraph_destroy egraph_add_expr
-         egraph_addresult_destroy egraph_run egraph_get_simplest
+         egraph_addresult_destroy egraph_run
+         egraph_get_simplest egraph_get_variants
          _EGraphIter destroy_egraphiters egraph_get_cost
          egraph_is_unsound_detected egraph_get_times_applied
          destroy_string
@@ -69,21 +70,20 @@
 
 ;; node number -> s-expr string
 (define-eggmath egraph_get_simplest (_fun _egraph-pointer
-                                         _uint ;; node id
-                                         _uint ;; iteration
-                                         -> _pointer)) ;; string pointer
+                                          _uint ;; node id
+                                          _uint ;; iteration
+                                          -> _pointer)) ;; string pointer
 
 ;; TODO egg-rr
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants (_fun _egraph-pointer
-                                         _uint ;; node id
-                                         _uint ;; iteration
-                                         -> _pointer)) ;; string pointer
+                                          _uint ;; node id
+                                          -> _pointer)) ;; string pointer
 
 (define-eggmath egraph_get_cost (_fun _egraph-pointer
-                                     _uint ;; node id
-                                     _uint ;; iteration
-                                     -> _uint))
+                                      _uint ;; node id
+                                      _uint ;; iteration
+                                      -> _uint))
 
 (define-eggmath egraph_get_times_applied (_fun _egraph-pointer
                                                _pointer ;; name of the rule

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -74,10 +74,10 @@
                                           _uint ;; iteration
                                           -> _pointer)) ;; string pointer
 
-;; TODO egg-rr
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants (_fun _egraph-pointer
                                           _uint ;; node id
+                                          _uint ;; fuel
                                           -> _pointer)) ;; string pointer
 
 (define-eggmath egraph_get_cost (_fun _egraph-pointer

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -5,7 +5,7 @@
          racket/runtime-path)
 
 (provide egraph_create egraph_destroy egraph_add_expr
-         egraph_addresult_destroy egraph_run
+         egraph_addresult_destroy egraph_run egraph_run_with_iter_limit
          egraph_get_simplest egraph_get_variants
          _EGraphIter destroy_egraphiters egraph_get_cost
          egraph_is_unsound_detected egraph_get_times_applied
@@ -59,14 +59,26 @@
 
 (define-eggmath egraph_is_unsound_detected (_fun _egraph-pointer -> _bool))
 
-(define-eggmath egraph_run (_fun _egraph-pointer
-                                 (len : (_ptr o _uint)) ;; pointer to size of resulting array
-                                 _uint ;; node limit
-                                (ffi-rules : (_list i _FFIRule-pointer)) ;; ffi rules
-                                _bool ;; constant folding enabled?
-                                (_uint = (length ffi-rules))
-                                -> (iters : _EGraphIter-pointer)
-                                -> (values iters len)))
+(define-eggmath egraph_run_with_iter_limit
+  (_fun _egraph-pointer                           ;; egraph
+        (len : (_ptr o _uint))                    ;; pointer to size of resulting array
+        _uint                                     ;; iter limit
+        _uint                                     ;; node limit
+        (ffi-rules : (_list i _FFIRule-pointer))  ;; ffi rules
+        _bool                                     ;; constant folding enabled?
+        (_uint = (length ffi-rules))              ;; number of rules
+        -> (iters : _EGraphIter-pointer)
+        -> (values iters len)))
+
+(define-eggmath egraph_run
+  (_fun _egraph-pointer                           ;; egraph
+        (len : (_ptr o _uint))                    ;; pointer to size of resulting array
+        _uint                                     ;; node limit
+        (ffi-rules : (_list i _FFIRule-pointer))  ;; ffi rules
+        _bool                                     ;; constant folding enabled?
+        (_uint = (length ffi-rules))              ;; number of rules
+        -> (iters : _EGraphIter-pointer)
+        -> (values iters len)))
 
 ;; node number -> s-expr string
 (define-eggmath egraph_get_simplest (_fun _egraph-pointer

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -26,8 +26,9 @@
   (destroy_string ptr)
   str)
 
-(define (egraph-get-variants egraph-data node-id)
-  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id))
+(define (egraph-get-variants egraph-data node-id orig-expr)
+  (define expr-str (expr->egg-expr orig-expr egraph-data))
+  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id expr-str))
   (define str (cast ptr _pointer _string/utf-8))
   (destroy_string ptr)
   str)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -26,8 +26,8 @@
   (destroy_string ptr)
   str)
 
-(define (egraph-get-variants egraph-data node-id iter fuel)
-  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id iter fuel))
+(define (egraph-get-variants egraph-data node-id)
+  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id))
   (define str (cast ptr _pointer _string/utf-8))
   (destroy_string ptr)
   str)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -72,9 +72,14 @@
            (convert-iteration-data (ptr-add egraphiters 1 _EGraphIter) (- size 1)))]
     [else empty]))
 
-
-(define (egraph-run egraph-data node-limit ffi-rules precompute?)
-  (define-values (egraphiters res-len) (egraph_run (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?))
+;; runs rules on an egraph
+;; can optionally specify an iter limit
+(define (egraph-run egraph-data iter-limit node-limit ffi-rules precompute?)
+  (define egraph-ptr (egraph-data-egraph-pointer egraph-data))
+  (define-values (egraphiters res-len)
+    (if iter-limit
+        (egraph_run_with_iter_limit egraph-ptr iter-limit node-limit ffi-rules precompute?)
+        (egraph_run egraph-ptr node-limit ffi-rules precompute?)))
   (define res (convert-iteration-data egraphiters res-len))
   (destroy_egraphiters res-len egraphiters)
   res)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -26,8 +26,8 @@
   (destroy_string ptr)
   str)
 
-(define (egraph-get-variants egraph-data node-id)
-  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id))
+(define (egraph-get-variants egraph-data node-id fuel)
+  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id fuel))
   (define str (cast ptr _pointer _string/utf-8))
   (destroy_string ptr)
   str)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -96,11 +96,9 @@
 (define (egg-exprs->exprs exprs eg-data)
   (define port (open-input-string exprs))
   (let loop ([parse (read port)] [exprs '()])
-    ; (printf "~a ->" parse)
     (if (eof-object? parse)
         (reverse exprs)
         (let ([expr (egg-parsed->expr parse (egraph-data-egg->herbie-dict eg-data))])
-          ; (printf " ~a\n" expr)
           (loop (read port) (cons expr exprs))))))
 
 (define (egg-parsed->expr parsed rename-dict)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -26,8 +26,8 @@
   (destroy_string ptr)
   str)
 
-(define (egraph-get-variants egraph-data node-id fuel)
-  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id fuel))
+(define (egraph-get-variants egraph-data node-id iter fuel)
+  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id iter fuel))
   (define str (cast ptr _pointer _string/utf-8))
   (destroy_string ptr)
   str)

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod math;
 pub mod rules;
 
-use egg::{AstSize, Extractor, Id, Iteration, Language};
+use egg::{Extractor, Id, Iteration, Language};
 use indexmap::IndexMap;
 use math::*;
 
@@ -275,7 +275,7 @@ fn get_op_str(n: &Math) -> Option<String> {
 }
 
 fn variant_get_simplest(
-    extractor: &mut Extractor<AstSize, Math, ConstantFold>,
+    extractor: &mut Extractor<AltCost, Math, ConstantFold>,
     cache: &mut IndexMap<Id, String>,
     id: &Id,
 ) -> String {
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn egraph_get_variants(
         let head_node = &orig_recexpr.as_ref()[orig_recexpr.as_ref().len() - 1];
 
         // cache
-        let mut extractor = Extractor::new(&runner.egraph, AstSize);
+        let mut extractor = Extractor::new(&runner.egraph, AltCost::new(&runner.egraph, vec![]));
         let mut cache: IndexMap<Id, String> = Default::default();
 
         // extract

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -254,6 +254,30 @@ pub unsafe extern "C" fn egraph_get_simplest(
     })
 }
 
+// TODO egg rr
+#[no_mangle]
+pub unsafe extern "C" fn egraph_get_variants(
+    ptr: *mut Context,
+    node_id: u32,
+    iter: u32,
+) -> *const c_char {
+    ffirun(|| {
+        let ctx = &*ptr;
+        let runner = ctx
+            .runner
+            .as_ref()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+
+        let ext = find_extracted(runner, node_id, iter);
+
+        // TODO egg rr : wrap in "(..)" to make it a list
+        let best_str = CString::new(ext.best.to_string()).unwrap();
+        let best_str_pointer = best_str.as_ptr();
+        std::mem::forget(best_str);
+        best_str_pointer
+    })
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn egraph_is_unsound_detected(ptr: *mut Context) -> bool {
     ffirun(|| {

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -174,10 +174,8 @@ impl Analysis<Math> for ConstantFold {
                 true
             }
             (Some(a), Some(ref b)) => {
-                if a != b {
-                    if !self.unsound.swap(true, Ordering::SeqCst) {
-                        log::warn!("Bad merge detected: {} != {}", a, b);
-                    }
+                if a != b && !self.unsound.swap(true, Ordering::SeqCst) {
+                    log::warn!("Bad merge detected: {} != {}", a, b);
                 }
                 false
             }

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -26,7 +26,8 @@ pub struct Extracted {
 impl IterationData<Math, ConstantFold> for IterData {
     fn make(runner: &Runner) -> Self {
         let mut extractor = Extractor::new(&runner.egraph, AstSize);
-        let extracted = runner.roots
+        let extracted = runner
+            .roots
             .iter()
             .map(|&root| {
                 let (cost, best) = extractor.find_best(root);

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -32,6 +32,12 @@ pub struct AltCost<'a> {
     pub ignore: Vec<Id>,
 }
 
+impl<'a> AltCost<'a> {
+    pub fn new(egraph: &'a EGraph, ignore: Vec<Id>) -> Self {
+        Self { egraph, ignore }
+    }
+}
+
 impl<'a> CostFunction<Math> for AltCost<'a> {
     type Cost = usize;
 
@@ -59,11 +65,7 @@ impl<'a> CostFunction<Math> for AltCost<'a> {
 
 impl IterationData<Math, ConstantFold> for IterData {
     fn make(runner: &Runner) -> Self {
-        let cost = AltCost {
-            egraph: &runner.egraph,
-            ignore: vec![],
-        };
-        let mut extractor = Extractor::new(&runner.egraph, cost);
+        let mut extractor = Extractor::new(&runner.egraph, AltCost::new(&runner.egraph, vec![]));
         let extracted = runner
             .roots
             .iter()

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -16,7 +16,6 @@ pub type Iteration = egg::Iteration<IterData>;
 
 pub struct IterData {
     pub extracted: Vec<(Id, Extracted)>,
-    pub egraph: EGraph,
 }
 
 pub struct Extracted {
@@ -27,18 +26,15 @@ pub struct Extracted {
 impl IterationData<Math, ConstantFold> for IterData {
     fn make(runner: &Runner) -> Self {
         let mut extractor = Extractor::new(&runner.egraph, AstSize);
-        let extracted = runner
-            .egraph
-            .classes()
-            .map(|c| {
-                let (cost, best) = extractor.find_best(c.id);
+        let extracted = runner.roots
+            .iter()
+            .map(|&root| {
+                let (cost, best) = extractor.find_best(root);
                 let ext = Extracted { cost, best };
-                (c.id, ext)
+                (root, ext)
             })
             .collect();
-        let egraph = runner.egraph.clone();
-
-        Self { extracted, egraph }
+        Self { extracted }
     }
 }
 
@@ -72,16 +68,6 @@ pub struct ConstantFold {
     pub unsound: AtomicBool,
     pub constant_fold: bool,
     pub prune: bool,
-}
-
-impl Clone for ConstantFold {
-    fn clone(&self) -> Self {
-        Self {
-            unsound: AtomicBool::from(self.unsound.load(Ordering::SeqCst)),
-            constant_fold: self.constant_fold,
-            prune: self.prune,
-        }
-    }
 }
 
 impl Default for ConstantFold {

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -13,7 +13,7 @@
 (define default-flags
   #hash([precision . (fallback)]
         [setup . (simplify search)]
-        [generate . (rr taylor simplify)]
+        [generate . (rr egg-rr taylor simplify)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -6,7 +6,7 @@
 (define all-flags
   #hash([precision . (double fallback)]
         [setup . (simplify search)]
-        [generate . (rr taylor simplify better-rr)]
+        [generate . (rr taylor simplify better-rr egg-rr)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -157,7 +157,7 @@
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
   (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (define irules (rules->irules rules))
-  (define use-all-iters? #t)
+  (define use-all-iters? #f)
   (define fuel 1)
 
   (define extracted

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -163,9 +163,6 @@
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
   (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (define irules (rules->irules rules))
-  (define use-all-iters? #f)
-  (define fuel 1)
-
   (define extracted
     (with-egraph
       (lambda (egg-graph)
@@ -179,18 +176,10 @@
               (warn 'unsound-rules #:url "faq.html#unsound-rules"
                   "Unsound rule application detected in e-graph. Results from recursive rewrite may not be sound.")
               '()]
-             [use-all-iters?
-              (define expr-id (first node-ids))
-              (reap [sow]
-                (for ([iter (in-range (length iter-data))])
-                  (define output-str (egraph-get-variants egg-graph expr-id iter fuel))
-                  (for ([variant (egg-exprs->exprs output-str egg-graph)])
-                    (sow variant))))]
              [else
               (define expr-id (first node-ids))
               (define last-iter (- (length iter-data) 1))
-              (define output-str (egraph-get-variants egg-graph expr-id last-iter fuel))
-              (egg-exprs->exprs output-str egg-graph)]))))))
+              (egg-exprs->exprs (egraph-get-variants egg-graph expr-id) egg-graph)]))))))
 
   (for/list ([variant (remove-duplicates extracted)] #:unless (same-op? expr variant))
     (list (change egg-rule root-loc (list (cons 'x variant))))))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -157,7 +157,7 @@
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
   (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (define irules (rules->irules rules))
-  (define fuel 2)
+  (define fuel 1)
 
   (define extracted
     (with-egraph

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -151,6 +151,12 @@
  [egg-herbie (with-egraph egraph-add-exprs egraph-run egraph-get-variants
               egraph-is-unsound-detected egg-exprs->exprs)])
 
+(define (same-op? expr variant)
+  (and (list? expr)
+       (list? variant)
+       (equal? (car expr) (car variant))
+       (= (length expr) (length variant))))
+
 ; TODO egg rr experiment
 ; - how do changes work with egg rewrites?
 ; - how to get variations from egg?
@@ -186,8 +192,7 @@
               (define output-str (egraph-get-variants egg-graph expr-id last-iter fuel))
               (egg-exprs->exprs output-str egg-graph)]))))))
 
-  (define extracted* (remove-duplicates extracted))
-  (for/list ([variant extracted] #:unless (equal? expr variant))
+  (for/list ([variant (remove-duplicates extracted)] #:unless (same-op? expr variant))
     (list (change egg-rule root-loc (list (cons 'x variant))))))
 
 ;;  Rewrite chooser

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -152,12 +152,6 @@
               egraph-is-unsound-detected egraph-get-times-applied
               egg-exprs->exprs)])
 
-(define (same-op? expr variant)
-  (and (list? expr)
-       (list? variant)
-       (equal? (car expr) (car variant))
-       (= (length expr) (length variant))))
-
 ; If unsoundness was detected, try falling back to one at a time
 ; Returns (cons <rule-count> <variants>)
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()])
@@ -178,14 +172,13 @@
             (cons (hash) '())]
            [else
             (define expr-id (first node-ids))
-            (define output (egraph-get-variants egg-graph expr-id))
+            (define output (egraph-get-variants egg-graph expr-id expr))
             (define extracted (egg-exprs->exprs output egg-graph))
             (define rule-counts
               (for/hash ([rule rules])
                 (values (rule-name rule) (egraph-get-times-applied egg-graph (rule-name rule)))))
             (define variants
-              (for/list ([variant (remove-duplicates extracted)]
-                         #:unless (same-op? expr variant))
+              (for/list ([variant (remove-duplicates extracted)])
                 (list (change egg-rule root-loc (list (cons 'x variant))))))
             (cons rule-counts variants)]))))))
 
@@ -230,10 +223,9 @@
              [else
               (define variants
                 (for/list ([id node-ids] [expr exprs] [root-loc root-locs])
-                  (define output (egraph-get-variants egg-graph id))
+                  (define output (egraph-get-variants egg-graph id expr))
                   (define extracted (egg-exprs->exprs output egg-graph))
-                  (for/list ([variant (remove-duplicates extracted)]
-                            #:unless (same-op? expr variant))
+                  (for/list ([variant (remove-duplicates extracted)])
                     (list (change egg-rule root-loc (list (cons 'x variant)))))))
               (λ () variants)]))))))
   (result-thunk))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -73,6 +73,13 @@
         (when result
             (sow (list (change rule root-loc (cdr result)))))))))
 
+; TODO egg rr experiment
+; - how do changes work with egg rewrites?
+; - how to get variations from egg?
+(define (egg-rewrite-expression-head expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
+  ; this is wrong
+  (list expr))
+
 (define (rewrite-expression-head expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
   (define type (repr-of expr repr (*var-reprs*)))
   (define (rewriter sow expr ghead glen loc cdepth)

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -157,7 +157,7 @@
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
   (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (define irules (rules->irules rules))
-  (define fuel 4)
+  (define fuel 2)
 
   (define extracted
     (with-egraph
@@ -166,6 +166,7 @@
           egg-graph
           (list expr)
           (lambda (node-ids)
+            (egg-run-rules egg-graph (*node-limit*) irules node-ids #t)
             (cond
              [(egraph-is-unsound-detected egg-graph)
               (warn 'unsound-rules #:url "faq.html#unsound-rules"

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -155,7 +155,10 @@
 ; - how do changes work with egg rewrites?
 ; - how to get variations from egg?
 (define (egg-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
+  (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (define irules (rules->irules rules))
+  (define fuel 4)
+
   (define extracted
     (with-egraph
       (lambda (egg-graph)
@@ -170,11 +173,8 @@
               '()]
              [else
               (define expr-id (first node-ids))
-              (if (egraph-is-unsound-detected egg-graph)
-                  (egg-exprs->exprs (egraph-get-variants egg-graph expr-id) egg-graph)
-                  '())]))))))
+              (egg-exprs->exprs (egraph-get-variants egg-graph expr-id fuel) egg-graph)]))))))
 
-  (define egg-rule (rule "egg" 'x 'x (list repr) repr))
   (for/list ([variant extracted] #:unless (equal? expr variant))
     (list (change egg-rule root-loc (list (cons 'x variant))))))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -166,17 +166,15 @@
                       (egg-expr->expr (egraph-get-simplest egg-graph id iter) egg-graph)))
          node-ids))))))
 
-(define (egg-run-rules egg-graph node-limit irules node-ids precompute? #:hook [hook #f])
+(define (egg-run-rules egg-graph node-limit irules node-ids precompute? #:limit [iter-limit #f])
   (define ffi-rules (make-ffi-rules irules))
   (define start-time (current-inexact-milliseconds))
 
   #;(define (timeline-cost iter)
-    
-    (define cnt (egraph-get-size egg-graph))
-    
-    (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
+      (define cnt (egraph-get-size egg-graph)) 
+      (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
   
-  (define iteration-data (egraph-run egg-graph node-limit ffi-rules precompute?))
+  (define iteration-data (egraph-run egg-graph iter-limit node-limit ffi-rules precompute?))
 
   (let loop
     ([iter iteration-data] [counter 0] [time 0])
@@ -191,7 +189,6 @@
        (debug #:from 'simplify #:depth 2 "iteration " counter ": " cnt " enodes " "(cost " cost ")")
        (define new-time (+ time (iteration-data-time (first iter))))
        (timeline-push! 'egraph counter cnt cost new-time)
-       (when hook (hook egg-graph))
        (loop (rest iter) (+ counter 1) new-time)]))
 
   (free-ffi-rules ffi-rules)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -3,7 +3,8 @@
 (require pkg/lib racket/lazy-require)
 (require "../common.rkt" "../programs.rkt" "../timeline.rkt" "../errors.rkt"
          "../syntax/rules.rkt" "../alternative.rkt")
-(provide simplify-expr simplify-batch make-simplification-combinations use-egg-math?)
+(provide simplify-expr simplify-batch make-simplification-combinations
+         use-egg-math? rules->irules egg-run-rules)
 (module+ test (require rackunit "../load-plugin.rkt"))
 
 ; make sure to check both package scopes

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -166,7 +166,7 @@
                       (egg-expr->expr (egraph-get-simplest egg-graph id iter) egg-graph)))
          node-ids))))))
 
-(define (egg-run-rules egg-graph node-limit irules node-ids precompute?)
+(define (egg-run-rules egg-graph node-limit irules node-ids precompute? #:hook [hook #f])
   (define ffi-rules (make-ffi-rules irules))
   (define start-time (current-inexact-milliseconds))
 
@@ -191,6 +191,7 @@
        (debug #:from 'simplify #:depth 2 "iteration " counter ": " cnt " enodes " "(cost " cost ")")
        (define new-time (+ time (iteration-data-time (first iter))))
        (timeline-push! 'egraph counter cnt cost new-time)
+       (when hook (hook egg-graph))
        (loop (rest iter) (+ counter 1) new-time)]))
 
   (free-ffi-rules ffi-rules)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -3,7 +3,7 @@
 (require pkg/lib racket/lazy-require)
 (require "../common.rkt" "../programs.rkt" "../timeline.rkt" "../errors.rkt"
          "../syntax/rules.rkt" "../alternative.rkt")
-(provide simplify-expr simplify-batch make-simplification-combinations)
+(provide simplify-expr simplify-batch make-simplification-combinations use-egg-math?)
 (module+ test (require rackunit "../load-plugin.rkt"))
 
 ; make sure to check both package scopes

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -146,27 +146,22 @@
     (raise-user-error 'gen-rewrites! "No expressions queued in patch table. Run `patch-table-add!`"))
   (timeline-event! 'rewrite)
 
-  (define changelists
-    (for/list ([altn (in-list (^queued^))] [n (in-naturals 1)])
-      (define expr (program-body (alt-program altn)))
-      (debug #:from 'progress #:depth 4 "[" n "/" (length (^queued^)) "] rewriting for" expr)
-      (define tnow (current-inexact-milliseconds))
-      (begin0 (rewrite-expression expr (*output-repr*) #:rules (*rules*) #:root '(2))
-        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
-
-  (define reprchange-rules
+  (define reprchange-rules                              ;; empty in non-Pareto mode
     (if (*pareto-mode*)
         (filter (λ (r) (expr-contains? (rule-output r) rewrite-repr-op?)) (*rules*))
         (list)))
 
-  ; Empty in normal mode
+  ;; get subexprs and locations
+  (define exprs (map (compose program-body alt-program) (^queued^)))
+  (define lowexprs (map (compose program-body alt-program) (^queuedlow^)))
+  (define locs (make-list (length (^queued^)) '(2)))          ;; always at the root
+  (define lowlocs (make-list (length (^queuedlow^)) '(2)))    ;; always at the root
+
+  ;; rewrite
+  (define changelists
+    (rewrite-expressions exprs (*output-repr*) #:rules (*rules*) #:roots locs))
   (define changelists-low-locs
-    (for/list ([altn (in-list (^queuedlow^))] [n (in-naturals 1)])
-      (define expr (program-body (alt-program altn)))
-      (debug #:from 'progress #:depth 4 "[" n "/" (length (^queuedlow^)) "] rewriting for" expr)
-      (define tnow (current-inexact-milliseconds))
-      (begin0 (rewrite-expression expr (*output-repr*) #:rules reprchange-rules #:root '(2))
-        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
+    (rewrite-expressions lowexprs (*output-repr*) #:rules reprchange-rules #:roots lowlocs))
 
   (define comb-changelists (append changelists changelists-low-locs))
   (define altns (append (^queued^) (^queuedlow^)))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -203,6 +203,7 @@
   (unless (or (^series^) (^rewrites^))
     (raise-user-error 'simplify! "No candidates generated. Run (gen-series!) or (gen-rewrites!)"))
 
+  (^final^ (append (or (^series^) empty) (or (^rewrites^) empty)))
   (when (flag-set? 'generate 'simplify)
     (timeline-event! 'simplify)
     (define children (append (or (^series^) empty) (or (^rewrites^) empty)))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -144,17 +144,14 @@
 (define (gen-rewrites!)
   (when (and (null? (^queued^)) (null? (^queuedlow^)))
     (raise-user-error 'gen-rewrites! "No expressions queued in patch table. Run `patch-table-add!`"))
-
   (timeline-event! 'rewrite)
-  (define rewrite (if (flag-set? 'generate 'rr) rewrite-expression-head rewrite-expression))
-  (timeline-push! 'method (~a (object-name rewrite)))
 
   (define changelists
     (for/list ([altn (in-list (^queued^))] [n (in-naturals 1)])
       (define expr (program-body (alt-program altn)))
       (debug #:from 'progress #:depth 4 "[" n "/" (length (^queued^)) "] rewriting for" expr)
       (define tnow (current-inexact-milliseconds))
-      (begin0 (rewrite expr (*output-repr*) #:rules (*rules*) #:root '(2))
+      (begin0 (rewrite-expression expr (*output-repr*) #:rules (*rules*) #:root '(2))
         (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
 
   (define reprchange-rules
@@ -168,7 +165,7 @@
       (define expr (program-body (alt-program altn)))
       (debug #:from 'progress #:depth 4 "[" n "/" (length (^queuedlow^)) "] rewriting for" expr)
       (define tnow (current-inexact-milliseconds))
-      (begin0 (rewrite expr (*output-repr*) #:rules reprchange-rules #:root '(2))
+      (begin0 (rewrite-expression expr (*output-repr*) #:rules reprchange-rules #:root '(2))
         (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
 
   (define comb-changelists (append changelists changelists-low-locs))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -176,10 +176,11 @@
   (define rule-counts
     (for ([rgroup (group-by identity rules-used)])
       (timeline-push! 'rules (~a (rule-name (first rgroup))) (length rgroup))))
-
+  
   (define rewritten
     (for/fold ([done '()] #:result (reverse done))
-              ([cls comb-changelists] [altn altns] #:when true [cl cls])
+              ([cls comb-changelists] [altn altns]
+              #:when true [cl cls])
       (let loop ([cl cl] [altn altn])
         (if (null? cl)
             (cons altn done)


### PR DESCRIPTION
This PR adds a new `egg`-based recursive rewriter, `egg-rr`, The new rewriter does the following:
1. Add expressions to rewrite to an egraph.
2. Run rewrites.
3. For every enode in the root eclass, extract an expression (variant) where the root is that enode and the children are the best expressions according to the current cost model. For step 3, we exclude enodes that are the same type as the original root enode.

Overall, this leads to an improvement across the entire Herbie benchmarks suite as `egg-rr` is a more powerful rewriter and increased stability (much lower variance on suites and individual benchmarks). However, there are two key differences that cause regressions on individual benchmarks: unsoundness and missing rewrites on child subexpressions.

_Unsoundness_: Since Herbie's rules are unsound (`/`, `sqrt`, etc.), `egg` occasionally performs an unsound rewrite which makes extraction impossible since non-equivalent expressions are merged together. Current RR avoids this since all variants are rewritten individually from each other. This has been mitigated using a fallback system that ensures variants can be recovered although expressions may not be fully rewritten. The fallback system is as follows:
1. Given a set of expressions (presumably with high local error), try batching the expressions in a single run
2. If unsoundness was detected, throw away the previous run and run each expression individually (perhaps only one expression is causing the issue)
3. For each individual run, if unsoundness is detected, run again but with an iteration limit that ensures we don't hit the iteration number where unsoundness was detected
4. If something still goes wrong, give up (maybe impossible?)

_Missing variants_: Testing has shown that `egg-rr` does not extract certain variants that are proven to be helpful with current RR. This is likely (not 100% certain) because current RR performs very specific rewrites on subexpressions (child eclasses in `egg`) that would be deemed "too expensive" to extract using the current cost model in `egg-rr`. The best examples of these cases are the `quad` benchmarks where rules like
```
[flip-+     (+ a b)  (/ (- (* a a) (* b b)) (- a b))]
[flip--     (- a b)  (/ (- (* a a) (* b b)) (+ a b))]
```
are performed on subexpressions. This has been deemed acceptable since Herbie is much more stable on these benchmarks (for `quad`, Herbie with `egg-rr` varies by 1 bit of accuracy while mainline Herbie can swing between 5 bits).

In summary, `egg-rr` improves the recursive rewriter by increasing accuracy and stability across runs. It has two problems; one of which has been mitigated while the other is acceptable and will be pursued in the future. In addition, the design of Herbie has been simplified, and `egg` is now the underlying engine behind 2 of 4 of Herbie's rewriting subsystems.

For now, the legacy rewriter can still be used and will be used if `egg` is not available. By default, `egg-rr` is enabled. At a later time, the legacy rewriter will most likely be removed, and `egg` will become a required dependency.