### PR TITLE
Update egg to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For full details on installing Herbie, please see the
 ### Installing from Source
 
 Installing from source requires Racket 8.0 or later,
-  Rust 1.46.0 or later, and supports Windows, macOS, and Linux
+  Rust 1.60.0 or later, and supports Windows, macOS, and Linux
   for various architectures.
 
 Install Racket from [here](https://download.racket-lang.org/).

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -9,14 +9,13 @@ egg = "0.8"
 
 log = "0.4"
 indexmap = "1"
-libc = "0.2.71"
-smallvec = "1.4.0"
+libc = "0.2.125"
 
-num-rational = "0.3.0"
-num-integer = "0.1.42"
-num-bigint = "0.3.0"
-num-traits = "0.2.12"
-env_logger = { version = "0.7", default-features = false }
+num-bigint = "0.4.3"
+num-integer = "0.1.45"
+num-rational = "0.4.0"
+num-traits = "0.2.15"
+env_logger = { version = "0.9", default-features = false }
 
 [lib]
 name = "egg_math"

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "egg-herbie"
-version = "0.2.3"
+version = "0.3.0"
 authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2018"
 
-
 [dependencies]
-egg = "0.6"
+egg = "0.8"
 
 log = "0.4"
 indexmap = "1"
@@ -18,9 +17,6 @@ num-integer = "0.1.42"
 num-bigint = "0.3.0"
 num-traits = "0.2.12"
 env_logger = { version = "0.7", default-features = false }
-
-[features]
-upward-merging = ["egg/upward-merging"]
 
 [lib]
 name = "egg_math"

--- a/egg-herbie/src/rules.rs
+++ b/egg-herbie/src/rules.rs
@@ -9,7 +9,7 @@ pub fn mk_rules(tuples: &[(&str, &str, &str)]) -> Vec<Rewrite> {
         .map(|(name, left, right)| {
             let left = Pattern::from_str(left).unwrap();
             let right = Pattern::from_str(right).unwrap();
-            Rewrite::new(*name, *name, left, right).unwrap()
+            Rewrite::new(*name, left, right).unwrap()
         })
         .collect()
 }

--- a/www/doc/1.6/installing.html
+++ b/www/doc/1.6/installing.html
@@ -44,7 +44,7 @@ Welcome to Racket v8.5 [cs].
 
   <p>
     Install Rust, using <a href="https://rustup.rs/">rustup</a> or via some other means.
-    Versions as old as 1.46.0 are supported.
+    Versions as old as 1.60.0 are supported.
     Also install Racket, version 8.0 or later, either using the the
     <a href="http://download.racket-lang.org/racket-v8.5.html">official installer</a>
     or distro-provided packages.


### PR DESCRIPTION
This PR updates `egg` to version 0.8.1 as well as other dependencies of `egg-herbie`.