### PR TITLE
Cleanup

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -84,7 +84,7 @@
 
 ;; runs rules on an egraph
 ;; can optionally specify an iter limit
-(define (egraph-run egraph-data iter-limit node-limit ffi-rules precompute?)
+(define (egraph-run egraph-data node-limit ffi-rules precompute? [iter-limit #f])
   (define egraph-ptr (egraph-data-egraph-pointer egraph-data))
   (define-values (egraphiters res-len)
     (if iter-limit

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -1,6 +1,5 @@
 #lang racket
 
-(require racket/runtime-path racket/hash)
 (require (only-in xml write-xexpr) json)
 (require racket/date "../src/common.rkt" "../src/datafile.rkt")
 (provide directory-jsons)

--- a/infra/survey.rkt
+++ b/infra/survey.rkt
@@ -1,7 +1,6 @@
 #lang racket
 (require json xml)
-(require "../src/common.rkt" "../src/timeline.rkt" "../src/profile.rkt"
-         "../src/datafile.rkt" "../src/web/timeline.rkt")
+(require "../src/datafile.rkt")
 
 (define metrics
   (list `(start . ,table-row-start)

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -3,11 +3,10 @@
 (require (submod "syntax/rules.rkt" internals)
          (submod "syntax/syntax.rkt" internals)
          "common.rkt" "interface.rkt" "errors.rkt"
-         "syntax/rules.rkt" "syntax/syntax.rkt")
+         "syntax/syntax.rkt")
 
-(module+ test (require "load-plugin.rkt"))
-
-(provide generate-conversions generate-prec-rewrites get-rewrite-operator *conversions*)
+(provide generate-conversions generate-prec-rewrites
+         get-rewrite-operator *conversions*)
 
 (define *conversions* (make-parameter (hash)))
 
@@ -128,6 +127,9 @@
 
 ;; try built in reprs
 (module+ test
+  (require "load-plugin.rkt")
+  (load-herbie-plugins)
+  
   (define convs (list (map get-representation '(binary64 binary32))))
   (generate-conversions convs)
   (generate-prec-rewrites convs))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,8 +1,7 @@
 #lang racket
 
 (require racket/hash)
-(require "../common.rkt" "../alternative.rkt" "../points.rkt"
-         "../timeline.rkt" "../programs.rkt")
+(require "../common.rkt" "../alternative.rkt" "../points.rkt" "../programs.rkt")
 
 (provide
  (contract-out

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -17,7 +17,6 @@
 ;; Bindings are stored as association lists
 
 (define (merge-bindings binding1 binding2)
-  (define (fail . irr) #f)
   (and binding1
        binding2
        (let/ec quit
@@ -25,8 +24,6 @@
            (dict-update binding k (λ (x) (if (equal? x v) v (quit #f))) v)))))
 
 (define (pattern-match pattern expr)
-  (define (fail . irr) #f)
-
   (match pattern
    [(? number?)
     (and (equal? pattern expr) '())]

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -79,9 +79,6 @@
 ;;  egg-rewrite-iter-limit - call to egg on an expression with an iter limit (last resort)
 ;;
 
-(define (expr-list? li)
-  (and (list? li) (list? (car li))))
-
 (define (batch-egg-rewrite exprs
                            repr
                            #:rules rules
@@ -110,19 +107,19 @@
               [(egraph-is-unsound-detected egg-graph)
                 ; unsoundness detected, fallback
                 (match* (exprs iter-limit)
-                 [((? expr-list?) #f)         ; run expressions individually
+                 [((list (? list?) (? list?) (? list?) ...) #f)     ; run expressions individually
                   (λ ()
                     (for/list ([expr exprs] [root-loc root-locs])
                       (timeline-push! 'method "egg-rewrite")
                       (car (loop (list expr) (list root-loc) #f))))]
-                 [(_ #f)                      ; run expressions with iter limit
+                 [((list (? list?)) #f)                             ; run expressions with iter limit
                   (λ ()
                     (let ([limit (- (length iter-data) 2)])
                       (timeline-push! 'method "egg-rewrite-iter-limit")
                       (loop exprs root-locs limit)))]
-                 [(_ (? number?))                      ; give up
+                 [(_ (? number?))                                   ; give up
                   (timeline-push! 'method "egg-rewrite-fail")
-                  (λ () '())])]
+                  (λ () '(()))])]
               [else
                 (define variants
                   (for/list ([id node-ids] [expr exprs] [root-loc root-locs])

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -99,7 +99,7 @@
             egg-graph
             exprs
             (λ (node-ids)
-              (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids #t))
+              (define iter-data (egg-run-rules egg-graph #:limit iter-limit (*node-limit*) irules node-ids #t))
               (for ([rule rules])
                 (define count (egraph-get-times-applied egg-graph (rule-name rule)))
                 (when (> count 0) (timeline-push! 'rules (~a (rule-name rule)) count)))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -1,8 +1,7 @@
 #lang racket
 
-(require "../common.rkt" "../programs.rkt" "matcher.rkt" "../interface.rkt"
-         "../syntax/rules.rkt" "../syntax/syntax.rkt"
-         "../syntax/sugar.rkt" "../syntax/types.rkt")
+(require "../common.rkt" "../programs.rkt" "matcher.rkt"
+         "../syntax/rules.rkt" "../syntax/syntax.rkt" "../syntax/sugar.rkt")
 
 (provide simplify load-rule-hacks)
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -4,9 +4,13 @@
          "../syntax/types.rkt" "../interface.rkt" "../errors.rkt" "../preprocess.rkt"
          "../points.rkt")
 (require "../ground-truth.rkt" "../float.rkt") ; For binary search
-(module+ test (require rackunit "../load-plugin.rkt"))
+
 (provide infer-splitpoints (struct-out sp) splitpoints->point-preds combine-alts
          pareto-regimes)
+
+(module+ test
+  (require rackunit "../load-plugin.rkt")
+  (load-herbie-builtins))
 
 (struct option (split-indices alts pts expr errors) #:transparent
 	#:methods gen:custom-write

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -8,7 +8,9 @@
          make-simplification-combinations
          rules->irules egg-run-rules)
 
-(module+ test (require rackunit "../load-plugin.rkt"))
+(module+ test
+  (require rackunit "../load-plugin.rkt")
+  (load-herbie-plugins))
 
 ;; One module to rule them all, the great simplify. It uses egg-herbie
 ;; to simplify an expression as much as possible without making
@@ -114,7 +116,7 @@
       (define cnt (egraph-get-size egg-graph)) 
       (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
   
-  (define iteration-data (egraph-run egg-graph iter-limit node-limit ffi-rules precompute?))
+  (define iteration-data (egraph-run egg-graph node-limit ffi-rules precompute? iter-limit))
   (let loop ([iter iteration-data] [counter 0] [time 0])
     (unless (null? iter)
       (define cnt (iteration-data-num-nodes (first iter)))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -1,9 +1,7 @@
 #lang racket
 
 (require math/number-theory)
-(require "../common.rkt")
-(require "../programs.rkt")
-(require "reduce.rkt")
+(require "../common.rkt" "../programs.rkt" "reduce.rkt")
 (provide approximate)
 
 (define (approximate expr var #:transform [tform (cons identity identity)] #:iters [iters 5])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -500,5 +500,6 @@
 
 (module+ test
   (require rackunit "../interface.rkt" "../load-plugin.rkt")
+  (load-herbie-plugins)
   (*output-repr* (get-representation 'binary64))
   (check-pred exact-integer? (car (taylor 'x '(pow x 1.0)))))

--- a/src/cost.rkt
+++ b/src/cost.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "interface.rkt" "syntax/syntax.rkt" "syntax/sugar.rkt")
+(require "interface.rkt" "syntax/syntax.rkt")
 (provide program-cost expr-cost)
 
 (define (operator-cost op)

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require racket/date json)
-(require "common.rkt" "interface.rkt")
+(require "common.rkt")
 
 (provide
  (struct-out table-row) (struct-out report-info)

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -1,11 +1,12 @@
 #lang racket
 (require "config.rkt")
 (provide raise-herbie-error raise-herbie-syntax-error
-         raise-herbie-sampling-error
+         raise-herbie-sampling-error raise-herbie-missing-error
          herbie-error->string herbie-error-url
          (struct-out exn:fail:user:herbie)
          (struct-out exn:fail:user:herbie:syntax)
          (struct-out exn:fail:user:herbie:sampling)
+         (struct-out exn:fail:user:herbie:missing)
          warn warning-log *warnings-disabled*
          print-warnings)
 
@@ -18,6 +19,9 @@
 (struct exn:fail:user:herbie:sampling exn:fail:user:herbie ()
   #:extra-constructor-name make-exn:fail:user:herbie:sampling)
 
+(struct exn:fail:user:herbie:missing exn:fail:user:herbie ()
+  #:extra-constructor-name make-exn:fail:user:herbie:missing)
+
 (define (raise-herbie-error message #:url [url #f] . args)
   (raise (make-exn:fail:user:herbie
           (apply format message args) (current-continuation-marks) url)))
@@ -28,6 +32,10 @@
 
 (define (raise-herbie-sampling-error message #:url [url #f] . args)
   (raise (make-exn:fail:user:herbie:sampling
+          (apply format message args) (current-continuation-marks) url)))
+
+(define (raise-herbie-missing-error message #:url [url #f] . args)
+  (raise (make-exn:fail:user:herbie:missing
           (apply format message args) (current-continuation-marks) url)))
 
 (define (herbie-error-url exn)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -2,8 +2,7 @@
 
 
 (require math/bigfloat math/base)
-(require "common.rkt" "interface.rkt" "syntax/types.rkt" "errors.rkt")
-(module+ test (require rackunit "load-plugin.rkt"))
+(require "common.rkt" "interface.rkt" "errors.rkt")
 
 (provide 
  special-value?
@@ -72,6 +71,9 @@
       (largest-ordinary-value repr)))
 
 (module+ test
+  (require rackunit "load-plugin.rkt")
+  (load-herbie-plugins)
+
   (define binary64 (get-representation 'binary64))
   (check-false (special-value? 2.5 binary64))
   (check-true  (special-value? +nan.0 binary64))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require math/bigfloat math/flonum)
+(require math/bigfloat)
 (require "syntax/types.rkt" "errors.rkt")
 
 (provide (struct-out representation) get-representation

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -84,9 +84,8 @@
 ;; e.g. float for binary32.
 (define (register-representation-alias! name repr)
   (unless (representation? repr)
-      (error' register-representation-alias!
-              "Expected a representation. Received ~a. Check your plugins!!"
-              repr))
+    (raise-herbie-error "Tried to register an alias for representation ~a: not found"
+                        (representation-name repr)))
   (set! representations (hash-set representations name repr)))
 
 (define-syntax-rule (define-representation (name type repr?) args ...)

--- a/src/load-plugin.rkt
+++ b/src/load-plugin.rkt
@@ -26,8 +26,6 @@
    ['racket   (dynamic-require fallback-plugin #f) #t]
    [_ #f]))
 
-(register-generator! generate-builtins)
-
 (define (load-herbie-plugins)
   (load-herbie-builtins)    ; automatically load default representations
   (for ([dir (find-relevant-directories '(herbie-plugin))])
@@ -38,3 +36,7 @@
     (when value
       (with-handlers ([exn:fail:filesystem:missing-module? void])
         (dynamic-require value #f)))))
+
+;; requiring "load-plugin.rkt" automatically registers
+;; all built-in representation but does not load them
+(register-generator! generate-builtins)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "syntax/rules.rkt" "syntax/sugar.rkt" "syntax/types.rkt"
+(require "syntax/rules.rkt" "syntax/types.rkt"
          "core/alt-table.rkt" "core/localize.rkt" "core/regimes.rkt" "core/simplify.rkt"
          "alternative.rkt" "common.rkt" "conversions.rkt" "errors.rkt"
          "interface.rkt" "patch.rkt" "points.rkt" "preprocess.rkt" "ground-truth.rkt"

--- a/src/pareto.rkt
+++ b/src/pareto.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require rackunit)
-(require "alternative.rkt" "interface.rkt" "points.rkt")
+(require "alternative.rkt" "points.rkt")
 
 (provide generate-pareto-curve)
 

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -54,7 +54,7 @@
     (hash-update! (patchtable-table *patch-table*) expr
                   (if improve (curry cons improve) identity) (list))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;; Internals ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Taylor ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define transforms-to-try
   (let ([invert-x (λ (x) `(/ 1 ,x))] [exp-x (λ (x) `(exp ,x))] [log-x (λ (x) `(log ,x))]
@@ -129,10 +129,7 @@
     (^series^ series-expansions*))
   (void))
 
-(define (bad-alt! altn)
-  (define expr (program-body (alt-program altn)))
-  (when (expr-contains? expr rewrite-repr-op?)
-    (error 'bad-alt! "containg rewrite repr ~a" expr)))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (gen-rewrites!)
   (when (and (null? (^queued^)) (null? (^queuedlow^)))
@@ -186,6 +183,8 @@
   ; TODO: accuracy stats for timeline
   (^rewrites^ rewritten*)
   (void))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Simplify ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (get-starting-expr altn)
   (match (alt-event altn)

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -1,9 +1,9 @@
 #lang racket
 
-(require setup/getinfo)
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals)
          "errors.rkt" "interface.rkt")
+
 (provide define-type define-representation define-operator-impl
          define-operator define-ruleset define-ruleset*
          register-ruleset! register-operator-impl! 

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "float.rkt" "common.rkt" "programs.rkt" "config.rkt" "errors.rkt" "interface.rkt")
+(require "config.rkt" "float.rkt" "interface.rkt" "programs.rkt")
 
 (provide *pcontext* in-pcontext mk-pcontext for/pcontext pcontext? split-pcontext join-pcontext
          errors batch-errors errors-score oracle-error baseline-error oracle-error-idx)

--- a/src/preprocess.rkt
+++ b/src/preprocess.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "interface.rkt" "programs.rkt" "float.rkt" "points.rkt")
+(require "interface.rkt" "points.rkt")
 
 (provide preprocess-pcontext *herbie-preprocess* apply-preprocess)
 

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -2,7 +2,6 @@
 
 (require math/bigfloat rival)
 (require "syntax/types.rkt" "syntax/syntax.rkt" "interface.rkt" "timeline.rkt")
-(module+ test (require rackunit))
 
 (provide (all-from-out "syntax/syntax.rkt")
          program-body program-variables
@@ -12,6 +11,10 @@
          batch-eval-progs eval-prog eval-application
          free-variables replace-expression replace-vars
          apply-repr-change)
+
+(module+ test
+  (require rackunit "load-plugin.rkt")
+  (load-herbie-plugins))
 
 (define expr? (or/c list? symbol? boolean? real?))
 
@@ -135,9 +138,6 @@
   (define exprc 0)
   (define varc (length vars))
 
-  ;; Local cache of operator info
-  (define cached-ops (make-hash))
-
   ;; Known representations
   (define bool-repr (get-representation 'bool))
 
@@ -169,7 +169,6 @@
                   (set! exprc (+ 1 exprc))
                   (set! exprs (cons expr exprs))))))
 
-  (define progc (length progs))
   (define names
     (for/list ([prog progs])
       (munge (program-body prog) repr)))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -1,9 +1,8 @@
 #lang racket
 
 (require math/bigfloat rival)
-(require "syntax/types.rkt" "syntax/syntax.rkt" "float.rkt" "interface.rkt"
-         "timeline.rkt")
-(module+ test (require rackunit "load-plugin.rkt"))
+(require "syntax/types.rkt" "syntax/syntax.rkt" "interface.rkt" "timeline.rkt")
+(module+ test (require rackunit))
 
 (provide (all-from-out "syntax/syntax.rkt")
          program-body program-variables

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -1,10 +1,10 @@
 #lang racket
 (require math/bigfloat rival math/base
          (only-in fpbench interval range-table-ref condition->range-table [expr? fpcore-expr?]))
-(require "searchreals.rkt" "programs.rkt" "config.rkt" "errors.rkt" "common.rkt"
-         "float.rkt" "alternative.rkt" "interface.rkt"
-         "timeline.rkt" "syntax/types.rkt" "syntax/sugar.rkt")
-(module+ test (require rackunit "load-plugin.rkt"))
+(require "searchreals.rkt" "programs.rkt" "errors.rkt" "common.rkt"
+         "float.rkt" "interface.rkt" "timeline.rkt"
+         "syntax/types.rkt" "syntax/sugar.rkt")
+
 (provide make-sampler batch-prepare-points)
 
 ;; Much of this code assumes everything supports intervals. Almost
@@ -13,7 +13,11 @@
 (module+ test
   (require "syntax/read.rkt")
   (require racket/runtime-path)
+  (require rackunit "load-plugin.rkt")
+
   (define-runtime-path benchmarks "../bench/")
+  (load-herbie-builtins)
+  
   (define exprs
     (let ([tests (load-tests benchmarks)])
       (append (map test-program tests) (map test-precondition tests))))
@@ -44,6 +48,9 @@
      (ival #f #t)]))
 
 (module+ test
+  (require rackunit "load-plugin.rkt")
+  (load-herbie-builtins)
+
   (define repr (get-representation 'binary64))
   (check-equal? (precondition->hyperrects
                  '(λ (a b) (and (and (<=.f64 0 a) (<=.f64 a 1))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -1,16 +1,15 @@
 #lang racket
 (require profile math/bigfloat racket/engine json)
-(require "common.rkt" "errors.rkt" "debug.rkt" "points.rkt" "programs.rkt" "ground-truth.rkt"
-         "mainloop.rkt" "alternative.rkt" "timeline.rkt" (submod "timeline.rkt" debug)
-         "interface.rkt" "datafile.rkt" "syntax/read.rkt" "syntax/rules.rkt" "profile.rkt"
-         (submod "syntax/rules.rkt" internals) "syntax/syntax.rkt" "conversions.rkt"
-         "syntax/sugar.rkt" "preprocess.rkt" "sampling.rkt" "cost.rkt")
+(require "syntax/read.rkt" "syntax/sugar.rkt"
+         "alternative.rkt" "common.rkt" "conversions.rkt" "cost.rkt"
+         "datafile.rkt" "debug.rkt" "errors.rkt" "interface.rkt"
+         "mainloop.rkt" "preprocess.rkt" "points.rkt" "profile.rkt"
+         "programs.rkt" "timeline.rkt" (submod "timeline.rkt" debug))
 
 (provide get-test-result *reeval-pts* *timeout*
          (struct-out test-result) (struct-out test-success)
          (struct-out test-failure) (struct-out test-timeout)
          get-table-data unparse-result)
-
 
 ;; These cannot move between threads!
 (struct test-result (test bits time timeline warnings))

--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -2,8 +2,6 @@
 (require math/bigfloat rival)
 (require "interface.rkt" "timeline.rkt")
 
-(module+ test (require rackunit))
-
 (provide find-intervals hyperrect-weight)
 
 (struct search-space (true false other))

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -161,3 +161,34 @@
           (if (equal? (length duplicates) 1) "name" "names")
           (string-join (map (curry format "\"~a\"") duplicates) ", ")))
   out)
+
+(module+ test
+  (require rackunit "../load-plugin.rkt")
+  (load-herbie-builtins)
+
+  (define repr (get-representation 'binary64))
+
+  ;; inlining
+
+  ;; Test classic quadp and quadm examples
+  (register-function! 'discr (list 'a 'b 'c) repr `(sqrt (- (* b b) (* 4 a c))))
+  (define quadp `(/ (+ (- y) (discr x y z)) (* 2 x)))
+  (define quadm `(/ (- (- y) (discr x y z)) (* 2 x)))
+  (check-equal? (desugar-program quadp repr (map (curryr cons repr) (list 'x 'y 'z)))
+                '(/.f64 (+.f64 (neg.f64 y) (sqrt.f64 (-.f64 (*.f64 y y) (*.f64 (*.f64 4 x) z)))) (*.f64 2 x)))
+  (check-equal? (desugar-program quadm repr (map (curryr cons repr) (list 'x 'y 'z)))
+                '(/.f64 (-.f64 (neg.f64 y) (sqrt.f64 (-.f64 (*.f64 y y) (*.f64 (*.f64 4 x) z)))) (*.f64 2 x)))
+
+  ;; x^5 = x^3 * x^2
+  (register-function! 'sqr (list 'x) repr '(* x x))
+  (register-function! 'cube (list 'x) repr '(* x x x))
+  (define fifth '(* (cube a) (sqr a)))
+  (check-equal? (desugar-program fifth repr (list (cons 'a repr)))
+                '(*.f64 (*.f64 (*.f64 a a) a) (*.f64 a a)))
+
+  ;; casting edge cases
+  (check-equal? (desugar-program `(cast x) repr `((x . ,repr)))
+                'x)
+  (check-equal? (desugar-program `(cast (! :precision binary64 x)) repr `((x . ,repr)))
+                'x)
+)

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
-(require "../config.rkt" "../common.rkt" "../errors.rkt" "../programs.rkt" "../interface.rkt"
-         "../conversions.rkt"
+(require "../common.rkt" "../conversions.rkt" "../errors.rkt"
+         "../programs.rkt" "../interface.rkt"
          "syntax-check.rkt" "type-check.rkt" "sugar.rkt")
 
 (provide (struct-out test)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -698,7 +698,6 @@
   [expm1-log1p (expm1 (log1p x))          x]
   [hypot-def   (sqrt (+ (* x x) (* y y))) (hypot x y)]
   [hypot-1-def (sqrt (+ 1 (* y y)))       (hypot 1 y)]
-  [atan2-def   (atan (/ y x))             (atan2 y x)]
   [fma-def     (+ (* x y) z)              (fma x y z)]
   [fma-neg     (- (* x y) z)              (fma x y (neg z))]
   [fma-udef    (fma x y z)                (+ (* x y) z)])
@@ -709,7 +708,6 @@
   [log1p-udef    (log1p x)      (log (+ 1 x))]
   [log1p-expm1-u x              (log1p (expm1 x))]
   [expm1-log1p-u x              (expm1 (log1p x))]
-  [atan2-udef    (atan2 y x)    (atan (/ y x))]
   [hypot-udef    (hypot x y)    (sqrt (+ (* x x) (* y y)))])
 
 (define-ruleset* numerics-papers (numerics)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -703,6 +703,7 @@
   [expm1-log1p (expm1 (log1p x))          x]
   [hypot-def   (sqrt (+ (* x x) (* y y))) (hypot x y)]
   [hypot-1-def (sqrt (+ 1 (* y y)))       (hypot 1 y)]
+  [atan2-def   (atan (/ y x))             (atan2 y x)]
   [fma-def     (+ (* x y) z)              (fma x y z)]
   [fma-neg     (- (* x y) z)              (fma x y (neg z))]
   [fma-udef    (fma x y z)                (+ (* x y) z)])
@@ -713,6 +714,7 @@
   [log1p-udef    (log1p x)      (log (+ 1 x))]
   [log1p-expm1-u x              (log1p (expm1 x))]
   [expm1-log1p-u x              (expm1 (log1p x))]
+  [atan2-udef    (atan2 y x)    (atan (/ y x))]
   [hypot-udef    (hypot x y)    (sqrt (+ (* x x) (* y y)))])
 
 (define-ruleset* numerics-papers (numerics)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -190,32 +190,3 @@
     [(list? expr)
      (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
     [#t expr]))
-
-#;(module+ test
-  (require rackunit)
-  (define repr (get-representation 'binary64))
-
-  ;; inlining
-
-  ;; Test classic quadp and quadm examples
-  (register-function! 'discr (list 'a 'b 'c) repr `(sqrt (- (* b b) (* 4 a c))))
-  (define quadp `(/ (+ (- y) (discr x y z)) (* 2 x)))
-  (define quadm `(/ (- (- y) (discr x y z)) (* 2 x)))
-  (check-equal? (desugar-program quadp repr (map (curryr cons repr) (list 'x 'y 'z)))
-                '(/.f64 (+.f64 (neg.f64 y) (sqrt.f64 (-.f64 (*.f64 y y) (*.f64 (*.f64 4 x) z)))) (*.f64 2 x)))
-  (check-equal? (desugar-program quadm repr (map (curryr cons repr) (list 'x 'y 'z)))
-                '(/.f64 (-.f64 (neg.f64 y) (sqrt.f64 (-.f64 (*.f64 y y) (*.f64 (*.f64 4 x) z)))) (*.f64 2 x)))
-
-  ;; x^5 = x^3 * x^2
-  (register-function! 'sqr (list 'x) repr '(* x x))
-  (register-function! 'cube (list 'x) repr '(* x x x))
-  (define fifth '(* (cube a) (sqr a)))
-  (check-equal? (desugar-program fifth repr (list (cons 'a repr)))
-                '(*.f64 (*.f64 (*.f64 a a) a) (*.f64 a a)))
-
-  ;; casting edge cases
-  (check-equal? (desugar-program `(cast x) repr `((x . ,repr)))
-                'x)
-  (check-equal? (desugar-program `(cast (! :precision binary64 x)) repr `((x . ,repr)))
-                'x)
-)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -1,8 +1,7 @@
 #lang racket
 
-(require "types.rkt" "syntax.rkt" "../errors.rkt" "../interface.rkt")
+(require "syntax.rkt" "../errors.rkt" "../interface.rkt")
 (provide desugar-program resugar-program)
-(module+ test (require rackunit))
 
 ;; preprocessing
 (define (expand expr)
@@ -193,6 +192,7 @@
     [#t expr]))
 
 #;(module+ test
+  (require rackunit)
   (define repr (get-representation 'binary64))
 
   ;; inlining

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "types.rkt" "syntax.rkt" "../interface.rkt")
+(require "types.rkt" "syntax.rkt" "../errors.rkt" "../interface.rkt")
 (provide desugar-program resugar-program)
 (module+ test (require rackunit))
 
@@ -103,7 +103,8 @@
              (define rtype (operator-info name 'otype))
              (when (or (equal? rtype repr) (equal? (representation-type rtype) 'bool))
                (k (list name) rtype)))
-           (error 'sugar "Could not find constant implementation for ~a at ~a" x (representation-name repr)))]
+           (raise-herbie-missing-error "Could not find constant implementation for ~a at ~a"
+                                        x (representation-name repr)))]
         [(list op args ...)
          (define-values (args* atypes)
            (for/lists (args* atypes) ([arg args])
@@ -127,8 +128,8 @@
           [else
            (define conv (get-repr-conv vrepr repr))
            (unless conv
-             (error 'expand-parametric "Conversion does not exist: ~a -> ~a\n"
-                    (representation-name vrepr) (representation-name repr)))
+             (raise-herbie-missing-error "Conversion does not exist: ~a -> ~a"
+                (representation-name vrepr) (representation-name repr)))
            (values (list conv expr) repr)])]))) 
   expr*)
 

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -3,7 +3,6 @@
 (require syntax/id-set)
 (require "../common.rkt" "../conversions.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt")
 (provide assert-program!)
-(module+ test (require rackunit "../load-plugin.rkt"))
 
 (define (check-expression* stx vars error!)
   (match stx
@@ -177,6 +176,9 @@
 
 ;; testing FPCore format
 (module+ test
+  (require rackunit "../load-plugin.rkt")
+  (load-herbie-builtins)
+
   (define (get-errs stx)
     (reap [sow]
           (define (error! stx fmt . args)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -183,7 +183,7 @@
       (unless (equal? (representation-type arepr) itype)
         (raise-herbie-missing-error
           "Cannot register ~a as implementation of ~a: ~a is not a representation of ~a"
-          name operator rrepr (operator-otype op)))))
+          name operator (representation-name rrepr) (operator-otype op)))))
 
   (define impl (operator-impl name op areprs rrepr fl-fun bf-fun ival-fun))
   (hash-set! operator-impls name impl)
@@ -201,12 +201,11 @@
     (for ([impl (operator-all-impls name)])
       (define atypes (operator-info impl 'itype))
       (when (equal? atypes actual-types) (k impl)))
-    (when fail-fast?
-      (raise-herbie-missing-error
+    (unless fail-fast? (k #f))
+    (raise-herbie-missing-error
         "Parametric operator (~a ~a) not found"
         name
-        (string-join (map (λ (r) (format "<~a>" (representation-name r))) actual-types) " "))
-      #f)))
+        (string-join (map (λ (r) (format "<~a>" (representation-name r))) actual-types) " "))))
 
 (define (impl->operator name)
   (operator-name (operator-impl-op (hash-ref operator-impls name))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
-(require math/flonum math/base math/bigfloat math/special-functions rival)
-(require "../common.rkt" "../interface.rkt" "../errors.rkt" "types.rkt")
+(require math/bigfloat rival)
+(require "../common.rkt" "../interface.rkt" "../errors.rkt")
 
 (provide (rename-out [operator-or-impl? operator?])
          variable? constant-operator? operator-exists? impl-exists?

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -1,9 +1,9 @@
 #lang racket
 
 (require rackunit)
-(require "../common.rkt" "../programs.rkt" "../sampling.rkt" "../ground-truth.rkt")
-(require "rules.rkt" (submod "rules.rkt" internals) "../interface.rkt")
-(require "../programs.rkt" "../float.rkt" "sugar.rkt" "../load-plugin.rkt")
+(require "../common.rkt" "../programs.rkt" "../float.rkt"
+         "../ground-truth.rkt" "../interface.rkt" "../load-plugin.rkt"
+         "rules.rkt" (submod "rules.rkt" internals))
 
 (load-herbie-builtins)
 

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt" "types.rkt")
+(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt")
 (provide assert-program-typed!)
 
 (define (assert-program-typed! stx)

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -1,7 +1,5 @@
 #lang racket
 
-(require math/bigfloat)
-
 (provide type-name get-type type-name?)
 (module+ internals (provide define-type))
 

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -1,5 +1,7 @@
 #lang racket
-(require "config.rkt" "float.rkt" racket/hash json)
+
+(require json "config.rkt")
+
 (provide timeline-event! timeline-push! timeline-adjust!
          timeline-load! timeline-extract timeline-compact!
          timeline-merge timeline-relink *timeline-disabled*)

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -8,7 +8,7 @@
                           *expr-cse-able?*))
 
 (require "../common.rkt" "../syntax/read.rkt" "../programs.rkt"
-         "../interface.rkt" "../preprocess.rkt" "../syntax/sugar.rkt")
+         "../interface.rkt" "../syntax/sugar.rkt")
 
 (provide render-menu render-warnings render-large render-program
          program->fpcore render-reproduction js-tex-include)

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -4,7 +4,7 @@
          (only-in fpbench core->tex supported-by-lang?))
 (require "../points.rkt" "../float.rkt" "../alternative.rkt" "../interface.rkt"
          "../syntax/rules.rkt" "../core/regimes.rkt" "../common.rkt"
-        "common.rkt" "../programs.rkt" "../syntax/sugar.rkt")
+         "common.rkt" "../syntax/sugar.rkt")
 (provide render-history)
 
 (define (split-pcontext pcontext splitpoints alts repr)

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -1,8 +1,8 @@
 #lang racket
 
 (require (only-in fpbench fpcore? supported-by-lang? core->js js-header) json)
-(require "../alternative.rkt" "../syntax/read.rkt" "../sandbox.rkt" "../interface.rkt")
-(require "common.rkt" "timeline.rkt" "plot.rkt" "make-graph.rkt" "traceback.rkt" "../programs.rkt"
+(require "../alternative.rkt" "../syntax/read.rkt" "../sandbox.rkt" )
+(require "common.rkt" "timeline.rkt" "plot.rkt" "make-graph.rkt" "traceback.rkt"
         "../syntax/sugar.rkt" "../float.rkt")
 (provide all-pages make-page page-error-handler)
 

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -1,7 +1,6 @@
 #lang racket
 (require json (only-in xml write-xexpr xexpr?) racket/date)
-(require "../common.rkt" "../syntax/read.rkt" "../sandbox.rkt"
-         "../datafile.rkt" "common.rkt")
+(require "../common.rkt" "../datafile.rkt" "common.rkt")
 (provide make-timeline)
 
 (define timeline-phase? (hash/c symbol? any/c))


### PR DESCRIPTION
Just some pre-release code cleanup:
- refactor Herbie-side egg-rr code
- trims imports
- re-enables some unit tests
- remove dubious locations of `exn:fail?` error handling
- changes certain errors to herbie:user errors