### PR TITLE
Taylor: fix cbrt and fast paths for 1/2 and 1/3 powers 

### DIFF
--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -171,6 +171,11 @@
                         ((cdr rest) n))))))]
     [`(pow ,base ,(? exact-integer? power))
      (taylor-pow (normalize-series (taylor var base)) power)]
+    [`(pow ,base 1/2)
+     (taylor-sqrt (taylor var base))]
+    ; implementation incorrect
+    ; [`(pow ,base 1/3)
+    ;  (taylor-cbrt (taylor var base))]
     [`(pow ,base ,power)
      (taylor var `(exp (* ,power (log ,base))))]
     [`(expm1 ,arg) (taylor var `(- (exp ,arg) 1))]
@@ -335,9 +340,10 @@
          [offset* (- offset (modulo offset 3))]
          [coeffs (cdr num*)]
          [coeffs* (if (= (modulo offset 3) 0) coeffs (λ (n) (if (= n 0) 0 (coeffs (+ n (modulo offset 3))))))]
+         [coeffs0 (coeffs* 0)]
          [hash (make-hash)])
-    (hash-set! hash 0 (simplify `(cbrt ,(coeffs* 0))))
-    (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt ,(coeffs* 0))))))
+    (hash-set! hash 0 (simplify `(cbrt ,coeffs0)))
+    (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt ,coeffs0)))))
     (letrec ([f (λ (n)
                    (hash-ref! hash n
                               (λ ()

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -339,9 +339,10 @@
          [offset* (- offset (modulo offset 3))]
          [coeffs (cdr num*)]
          [coeffs* (if (= (modulo offset 3) 0) coeffs (λ (n) (if (= n 0) 0 (coeffs (+ n (modulo offset 3))))))]
+         [f0 (simplify `(cbrt ,(coeffs* 0)))]
          [hash (make-hash)])
-    (hash-set! hash 0 (simplify `(cbrt ,(coeffs 0))))
-    (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt (* (cbrt ,(coeffs 0)) (cbrt ,(coeffs 0))))))))
+    (hash-set! hash 0 f0)
+    (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt (* ,f0 ,f0))))))
     (letrec ([f (λ (n)
                    (hash-ref! hash n
                               (λ ()
@@ -351,12 +352,12 @@
                                     `(/ (- ,(coeffs* n) (pow ,(f (/ n 3)) 3)
                                           (+ ,@(for*/list ([j (in-range n)] [k (in-range (+ j 1) n)] #:when (< (+ j k) n))
                                                   `(* 3 (* ,(f j) ,(f k) ,(f (- n j k)))))))
-                                        (* 3 ,(f 0) ,(f 0)))]
+                                        (* 3 ,f0 ,f0))]
                                    [else
                                     `(/ (- ,(coeffs* n)
                                           (+ ,@(for*/list ([j (in-range n)] [k (in-range (+ j 1) n)] #:when (< (+ j k) n))
                                                   `(* 3 (* ,(f j) ,(f k) ,(f (- n j k)))))))
-                                        (* 3 ,(f 0) ,(f 0)))])))))])
+                                        (* 3 ,f0 ,f0))])))))])
       (cons (/ offset* 3) f))))
 
 (define (taylor-pow coeffs n)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -235,6 +235,7 @@
     [(list 'ceil (? exact-value? a)) (ceiling a)]
     [(list 'round (? exact-value? a)) (round a)]
     ;; Added
+    [(list 'exp 0) 1]
     [(list 'log 1) 0]
     [(list 'cbrt 1) 1]
     [_ #f]))


### PR DESCRIPTION
This PR fixes the taylor-cbrt implementation and uses `sqrt` and `cbrt` for `(pow _ 1/2)` and `(pow _ 1/3)` rather than the default.