### PR TITLE
Timeline improvements

### DIFF
--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -180,7 +180,7 @@
     (timeline-push! 'method "batch-egg-rewrite")
     (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
     (timeline-push! 'inputs (map ~a exprs))
-    (define out (batch-egg-rewrite expr repr #:rules rules #:roots root-locs #:depths depths))
+    (define out (batch-egg-rewrite exprs repr #:rules rules #:roots root-locs #:depths depths))
     (timeline-push! 'outputs (map ~a out))
     out]
    [else

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -180,15 +180,12 @@
     (define driver batch-egg-rewrite)
     (timeline-push! 'method (~a (object-name driver)))
     (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
-    (define tnow (current-inexact-milliseconds))
-    (begin0 (driver exprs repr #:rules rules #:roots root-locs #:depths depths)
-      (for ([expr exprs])
-        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))]
+    (driver exprs repr #:rules rules #:roots root-locs #:depths depths)]
    [else
     (define driver rewrite-once)
     (timeline-push! 'method (~a (object-name driver)))
     (for/list ([expr exprs] [root-loc root-locs] [depth depths] [n (in-naturals 1)])
         (debug #:from 'progress #:depth 4 "[" n "/" (length exprs) "] rewriting for" expr)
-        (define tnow (current-inexact-milliseconds))
+        (define timeline-stop! (timeline-start! 'times (~a expr)))
         (begin0 (driver expr repr #:rules rules #:root root-loc #:depth depth)
-          (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))]))
+          (timeline-stop!)))]))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -180,7 +180,7 @@
     (timeline-push! 'method "batch-egg-rewrite")
     (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
     (timeline-push! 'inputs (map ~a exprs))
-    (define out (batch-egg-rewrite rules #:roots root-locs #:depths depths))
+    (define out (batch-egg-rewrite expr repr #:rules rules #:roots root-locs #:depths depths))
     (timeline-push! 'outputs (map ~a out))
     out]
    [else

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -177,15 +177,16 @@
   (cond
    [(null? exprs) '()]
    [(flag-set? 'generate 'rr)
-    (define driver batch-egg-rewrite)
-    (timeline-push! 'method (~a (object-name driver)))
+    (timeline-push! 'method "batch-egg-rewrite")
     (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
-    (driver exprs repr #:rules rules #:roots root-locs #:depths depths)]
+    (timeline-push! 'inputs (map ~a exprs))
+    (define out (batch-egg-rewrite rules #:roots root-locs #:depths depths))
+    (timeline-push! 'outputs (map ~a out))
+    out]
    [else
-    (define driver rewrite-once)
-    (timeline-push! 'method (~a (object-name driver)))
+    (timeline-push! 'method "rewrite-once")
     (for/list ([expr exprs] [root-loc root-locs] [depth depths] [n (in-naturals 1)])
         (debug #:from 'progress #:depth 4 "[" n "/" (length exprs) "] rewriting for" expr)
         (define timeline-stop! (timeline-start! 'times (~a expr)))
-        (begin0 (driver expr repr #:rules rules #:root root-loc #:depth depth)
+        (begin0 (rewrite-once expr repr #:rules rules #:root root-loc #:depth depth)
           (timeline-stop!)))]))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -32,14 +32,12 @@
 ;; can insert a timeline break between them.
 
 (define (infer-splitpoints alts repr)
-  (debug "Finding splitpoints for:" alts #:from 'regime #:depth 2)
   (timeline-event! 'regimes)
+  (timeline-push! 'inputs (map (compose ~a program-body alt-program) alts)
   (define branch-exprs
     (if (flag-set? 'reduce 'branch-expressions)
         (exprs-to-branch-on alts repr)
         (program-variables (alt-program (first alts)))))
-  (debug "Trying" (length branch-exprs) "branch expressions:" branch-exprs
-         #:from 'regime-changes #:depth 3)
   (define options
     ;; We can only combine alts for which the branch expression is
     ;; critical, to enable binary search.
@@ -53,7 +51,6 @@
                      (not (set-member? sound-alts (list-ref alts (si-cidx si))))))
           (sow (option-on-expr sound-alts bexpr repr))))))
   (define best (argmin (compose errors-score option-errors) options))
-  (debug "Found split indices:" best #:from 'regime #:depth 3)
   (timeline-push! 'count (length alts) (length (option-split-indices best)))
   best)
 
@@ -128,6 +125,7 @@
 
 (define (option-on-expr alts expr repr)
   (debug #:from 'regimes #:depth 4 "Trying to branch on" expr "from" alts)
+  (define timeline-stop! (timeline-start! 'branch expr))
   (define vars (program-variables (alt-program (first alts))))
   (define pcontext* (sort-context-on-expr (*pcontext*) expr vars repr))
   (define pts (for/list ([(pt ex) (in-pcontext pcontext*)]) pt))
@@ -140,7 +138,9 @@
     (for/list ([alt alts]) (errors (alt-program alt) pcontext* repr)))
   (define bit-err-lsts (map (curry map ulps->bits) err-lsts))
   (define split-indices (err-lsts->split-indices bit-err-lsts can-split?))
-  (option split-indices alts pts expr (pick-errors split-indices pts err-lsts repr)))
+  (define out (option split-indices alts pts expr (pick-errors split-indices pts err-lsts repr)))
+  (timeline-stop! (errors-score (option-errors out)))
+  out)
 
 (define/contract (pick-errors split-indices pts err-lsts repr)
   (->i ([sis (listof si?)] 
@@ -214,8 +214,6 @@
   (define progs (map (compose (curryr extract-subexpression var expr) alt-program) alts))
   (define start-prog (extract-subexpression (*start-prog*) var expr))
 
-  (define eq-repr (get-parametric-operator '== repr repr))
-  
   (define (find-split prog1 prog2 v1 v2)
     (define iters 0)
 
@@ -223,6 +221,7 @@
     (define current-guess v1)
     (define sampling-fail? #f)
 
+    (define eq-repr (get-parametric-operator '== repr repr))
     (define (pred v)
       (set! iters (+ 1 iters))
       (set! best-guess current-guess)
@@ -246,22 +245,7 @@
     (define pt (binary-search-floats pred v1 v2 repr))
     (when sampling-fail?
       (set! pt best-guess))
-    (timeline-push! 'bstep (value->json v1 repr) (value->json v2 repr) iters (value->json pt repr))
     pt)
-
-  (define (sidx->spoint sidx next-sidx)
-    (define prog1 (list-ref progs (si-cidx sidx)))
-    (define prog2 (list-ref progs (si-cidx next-sidx)))
-
-    (define p1 (apply eval-expr (list-ref points (sub1 (si-pidx sidx)))))
-    (define p2 (apply eval-expr (list-ref points (si-pidx sidx))))
-
-    (sp (si-cidx sidx) expr (find-split prog1 prog2 p1 p2)))
-
-  (define (regimes-sidx->spoint sidx)
-    (sp (si-cidx sidx) expr (apply eval-expr (list-ref points (- (si-pidx sidx) 1)))))
-
-  (define final-sp (sp (si-cidx (last sindices)) expr +nan.0))
 
   (define use-binary
     (and (flag-set? 'reduce 'binary-search)
@@ -273,14 +257,24 @@
       
   (append
    (for/list ([si1 sindices] [si2 (cdr sindices)])
-     (cond
-       [use-binary
-        (with-handlers ([exn:fail:user:herbie:sampling?
-                         (lambda (e) (regimes-sidx->spoint si1))])
-          (sidx->spoint si1 si2))]
-       [else
-        (regimes-sidx->spoint si1)]))
-   (list final-sp)))
+     (define timeline-stop! (timeline-start! 'times (~a expr)))
+     (define prog1 (list-ref progs (si-cidx sidx)))
+     (define prog2 (list-ref progs (si-cidx next-sidx)))
+
+     (define p1 (apply eval-expr (list-ref points (sub1 (si-pidx sidx)))))
+     (define p2 (apply eval-expr (list-ref points (si-pidx sidx))))
+
+     (define split-at
+       (if use-binary
+           (with-handlers ([exn:fail:user:herbie:sampling? (const p1)])
+             (find-split prog1 prog2 p1 p2))
+           p1))
+     (timeline-stop!)
+
+     (timeline-push 'method (if use-binary "binary-search" "left-value"))
+     (timeline-push! 'bstep (value->json p1 repr) (value->json p2 repr) (value->json split-at repr))
+     (sp (si-cidx sidx) expr split-at))
+   (list (sp (si-cidx (last sindices)) expr +nan.0))))
 
 (define (point-with-dim index point val)
   (map (λ (pval pindex) (if (= pindex index) val pval))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -33,7 +33,7 @@
 
 (define (infer-splitpoints alts repr)
   (timeline-event! 'regimes)
-  (timeline-push! 'inputs (map (compose ~a program-body alt-program) alts)
+  (timeline-push! 'inputs (map (compose ~a program-body alt-program) alts))
   (define branch-exprs
     (if (flag-set? 'reduce 'branch-expressions)
         (exprs-to-branch-on alts repr)
@@ -258,11 +258,11 @@
   (append
    (for/list ([si1 sindices] [si2 (cdr sindices)])
      (define timeline-stop! (timeline-start! 'times (~a expr)))
-     (define prog1 (list-ref progs (si-cidx sidx)))
-     (define prog2 (list-ref progs (si-cidx next-sidx)))
+     (define prog1 (list-ref progs (si-cidx si1)))
+     (define prog2 (list-ref progs (si-cidx si2)))
 
-     (define p1 (apply eval-expr (list-ref points (sub1 (si-pidx sidx)))))
-     (define p2 (apply eval-expr (list-ref points (si-pidx sidx))))
+     (define p1 (apply eval-expr (list-ref points (sub1 (si-pidx si1)))))
+     (define p2 (apply eval-expr (list-ref points (si-pidx si1))))
 
      (define split-at
        (if use-binary
@@ -271,9 +271,9 @@
            p1))
      (timeline-stop!)
 
-     (timeline-push 'method (if use-binary "binary-search" "left-value"))
+     (timeline-push! 'method (if use-binary "binary-search" "left-value"))
      (timeline-push! 'bstep (value->json p1 repr) (value->json p2 repr) (value->json split-at repr))
-     (sp (si-cidx sidx) expr split-at))
+     (sp (si-cidx si1) expr split-at))
    (list (sp (si-cidx (last sindices)) expr +nan.0))))
 
 (define (point-with-dim index point val)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -125,7 +125,7 @@
 
 (define (option-on-expr alts expr repr)
   (debug #:from 'regimes #:depth 4 "Trying to branch on" expr "from" alts)
-  (define timeline-stop! (timeline-start! 'branch expr))
+  (define timeline-stop! (timeline-start! 'branch (~a expr)))
   (define vars (program-variables (alt-program (first alts))))
   (define pcontext* (sort-context-on-expr (*pcontext*) expr vars repr))
   (define pts (for/list ([(pt ex) (in-pcontext pcontext*)]) pt))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -64,11 +64,13 @@
 
   (define driver simplify-batch-egg)
   (debug #:from 'simplify "Simplifying using" driver ":\n " (string-join (map ~a exprs) "\n  "))
+  (timeline-push! 'inputs (map ~a exprs))
   (define resulting-lists (driver exprs #:rules rls #:precompute precompute?))
   (define out
     (for/list ([results resulting-lists] [expr exprs])
-             (remove-duplicates (cons expr results))))
+      (remove-duplicates (cons expr results))))
   (debug #:from 'simplify "Simplified to:\n " (string-join (map ~a (map last out)) "\n  "))
+  (timeline-push! 'outputs (map ~a (apply append exprs)))
   out)
 
 (define/contract (simplify-batch-egg exprs #:rules rls #:precompute precompute?)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -70,7 +70,7 @@
     (for/list ([results resulting-lists] [expr exprs])
       (remove-duplicates (cons expr results))))
   (debug #:from 'simplify "Simplified to:\n " (string-join (map ~a (map last out)) "\n  "))
-  (timeline-push! 'outputs (map ~a (apply append exprs)))
+  (timeline-push! 'outputs (map ~a (apply append out)))
   out)
 
 (define/contract (simplify-batch-egg exprs #:rules rls #:precompute precompute?)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -126,7 +126,7 @@
       (loop (rest iter) (+ counter 1) new-time)))
 
   (define sr (egraph-stop-reason egg-graph))
-  (timeline-push! 'egraph-stop (stop-reason->string sr) 1)
+  (timeline-push! 'stop (stop-reason->string sr) 1)
   
   (free-ffi-rules ffi-rules)
   iteration-data)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -328,11 +328,10 @@
                       #:preprocess [preprocess '()])
   (debug #:from 'progress #:depth 3 "[2/5] Deducing preprocessing steps")
   (define vars (program-variables specification))
+  (timeline-event! 'preprocess)
 
   ;; If the specification is given, it is used for sampling points
-  (define sortable
-    (parameterize ([*timeline-disabled* true])
-      (connected-components specification)))
+  (define sortable (connected-components specification))
 
   (define new-preprocess
     (for/list ([sortable-variables (in-list sortable)]

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -425,6 +425,7 @@
               'final-simplify (list altn)))
       alt-equal?))
   (timeline-event! 'end)
+  (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
 
   ; find the best, sort the rest by cost
   (define alts* (remove-duplicates cleaned-alts alt-equal?))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -118,9 +118,9 @@
         (for/list ([altn (in-list (^queued^))] [n (in-naturals 1)])
           (define expr (program-body (alt-program altn)))
           (debug #:from 'progress #:depth 4 "[" n "/" (length (^queued^)) "] generating series for" expr)
-          (define tnow (current-inexact-milliseconds))
+          (define timeline-stop! (timeline-start! 'times (~a expr)))
           (begin0 (filter-not (curry alt-equal? altn) (taylor-alt altn))
-            (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
+            (timeline-stop!)))))
 
     ; Probably unnecessary, at least CI passes!
     (define (is-nan? x)

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -35,7 +35,7 @@
     (void)))
 
 (define/contract (timeline-start! key . values)
-  (-> symbol? jsexpr? ... void?)
+  (-> symbol? jsexpr? ... (-> jsexpr? ... void?))
   (define tstart (current-inexact-milliseconds))
   (define (end! . args)
     (define tend (current-inexact-milliseconds))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -134,7 +134,7 @@
 (define-timeline kept #:unmergable)
 (define-timeline min-error #:unmergable)
 (define-timeline egraph #:unmergable)
-(define-timeline egraph-stop [reason false] [count +])
+(define-timeline stop [reason false] [count +])
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -115,7 +115,8 @@
 
 (define-timeline method [method])
 (define-timeline rules [rule false] [count +])
-(define-timeline times [input false] [count +])
+(define-timeline times [input false] [time +])
+(define-timeline series [expr false] [var false] [transform false] [time +])
 (define-timeline compiler [before +] [after +])
 (define-timeline outcomes [name false] [prec false] [category false] [time +] [count +])
 (define-timeline accuracy [accuracy])

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -135,7 +135,7 @@
 (define-timeline min-error #:unmergable)
 (define-timeline egraph #:unmergable)
 (define-timeline stop [reason false] [count +])
-(define-timeline branch #:unmergeable)
+(define-timeline branch #:unmergable)
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -36,9 +36,9 @@
 
 (define (timeline-start! key . values)
   (define tstart (current-inexact-milliseconds))
-  (define (end!)
+  (define (end! . args)
     (define tend (current-inexact-milliseconds))
-    (apply timeline-push! key (append values (list (- tend tstart))))
+    (apply timeline-push! key (append values args (list (- tend tstart))))
     (set-remove! *timeline-timers* end!))
   (set-add! *timeline-timers* end!)
   end!)
@@ -135,6 +135,7 @@
 (define-timeline min-error #:unmergable)
 (define-timeline egraph #:unmergable)
 (define-timeline stop [reason false] [count +])
+(define-timeline branch #:unmergeable)
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -34,7 +34,8 @@
       true)
     (void)))
 
-(define (timeline-start! key . values)
+(define/contract (timeline-start! key . values)
+  (-> symbol? jsexpr? ... void?)
   (define tstart (current-inexact-milliseconds))
   (define (end! . args)
     (define tend (current-inexact-milliseconds))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -124,6 +124,8 @@
 (define-timeline baseline [baseline])
 (define-timeline count [input +] [output +])
 (define-timeline alts #:unmergable)
+(define-timeline inputs #:unmergable)
+(define-timeline outputs #:unmergable)
 (define-timeline sampling #:custom merge-sampling-tables)
 (define-timeline symmetry #:unmergable)
 (define-timeline remove-preprocessing #:unmergable)

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -107,13 +107,16 @@
 
 (define (render-phase-bstep iters)
   `((dt "Steps")
-    (dd (table ([class "times"])
-               (tr (th "Iters") (th ([colspan "2"]) "Range") (th "Point"))
-               ,@(for/list ([rec (in-list iters)])
-                   (match-define (list v1 v2 iters pt) rec)
-                   `(tr (td ,(~a iters)) 
-                        (td (pre ,(~a v1))) (td (pre ,(~a v2)))
-                        (td (pre ,(~a pt)))))))))
+    (dd (table
+         (tr (th "Iters") (th "Point") (th) (th ([colspan "3"]) "Range") (th))
+         ,@(for/list ([rec (in-list iters)])
+             (match-define (list v1 v2 pt) rec)
+             `(tr (td (pre ,(~a pt)))
+                  (td "∈ [")
+                  (td (pre ,(~a v1)))
+                  (td ", ")
+                  (td (pre ,(~a v2)))
+                  (td "]")))))))
 
 (define (render-phase-egraph iters)
   (define costs (map third iters))

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -70,6 +70,7 @@
          ,@(dict-call curr render-phase-counts 'count)
          ,@(dict-call curr render-phase-alts 'alts)
          ,@(dict-call curr render-phase-times #:extra n 'times)
+         ,@(dict-call curr render-phase-series #:extra n 'series)
          ,@(dict-call curr render-phase-bstep 'bstep)
          ,@(dict-call curr render-phase-sampling 'sampling)
          ,@(dict-call curr (curryr simple-render-phase "Symmetry") 'symmetry)
@@ -256,6 +257,18 @@
                ,@(for/list ([rec (in-list (sort times > #:key second))] [_ (in-range 5)])
                    (match-define (list expr time) rec)
                    `(tr (td ,(format-time time)) (td (pre ,(~a expr)))))))))
+
+(define (render-phase-series n times)
+  `((dt "Calls")
+    (dd (p ,(~a (length times)) " calls:")
+        (canvas ([id ,(format "calls-~a" n)]
+                 [title "Weighted histogram; height corresponds to percentage of runtime in that bucket."]))
+        (script "histogram(\"" ,(format "calls-~a" n) "\", " ,(jsexpr->string (map second times)) ")")
+        (table ([class "times"])
+               ,@(for/list ([rec (in-list (sort times > #:key fourth))] [_ (in-range 5)])
+                   (match-define (list expr var transform time) rec)
+                   `(tr (td ,(format-time time))
+                        (td (pre ,expr)) (td (pre ,var)) (td ,transform)))))))
 
 (define (render-phase-compiler compiler)
   (match-define (list (list sizes compileds) ...) compiler)

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -266,7 +266,7 @@
     (dd (p ,(~a (length times)) " calls:")
         (canvas ([id ,(format "calls-~a" n)]
                  [title "Weighted histogram; height corresponds to percentage of runtime in that bucket."]))
-        (script "histogram(\"" ,(format "calls-~a" n) "\", " ,(jsexpr->string (map second times)) ")")
+        (script "histogram(\"" ,(format "calls-~a" n) "\", " ,(jsexpr->string (map fourth times)) ")")
         (table ([class "times"])
                ,@(for/list ([rec (in-list (sort times > #:key fourth))] [_ (in-range 5)])
                    (match-define (list expr var transform time) rec)

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -66,7 +66,7 @@
          ,@(dict-call curr render-phase-error 'min-error)
          ,@(dict-call curr render-phase-rules 'rules)
          ,@(dict-call curr render-phase-egraph 'egraph)
-         ,@(dict-call curr render-phase-egraph-stop 'egraph-stop)
+         ,@(dict-call curr render-phase-stop 'stop)
          ,@(dict-call curr render-phase-counts 'count)
          ,@(dict-call curr render-phase-alts 'alts)
          ,@(dict-call curr render-phase-times #:extra n 'times)
@@ -128,14 +128,14 @@
               (match-define (list iter nodes cost t) rec)
               `(tr (td ,(~a iter)) (td ,(~a nodes)) (td ,(~a cost))))))))
 
-(define (render-phase-egraph-stop data)
+(define (render-phase-stop data)
   (match-define (list (list reasons counts) ...) data)
   `((dt "Stop Event")
     (dd
       (table ([class "times"])
         ,@(for/list ([reason reasons] [count counts])
           `(tr (td ,(~a count) "×")
-                (td ,(~a reason))))))))
+               (td ,(~a reason))))))))
 
 (define (format-percent num den)
   (string-append


### PR DESCRIPTION
This PR tweaks the timeline with the hope of truly, for real, finally replacing the debug log.

- [x] Add a `timeline-start!` for timing things even if a timeout happens
- [x] Record per-variable timing for series expansion
- [x] Record all simplify batches in new (non-displayed) `inputs` and `outputs` keys
- [x] Record why the main loop stopped
- [x] Log information about regimes