### PR TITLE
Remove regraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ You can also run `src/herbie.rkt` directly.
 ### Installing from the Racket package index
 
 Use this method for installing Herbie if Rust is not on your system.
-This method requires Racket 8.0 or later, and supports
-    Windows, macOS, and Linux on x86-64 architectures.
+Installing via the Racket package index requires Racket 8.0 or later
+  and supports Windows, macOS, and Linux on x86-64 architectures.
+
 Install Racket from [here](https://download.racket-lang.org/).
 Install Herbie with:
 
@@ -46,7 +47,7 @@ This will install a `herbie` binary somewhere under `~/.racket` (Linux)
 You can also run `src/herbie.rkt` directly.
 
 Please note that this method of installation
-  does not work for Apple M1 systems and related ARM-architectures.
+  does not work for Apple M1 systems and related ARM architectures.
 We hope to support this in the near future.
 
 ## Running Herbie

--- a/README.md
+++ b/README.md
@@ -25,27 +25,27 @@ In this directory, build Herbie with:
 
     make install
 
-This will install a `herbie` binary to somewhere under `~/.racket` (Linux)
+This will install a `herbie` binary somewhere under `~/.racket` (Linux)
   although this path is dependent on OS and Racket version
-  (check the installation messages a possible location).
+  (check installation messages for a possible location).
 You can also run `src/herbie.rkt` directly.
 
 ### Installing from the Racket package index
 
-If Rust is not on your system, use this method for installing Herbie;
-This method requires Racket 8.0 or later,
-  and supports Windows, macOS, and Linux on x86-64 architectures.
+Use this method for installing Herbie if Rust is not on your system.
+This method requires Racket 8.0 or later, and supports
+    Windows, macOS, and Linux on x86-64 architectures.
 Install Racket from [here](https://download.racket-lang.org/).
 Install Herbie with:
 
     raco pkg install --auto herbie
 
-This will install a `herbie` binary to somewhere under `~/.racket` (Linux)
+This will install a `herbie` binary somewhere under `~/.racket` (Linux)
   although this path is dependent on OS and Racket version
-  (check the installation messages a possible location).
+  (check installation messages for a possible location).
 You can also run `src/herbie.rkt` directly.
 
-Please note that installing through the Racket package index
+Please note that this method of installation
   does not work for Apple M1 systems and related ARM-architectures.
 We hope to support this in the near future.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This will install a `herbie` binary somewhere under `~/.racket` (Linux)
   (check installation messages for a possible location).
 You can also run `src/herbie.rkt` directly.
 
-Please note that this method of installation
-  does not work for Apple M1 systems and related ARM architectures.
+Please note that this method of installation **will fail**
+  for *Apple M1* systems and other *ARM* architectures.
 We hope to support this in the near future.
 
 ## Running Herbie

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ For full details on installing Herbie, please see the
 
 ### Installing from Source
 
-This is the preferred method for installing Herbie.
 Installing from source requires Racket 8.0 or later,
   Rust 1.46.0 or later, and supports Windows, macOS, and Linux
   for various architectures.

--- a/README.md
+++ b/README.md
@@ -7,25 +7,49 @@ documentation, and an online demo. Herbie has semi-regular releases
 once a year, maintains backwards compatibility, and uses standardized
 formats.
 
-Installing
-----------
+## Installing
 
 For full details on installing Herbie, please see the
 [documentation](https://herbie.uwplse.org/doc/latest/installing.html).
 
-Herbie requires Racket 8.0 or later, and supports Windows, macOS, and
-Linux. Install it with:
+### Installing from Source
+
+This is the preferred method for installing Herbie.
+Installing from source requires Racket 8.0 or later,
+  Rust 1.46.0 or later, and supports Windows, macOS, and Linux
+  for various architectures.
+
+Install Racket from [here](https://download.racket-lang.org/).
+Install Rust from [here](https://www.rust-lang.org/tools/install).
+In this directory, build Herbie with:
+
+    make install
+
+This will install a `herbie` binary to somewhere under `~/.racket` (Linux)
+  although this path is dependent on OS and Racket version
+  (check the installation messages a possible location).
+You can also run `src/herbie.rkt` directly.
+
+### Installing from the Racket package index
+
+If Rust is not on your system, use this method for installing Herbie;
+This method requires Racket 8.0 or later,
+  and supports Windows, macOS, and Linux on x86-64 architectures.
+Install Racket from [here](https://download.racket-lang.org/).
+Install Herbie with:
 
     raco pkg install --auto herbie
 
-This will install a `herbie` binary to somewhere under `~/.racket`.
-You can also download the source and run `src/herbie.rkt` directly.
+This will install a `herbie` binary to somewhere under `~/.racket` (Linux)
+  although this path is dependent on OS and Racket version
+  (check the installation messages a possible location).
+You can also run `src/herbie.rkt` directly.
 
-Alternatively, Herbie and Herbie's Rust components can be built from source and installed
-  using `make install` in the herbie directory.
+Please note that installing through the Racket package index
+  does not work for Apple M1 systems and related ARM-architectures.
+We hope to support this in the near future.
 
-Running Herbie
---------------
+## Running Herbie
 
 For full details on running Herbie, please see the
 [tutorial](https://herbie.uwplse.org/doc/latest/using-web.html).
@@ -53,8 +77,7 @@ batch mode on files with the `improve` and `report` commands. Consult
 the [documentation](https://herbie.uwplse.org/doc/latest/options.html).
 for more.
 
-Helping Out
------------
+## Helping Out
 
 Herbie development is organized on our
 [mailing list](https://mailman.cs.washington.edu/mailman/listinfo/herbie),
@@ -65,8 +88,7 @@ We use [Github](https://github.com/herbie-fp/herbie) and
 [Trello](https://trello.com/b/lh7b33Dr/herbie) to organize development
 goals.
 
-Running Tests
--------------
+## Running Tests
 
 Herbie has unit tests for basic functionality, though coverage is far
 from complete. You can run the test suite by downloading the source

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -6,14 +6,14 @@
 (define all-flags
   #hash([precision . (double fallback)]
         [setup . (simplify search)]
-        [generate . (rr taylor simplify better-rr egg-rr)]
+        [generate . (rr taylor simplify better-rr)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 
 (define default-flags
   #hash([precision . (fallback)]
         [setup . (simplify search)]
-        [generate . (rr egg-rr taylor simplify)]
+        [generate . (rr taylor simplify)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 
@@ -22,6 +22,9 @@
     [('precision 'double)
      (eprintf "The precision:double option has been removed.\n")
      (eprintf "  Please use :precision binary32 and :precision binary64 instead.\n")
+     (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
+    [('generate 'better-rr)
+     (eprintf "The current recursive rewriter does not support the generate:better-rr option.\n")
      (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
     [(_ _)
      (void)]))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -1,16 +1,10 @@
 #lang racket
 
-(require racket/lazy-require racket/hash)
+(require racket/hash egg-herbie)
 (require "../common.rkt" "../programs.rkt" "../alternative.rkt"
-         "../syntax/rules.rkt" "../interface.rkt" "../timeline.rkt"
-         "../errors.rkt" "simplify.rkt")
+         "../syntax/rules.rkt" "../interface.rkt" "../timeline.rkt" "simplify.rkt")
 
-(provide
-  pattern-match
-  pattern-substitute
-  rewrite-expressions
-  change-apply
-  rule-apply)
+(provide pattern-match rewrite-expressions change-apply)
 
 ;;; Our own pattern matcher.
 ;;
@@ -77,85 +71,14 @@
         (when result
             (sow (list (change rule root-loc (cdr result)))))))))
 
-;;  Recursive rewriter
-
-(define (recursive-rewrite expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
-  (define type (repr-of expr repr (*var-reprs*)))
-  (define (rewriter sow expr ghead glen loc cdepth)
-    ; expr _ _ _ _ -> (list (list change))
-    (for ([rule rules] #:when (equal? type (rule-otype rule)))
-      (when (or
-             (not ghead) ; Any results work for me
-             (and
-              (list? (rule-output rule))
-              (= (length (rule-output rule)) glen)
-              (eq? (car (rule-output rule)) ghead)))
-        (for ([option (matcher* expr (rule-input rule) loc (- cdepth 1))])
-          ;; Each option is a list of change lists
-          (sow (cons (change rule (reverse loc) (cdr option)) (car option)))))))
-
-  (define (reduce-children sow options)
-    ; (list (list ((list change) * bindings)))
-    ; -> (list ((list change) * bindings))
-    (for ([children options])
-      (let ([bindings* (foldl merge-bindings '() (map cdr children))])
-        (when bindings*
-          (sow (cons (apply append (map car children)) bindings*))))))
-
-  (define (fix-up-variables sow pattern cngs)
-    ; pattern (list change) -> (list change) * bindings
-    (match-define (change rule loc bindings) (car cngs))
-    (define result (pattern-substitute (rule-output rule) bindings))
-    (define bindings* (pattern-match pattern result))
-    (when bindings* (sow (cons cngs bindings*))))
-
-  (define cache (make-hash))
-  (define (matcher* expr pattern loc cdepth)
-    (hash-ref! cache (list loc pattern cdepth)
-               (λ () (matcher expr pattern loc cdepth))))
-
-  (define (matcher expr pattern loc cdepth)
-    ; expr pattern _ -> (list ((list change) * bindings))
-    (reap [sow]
-      (match pattern
-        [(? variable?)
-         (sow (cons '() (list (cons pattern expr))))]
-        [(? number?)
-         (when (equal? expr pattern)
-           (sow (cons '() '())))]
-        [(list phead _ ...)
-         (when (and (list? expr) (equal? phead (car expr))
-                    (= (length pattern) (length expr)))
-           (let/ec k ;; We have an option to early exit if a child pattern cannot be matched
-             (define child-options ; (list (list ((list cng) * bnd)))
-               (for/list ([i (in-naturals)] [sube expr] [subp pattern] #:when (> i 0))
-                 ;; Note: fuel is "depth" not "cdepth", because we're recursing to a child
-                 (define options (matcher* sube subp (cons i loc) depth))
-                 (when (null? options) (k)) ;; Early exit 
-                 options))
-             (reduce-children sow (apply cartesian-product child-options))))
-
-         (when (and (> cdepth 0)
-                    (or (flag-set? 'generate 'better-rr)
-                        (not (and (list? expr) (equal? phead (car expr)) (= (length pattern) (length expr))))))
-           ;; Sort of a brute force approach to getting the bindings
-           (rewriter (curry fix-up-variables sow pattern)
-                     expr (car pattern) (length pattern) loc (- cdepth 1)))])))
-
-  ;; The "#f #f" means that any output result works. It's a bit of a hack
-  (reap [sow] (rewriter (compose sow reverse) expr #f #f (reverse root-loc) depth)))
-
+;;
 ;;  Egg rewriter
+;;
 
 ;; Fallback system
 ;;  batch-egg-rewrite - batched call to egg
 ;;  egg-rewrite - call to egg on an expression (skipped if batch-egg-rewrite called with 1 expr)
 ;;  egg-rewrite (with iter limit) - call to egg on an expression with an iter limit (last resort)
-
-(lazy-require
- [egg-herbie (with-egraph egraph-add-exprs egraph-get-variants
-              egraph-is-unsound-detected egraph-get-times-applied
-              egg-exprs->exprs)])
 
 ; If unsoundness was detected, try running one epxression at a time.
 ; Can optionally set iter limit (will give up if unsoundness detected).
@@ -253,24 +176,19 @@
   ; choose correct rr driver
   (cond
    [(null? exprs) '()]
-   [else
-    (define driver
-      (cond
-      [(not (flag-set? 'generate 'rr)) rewrite-once]
-      [(and (flag-set? 'generate 'egg-rr)) batch-egg-rewrite]
-      [else recursive-rewrite]))
+   [(flag-set? 'generate 'rr)
+    (define driver batch-egg-rewrite)
     (timeline-push! 'method (~a (object-name driver)))
-
-    ; sequential or batched rewriting
-    (match driver
-     [batch-egg-rewrite
-      (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
-      (define tnow (current-inexact-milliseconds))
-      (begin0 (driver exprs repr #:rules rules #:roots root-locs #:depths depths)
-        (for ([expr exprs]) (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))]
-     [_
-      (for/list ([expr exprs] [root-loc root-locs] [depth depths] [n (in-naturals 1)])
+    (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
+    (define tnow (current-inexact-milliseconds))
+    (begin0 (driver exprs repr #:rules rules #:roots root-locs #:depths depths)
+      (for ([expr exprs])
+        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))]
+   [else
+    (define driver rewrite-once)
+    (timeline-push! 'method (~a (object-name driver)))
+    (for/list ([expr exprs] [root-loc root-locs] [depth depths] [n (in-naturals 1)])
         (debug #:from 'progress #:depth 4 "[" n "/" (length exprs) "] rewriting for" expr)
         (define tnow (current-inexact-milliseconds))
         (begin0 (driver expr repr #:rules rules #:root root-loc #:depth depth)
-          (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))])]))
+          (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))]))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -257,7 +257,7 @@
     (define driver
       (cond
       [(not (flag-set? 'generate 'rr)) rewrite-once]
-      [(and use-egg-math? (flag-set? 'generate 'egg-rr)) batch-egg-rewrite]
+      [(and (flag-set? 'generate 'egg-rr)) batch-egg-rewrite]
       [else recursive-rewrite]))
     (timeline-push! 'method (~a (object-name driver)))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -99,6 +99,13 @@
                       (egg-expr->expr (egraph-get-simplest egg-graph id iter) egg-graph)))
          node-ids))))))
 
+(define (stop-reason->string sr)
+  (match sr
+   ['saturated  "saturated"]
+   ['iter-limit "iter limit"]
+   ['node-limit "node limit"]
+   ['unsound    "unsound"]))
+
 (define (egg-run-rules egg-graph node-limit irules node-ids precompute? #:limit [iter-limit #f])
   (define ffi-rules (make-ffi-rules irules))
   (define start-time (current-inexact-milliseconds))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -1,45 +1,30 @@
 #lang racket
 
-(require pkg/lib racket/lazy-require)
+(require egg-herbie)
 (require "../common.rkt" "../programs.rkt" "../timeline.rkt" "../errors.rkt"
          "../syntax/rules.rkt" "../alternative.rkt")
-(provide simplify-expr simplify-batch make-simplification-combinations
-         use-egg-math? rules->irules egg-run-rules)
-(module+ test (require rackunit "../load-plugin.rkt"))
 
-; make sure to check both package scopes
-(define (is-installed? name)
-  (or (null? (current-library-collection-paths))  ;; most-likely compiled a standalone executable
-      (hash-has-key? (installed-pkg-table #:scope 'installation) name)
-      (hash-has-key? (installed-pkg-table #:scope 'user) name)))
+(provide simplify-expr simplify-batch
+         make-simplification-combinations
+         rules->irules egg-run-rules)
+
+(module+ test (require rackunit "../load-plugin.rkt"))
 
 ;; One module to rule them all, the great simplify. It uses egg-herbie
 ;; to simplify an expression as much as possible without making
 ;; unnecessary changes. We do this by creating an egraph, saturating
 ;; it partially, then extracting the simplest expression from it.
 ;;
-;; If egg-herbie is not available, simplify uses regraph instead.
-;;
 ;; Simplify makes only one guarantee: that the input is mathematically
 ;; equivalent to the output. For any exact x, evaluating the input on
 ;; x will yield the same expression as evaluating the output on x.
-
-;; fall back on herbie-egraph if egg-herbie is unavailable
-(define use-egg-math?
-  (or (is-installed? "egg-herbie")
-      (is-installed? "egg-herbie-windows")
-      (is-installed? "egg-herbie-osx")
-      (is-installed? "egg-herbie-linux")))
 
 ;; prefab struct used to send rules to egg-herbie
 (struct irule (name input output) #:prefab)
 
 (define (rules->irules rules)
-  (if use-egg-math?
-      (for/list ([rule rules])
-        (irule (rule-name rule) (rule-input rule) (rule-output rule)))
-      (list)))
-
+  (for/list ([rule rules])
+    (irule (rule-name rule) (rule-input rule) (rule-output rule))))
 
 ;; given an alt, locations, and a hash from expr to simplification options
 ;; make all combinations of the alt using the simplification options available
@@ -77,73 +62,14 @@
 (define/contract (simplify-batch exprs #:rules rls #:precompute [precompute? false])
   (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))
 
-  (define driver
-    (cond
-     [use-egg-math?
-      simplify-batch-egg]
-     [else
-      (warn 'simplify #:url "faq.html#egg-herbie"
-            "Falling back on regraph because egg-herbie package not installed")
-      simplify-batch-regraph]))
-
+  (define driver simplify-batch-egg)
   (debug #:from 'simplify "Simplifying using" driver ":\n " (string-join (map ~a exprs) "\n  "))
   (define resulting-lists (driver exprs #:rules rls #:precompute precompute?))
   (define out
     (for/list ([results resulting-lists] [expr exprs])
              (remove-duplicates (cons expr results))))
   (debug #:from 'simplify "Simplified to:\n " (string-join (map ~a (map last out)) "\n  "))
-    
   out)
-
-(lazy-require
- [regraph (make-regraph rule-phase precompute-phase prune-phase extractor-phase
-                        regraph-count regraph-cost regraph-extract)])
-
-(define (eval-application* op . args)
-  (apply eval-application (impl->operator op) args))
-
-(define/contract (simplify-batch-regraph exprs #:rules rls #:precompute precompute?)
-  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))
-  (timeline-push! 'method "regraph")
-
-  (define start-time (current-inexact-milliseconds))
-  (define (log rg iter)
-    (define cnt (regraph-count rg))
-    (define cost (regraph-cost rg))
-    (debug #:from 'simplify #:depth 2 "iteration " iter ": " cnt " enodes " "(cost " cost ")")
-    (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time #f)))
-
-  (define rg (make-regraph exprs #:limit (*node-limit*)))
-
-  (define phases
-    (list (rule-phase (map rule-input rls) (map rule-output rls))
-          (and precompute? (precompute-phase eval-application*))
-          prune-phase
-          extractor-phase))
-
-  (for/and ([iter (in-naturals 0)])
-    (log rg iter)
-    (define initial-cnt (regraph-count rg))
-    ;; Iterates the egraph by applying each of the given rules to the egraph
-    (for ([phase phases] #:when phase) (phase rg))
-    (and (< initial-cnt (regraph-count rg) (*node-limit*))))
-
-  (log rg "done")
-  (map list (regraph-extract rg)))
-
-(lazy-require
- [egg-herbie (with-egraph egraph-add-exprs egraph-run
-              egraph-is-unsound-detected egraph-stop-reason
-              egraph-get-times-applied egraph-get-simplest egraph-get-cost
-              egg-expr->expr make-ffi-rules free-ffi-rules
-              iteration-data-num-nodes iteration-data-time)])
-
-(define (stop-reason->string sr)
-  (match sr
-   ['saturated  "saturated"]
-   ['iter-limit "iter limit"]
-   ['node-limit "node limit"]
-   ['unsound    "unsound"]))
 
 (define/contract (simplify-batch-egg exprs #:rules rls #:precompute precompute?)
   (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -30,7 +30,6 @@
     "rackunit-lib"
     "web-server-lib"
     ("egg-herbie" #:version "1.5")
-    ("regraph" #:version "1.4")
     ("rival" #:version "1.4")
     ("fpbench" #:version "2.0.3")))
 

--- a/www/doc/1.5/installing.html
+++ b/www/doc/1.5/installing.html
@@ -28,7 +28,7 @@
   <p>
     Install Racket either using
     the <a href="http://download.racket-lang.org/racket-v8.1.html">official
-    installer</a> or distro-provided packages. Versions as old as 7.0
+    installer</a> or distro-provided packages. Versions as old as 8.0
     are supported, but more recent versions are faster.
   </p>
 
@@ -40,11 +40,31 @@
 Welcome to Racket v8.1 [cs].
 > (exit)</pre>
 
-  <h2>Installing Herbie from a package</h2>
+<h2>Installing Herbie from source</h2>
 
-  <p>Once Racket is installed, install Herbie from a package with:</p>
+  <p>
+    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via some other means.
+    Versions as old as 1.46.0 are supported.
+    Also install Racket, version 8.0 or later, either using the
+    <a href="http://download.racket-lang.org/racket-v8.1.html">official installer</a>
+    or distro-provided packages.
+  </p>
+  
+  <p>
+    Once Racket and Rust are installed, download the Herbie source
+  <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
+  </p>
 
-  <pre class="shell">raco pkg install --auto herbie</pre>
+  <pre class="shell">git clone https://github.com/uwplse/herbie</pre>
+
+  <p>
+    Change to the <code>herbie</code> directory;
+    you should see a <code>README.md</code> file, a directory named <code>src</code>,
+    a directory named <code>bench/</code>, and a few other directories.
+    Install Herbie on your system with:
+  </p>
+
+  <pre class="shell">make install</pre>
 
   <p>
     This command installs Herbie and its dependencies, compiles it for
@@ -64,30 +84,11 @@ Welcome to Racket v8.1 [cs].
     correctly, check out the <a href="tutorial.html">tutorial</a>.
   </p>
 
-  <h2>Installing Herbie from source</h2>
+  <h2>Installing Herbie from a package</h2>
 
-  <p>
-    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via
-    some other means. Also install Racket, version 7.0 or later, either using
-    the <a href="http://download.racket-lang.org/racket-v8.1.html">official
-      installer</a> or distro-provided packages.
-    </p>
-    
-    <p>
-      Once Racket and Rust are installed, download the Herbie source
-    <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
-  </p>
+  <p>Once Racket is installed, install Herbie from a package with:</p>
 
-  <pre class="shell">git clone https://github.com/uwplse/herbie</pre>
-
-  <p>
-    Change to the <code>herbie</code> directory;
-    you should see a <code>README.md</code> file, a directory named <code>src</code>,
-    a directory named <code>bench/</code>, and a few other directories.
-    Install Herbie on your system with:
-  </p>
-
-  <pre class="shell">make install</pre>
+  <pre class="shell">raco pkg install --auto herbie</pre>
 
   <!-- This is a copy of the text above -->
 

--- a/www/doc/1.6/faq.html
+++ b/www/doc/1.6/faq.html
@@ -103,18 +103,6 @@
     likely the result of a bug in a third-party plugin.
   </p>
 
-  <h3 id="egg-herbie">Falling back on regraph because egg-herbie package not installed</h3>
-
-  <p>
-    Herbie can use either the <code>egg-herbie</code>
-    or <code>regraph</code> package to simplify
-    expressions; <code>egg-herbie</code> is much faster, but uses
-    compiled binaries that cannot be installed on some systems. Herbie
-    will then fall back to <code>regraph</code>, and get similar
-    results but run roughly twice as long.
-    Install <code>egg-herbie</code> with <code>raco</code>.
-  </p>
-
   <h3 id="unsound-rules">Unsound rule application detected</h3>
   
   <p>

--- a/www/doc/1.6/installing.html
+++ b/www/doc/1.6/installing.html
@@ -40,11 +40,31 @@
 Welcome to Racket v8.5 [cs].
 > (exit)</pre>
 
-  <h2>Installing Herbie from a package</h2>
+<h2>Installing Herbie from source</h2>
 
-  <p>Once Racket is installed, install Herbie from a package with:</p>
+  <p>
+    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via some other means.
+    Versions as old as 1.46.0 are supported.
+    Also install Racket, version 8.0 or later, either using the the
+    <a href="http://download.racket-lang.org/racket-v8.5.html">official installer</a>
+    or distro-provided packages.
+    </p>
+    
+    <p>
+      Once Racket and Rust are installed, download the Herbie source
+    <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
+  </p>
 
-  <pre class="shell">raco pkg install --auto herbie</pre>
+  <pre class="shell">git clone https://github.com/uwplse/herbie</pre>
+
+  <p>
+    Change to the <code>herbie</code> directory;
+    you should see a <code>README.md</code> file, a directory named <code>src</code>,
+    a directory named <code>bench/</code>, and a few other directories.
+    Install Herbie on your system with:
+  </p>
+
+  <pre class="shell">make install</pre>
 
   <p>
     This command installs Herbie and its dependencies, compiles it for
@@ -64,30 +84,11 @@ Welcome to Racket v8.5 [cs].
     correctly, check out the <a href="tutorial.html">tutorial</a>.
   </p>
 
-  <h2>Installing Herbie from source</h2>
+  <h2>Installing Herbie from a package</h2>
 
-  <p>
-    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via
-    some other means. Also install Racket, version 8.0 or later, either using
-    the <a href="http://download.racket-lang.org/racket-v8.5.html">official
-      installer</a> or distro-provided packages.
-    </p>
-    
-    <p>
-      Once Racket and Rust are installed, download the Herbie source
-    <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
-  </p>
+  <p>Once Racket is installed, install Herbie from a package with:</p>
 
-  <pre class="shell">git clone https://github.com/uwplse/herbie</pre>
-
-  <p>
-    Change to the <code>herbie</code> directory;
-    you should see a <code>README.md</code> file, a directory named <code>src</code>,
-    a directory named <code>bench/</code>, and a few other directories.
-    Install Herbie on your system with:
-  </p>
-
-  <pre class="shell">make install</pre>
+  <pre class="shell">raco pkg install --auto herbie</pre>  
 
   <!-- This is a copy of the text above -->
 


### PR DESCRIPTION
This PR removes `regraph` from Herbie for good! For the last two years, `regraph` has been part of Herbie's code base purely as a fallback system when `egg` could not be installed. Now that `egg` has become increasingly important to Herbie's functionality, it's time to remove `regraph`. 
- simplify and recursive rewrite has been cleaned up now that `egg` is not optional (no more lazy requires)
- legacy recursive rewriter has been removed
- installation section on the README is more descriptive to avoid installation problems