### PR TITLE
Partial fix for fitting KaTeX expressions inside surrounding boxes.

### DIFF
--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -78,8 +78,8 @@
      (head
       (meta ([charset "utf-8"]))
       (title "Result for " ,(~a (test-name test)))
-      (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
       ,@js-tex-include
+      (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
       (script ([src "../report.js"]))
       (script ([src "interactive.js"]))
       (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"])))

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -187,6 +187,10 @@ section h1 {
 #language { position: absolute; right: 1em; }
 #precondition { padding: 0 1em 1em; margin: 0 -1em 1em; border-bottom: 2px solid white; }
 #precondition:before { content: "Precondition"; float: left; color: #444; }
+/* Allow line breaks in display equations (see https://katex.org/docs/issues.html) */
+.katex-display > .katex { white-space: normal }
+.katex-display .base { margin: 0.25em 0 }
+.katex-display { margin: 0.5em 0; }
 #preprocess { padding: 0 1em 1em; margin: 0 -1em 1em; border-bottom: 2px solid white; }
 #preprocess:before { content: "Preprocess"; float: left; color: #444; }
 


### PR DESCRIPTION
This allows the browser to break katex display expressions on spaces that are not inside of parenthesized expressions.

This doesn't solve display issues where the majority of the expression is parenthesized, but it should generally solve precondition overflow. As written, this will affect the display of katex expressions anywhere on the page.

The code is copied from https://katex.org/docs/issues.html.

Note that this fix swaps the HTML loading order of the katex CSS file and the report CSS file so the report CSS comes later and its rules are prioritized.