### PR TITLE
Fix Pherbie

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -64,4 +64,4 @@ jobs:
       - name: "Install SoftPosit support"
         run: raco pkg install --no-cache --auto --name softposit-herbie plugin/
       - name: "Run posit benchmarks"
-        run: racket infra/travis.rkt --seed 0 --pareto 2 infra/bench/posit-pherbie.fpcore
+        run: racket infra/travis.rkt --seed 0 --num-iters 2 --pareto infra/bench/posit-pherbie.fpcore

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -33,4 +33,7 @@ jobs:
           path: plugin
       - name: "Install SoftPosit support"
         run: raco pkg install --no-cache --auto --name softposit-herbie plugin/
-      - run: racket infra/travis.rkt --precision posit16 --seed 0 plugin/bench/posits.fpcore
+      - name: "Run posit benchmarks"
+        run: racket infra/travis.rkt --precision posit16 --seed 0 plugin/bench/posits.fpcore
+      - name: "Run posit benchmarks (Pherbie)"
+        run: racket infra/travis.rkt --seed 0 --pareto 2 infra/bench/posit-pherbie.fpcore

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -35,5 +35,33 @@ jobs:
         run: raco pkg install --no-cache --auto --name softposit-herbie plugin/
       - name: "Run posit benchmarks"
         run: racket infra/travis.rkt --precision posit16 --seed 0 plugin/bench/posits.fpcore
-      - name: "Run posit benchmarks (Pherbie)"
+
+  softposit-pherbie:
+    name: "Plugin tests (Posits, Pherbie)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install Packages"
+        run: sudo apt-get install -y libmpfr6 libmpfr-dev
+      - name: "Install Racket"
+        uses: Bogdanp/setup-racket@v1.8
+        with:
+          version: stable
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
+      - uses: actions/checkout@master
+      - name: "Install dependencies"
+        run: make install
+      - name: "Check out softposit-herbie master"
+        uses: actions/checkout@master
+        with:
+          repository: herbie-fp/softposit-herbie
+          path: plugin
+      - name: "Install SoftPosit support"
+        run: raco pkg install --no-cache --auto --name softposit-herbie plugin/
+      - name: "Run posit benchmarks"
         run: racket infra/travis.rkt --seed 0 --pareto 2 infra/bench/posit-pherbie.fpcore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
-      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --pareto 2 bench/hamming/
+      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --num-iters 2 --pareto bench/hamming/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
-      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --pareto bench/hamming/
+      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --pareto 2 bench/hamming/

--- a/infra/bench/posit-pherbie.fpcore
+++ b/infra/bench/posit-pherbie.fpcore
@@ -1,0 +1,73 @@
+; -*- mode: scheme -*-
+
+(FPCore (x)
+ :name "2sqrt (example 3.1)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (sqrt (+ x 1)) (sqrt x)))
+
+(FPCore (x eps)
+ :name "2sin (example 3.3)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (sin (+ x eps)) (sin x)))
+
+(FPCore (x)
+ :name "tanhf (example 3.4)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (/ (- 1 (cos x)) (sin x)))
+
+(FPCore (N)
+ :name "2atan (example 3.5)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (atan (+ N 1)) (atan N)))
+
+(FPCore (x)
+ :name "2isqrt (example 3.6)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (/ 1 (sqrt x)) (/ 1 (sqrt (+ x 1)))))
+
+(FPCore (x)
+ :name "2frac (problem 3.3.1)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (/ 1 (+ x 1)) (/ 1 x)))
+
+(FPCore (x eps)
+ :name "2tan (problem 3.3.2)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (tan (+ x eps)) (tan x)))
+
+(FPCore (x)
+ :name "3frac (problem 3.3.3)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (+ (- (/ 1 (+ x 1)) (/ 2 x)) (/ 1 (- x 1))))
+
+(FPCore (x)
+ :name "2cbrt (problem 3.3.4)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (cbrt (+ x 1)) (cbrt x)))
+
+(FPCore (x eps)
+ :name "2cos (problem 3.3.5)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (cos (+ x eps)) (cos x)))
+
+(FPCore (N)
+ :name "2log (problem 3.3.6)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (- (log (+ N 1)) (log N)))
+
+(FPCore (x)
+ :name "exp2 (problem 3.3.7)"
+ :precision binary32
+ :herbie-conversions ((binary32 posit16))
+ (+ (- (exp x) 2) (exp (- x))))

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -89,10 +89,11 @@
     (when given-seed (set-seed! given-seed))]
    [("--precision") prec "Which precision to use for tests"
     (*precision* (get-representation (string->symbol prec)))]
-   [("--pareto") num "Enables Pherbie with <num> iters"
+   [("--num-iters") num "The number of iterations to use for the main loop"
+    (*num-iterations* (string->number num))]
+   [("--pareto") "Enables Pherbie"
     (*pareto-mode* #t)
     (*ignore-target* #t)
-    (*num-iterations* (string->number num))
     (*timeout* (* 1000 60 10))
     (disable-flag! 'rules 'numerics)] ; causes time to increase
    #:args bench-dir

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -89,10 +89,10 @@
     (when given-seed (set-seed! given-seed))]
    [("--precision") prec "Which precision to use for tests"
     (*precision* (get-representation (string->symbol prec)))]
-   [("--pareto") "Enables Pherbie"
+   [("--pareto") num "Enables Pherbie with <num> iters"
     (*pareto-mode* #t)
     (*ignore-target* #t)
-    (*num-iterations* 2)   ; keep iters low
+    (*num-iterations* (string->number num))
     (*timeout* (* 1000 60 10))
     (disable-flag! 'rules 'numerics)] ; causes time to increase
    #:args bench-dir

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -23,8 +23,7 @@
   (string->symbol (string-replace* (~a (representation-name repr)) replace-table)))
 
 (define (get-rewrite-operator repr)
-  (define rewrite (sym-append '<- (repr->symbol repr)))
-  (get-parametric-operator rewrite repr))
+  (get-parametric-operator 'convert repr))
 
 ;; Generates conversion, repr-rewrite operators for prec1 and prec2
 (define (generate-conversion-ops repr1 repr2)

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -5,8 +5,7 @@
          "common.rkt" "interface.rkt" "errors.rkt"
          "syntax/syntax.rkt")
 
-(provide generate-conversions generate-prec-rewrites
-         get-rewrite-operator *conversions*)
+(provide generate-conversions generate-prec-rewrites *conversions*)
 
 (define *conversions* (make-parameter (hash)))
 
@@ -21,9 +20,6 @@
 (define (repr->symbol repr)
   (define replace-table `((" " . "_") ("(" . "") (")" . "")))
   (string->symbol (string-replace* (~a (representation-name repr)) replace-table)))
-
-(define (get-rewrite-operator repr)
-  (get-parametric-operator 'convert repr))
 
 ;; Generates conversion, repr-rewrite operators for prec1 and prec2
 (define (generate-conversion-ops repr1 repr2)

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -52,16 +52,12 @@
   (define repr-rewrite1 (sym-append '<- prec1*))
   (define repr-rewrite2 (sym-append '<- prec2*))
 
-  (unless (operator-exists? repr-rewrite1)
-    (register-operator! repr-rewrite1 (list 'real) 'real
-      (list (cons 'bf identity) (cons 'ival identity)))
-    (register-operator-impl! repr-rewrite1 repr-rewrite1 (list repr1) repr1
+  (unless (impl-exists? repr-rewrite1)
+    (register-operator-impl! 'convert repr-rewrite1 (list repr1) repr1
       (list (cons 'fl identity))))
 
-  (unless (operator-exists? repr-rewrite2)
-    (register-operator! repr-rewrite2 (list 'real) 'real
-      (list (cons 'bf identity) (cons 'ival identity)))
-    (register-operator-impl! repr-rewrite2 repr-rewrite2 (list repr2) repr2
+  (unless (impl-exists? repr-rewrite2)
+    (register-operator-impl! 'convert repr-rewrite2 (list repr2) repr2
       (list (cons 'fl identity)))))
 
 ;; creates precision rewrite: prec1 <==> prec2

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -126,6 +126,7 @@
                     (define output (egraph-get-variants egg-graph id expr))
                     (define extracted (egg-exprs->exprs output egg-graph))
                     (for/list ([variant (remove-duplicates extracted)])
+                      (printf "~a -> ~a\n" expr variant)
                       (list (change egg-rule root-loc (list (cons 'x variant)))))))
                 (λ () variants)]))))))
     (result-thunk)))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -140,7 +140,7 @@
                              #:once? [once? #f])
   ; choose correct rr driver
   (cond
-   [(null? exprs) '()]
+   [(or (null? exprs) (null? rules)) (make-list (length exprs) '())]
    [(or once? (not (flag-set? 'generate 'rr)))
     (timeline-push! 'method "rewrite-once")
     (for/list ([expr exprs] [root-loc root-locs] [n (in-naturals 1)])

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -62,13 +62,13 @@
 ;;  Non-recursive rewriter
 ;;
 
-(define (rewrite-once expr repr #:rules rules #:root [root-loc '()] #:depth [depth 1])
-  (define type (repr-of expr repr (*var-reprs*)))
+(define (rewrite-once expr repr #:rules rules #:root [root-loc '()])
+  (define expr-repr (repr-of expr repr (*var-reprs*)))
   (reap [sow]
-    (for ([rule rules] #:when (equal? type (rule-otype rule)))
+    (for ([rule rules] #:when (equal? expr-repr (rule-otype rule)))
       (let* ([result (rule-apply rule expr)])
         (when result
-            (sow (list (change rule root-loc (cdr result)))))))))
+          (sow (list (change rule root-loc (cdr result)))))))))
 
 ;;
 ;;  Egg recursive rewriter
@@ -84,7 +84,7 @@
                            #:rules rules
                            #:roots [root-locs (make-list (length exprs) '())]
                            #:depths [depths (make-list (length exprs) 1)])
-  (define egg-rule (rule "egg-rr" 'x 'x (list repr) repr))
+  (define reprs (map (λ (e) (repr-of e repr (*var-reprs*))) exprs))
   (define irules (rules->irules rules))
   ; If unsoundness was detected, try running one epxression at a time.
   ; Can optionally set iter limit (will give up if unsoundness detected).
@@ -122,35 +122,36 @@
                   (λ () '(()))])]
               [else
                 (define variants
-                  (for/list ([id node-ids] [expr exprs] [root-loc root-locs])
+                  (for/list ([id node-ids] [expr exprs] [root-loc root-locs] [expr-repr reprs])
+                    (define egg-rule (rule "egg-rr" 'x 'x (list expr-repr) expr-repr))
                     (define output (egraph-get-variants egg-graph id expr))
                     (define extracted (egg-exprs->exprs output egg-graph))
                     (for/list ([variant (remove-duplicates extracted)])
-                      (printf "~a -> ~a\n" expr variant)
-                      (list (change egg-rule root-loc (list (cons 'x variant)))))))
+                     (list (change egg-rule root-loc (list (cons 'x variant)))))))
                 (λ () variants)]))))))
     (result-thunk)))
 
 ;;  Recursive rewrite chooser
 (define (rewrite-expressions exprs
-                             repr 
+                             repr
                              #:rules rules
                              #:roots [root-locs (make-list (length exprs) '())]
-                             #:depths [depths (make-list (length exprs) 1)])
+                             #:depths [depths (make-list (length exprs) 1)]
+                             #:once? [once? #f])
   ; choose correct rr driver
   (cond
    [(null? exprs) '()]
-   [(flag-set? 'generate 'rr)
+   [(or once? (not (flag-set? 'generate 'rr)))
+    (timeline-push! 'method "rewrite-once")
+    (for/list ([expr exprs] [root-loc root-locs] [n (in-naturals 1)])
+      (debug #:from 'progress #:depth 4 "[" n "/" (length exprs) "] rewriting for" expr)
+      (define timeline-stop! (timeline-start! 'times (~a expr)))
+      (begin0 (rewrite-once expr repr #:rules rules #:root root-loc)
+        (timeline-stop!)))]
+   [else
     (timeline-push! 'method "batch-egg-rewrite")
     (debug #:from 'progress #:depth 4 "batched rewriting for" exprs)
     (timeline-push! 'inputs (map ~a exprs))
     (define out (batch-egg-rewrite exprs repr #:rules rules #:roots root-locs #:depths depths))
     (timeline-push! 'outputs (map ~a out))
-    out]
-   [else
-    (timeline-push! 'method "rewrite-once")
-    (for/list ([expr exprs] [root-loc root-locs] [depth depths] [n (in-naturals 1)])
-        (debug #:from 'progress #:depth 4 "[" n "/" (length exprs) "] rewriting for" expr)
-        (define timeline-stop! (timeline-start! 'times (~a expr)))
-        (begin0 (rewrite-once expr repr #:rules rules #:root root-loc #:depth depth)
-          (timeline-stop!)))]))
+    out]))

--- a/src/pareto.rkt
+++ b/src/pareto.rkt
@@ -1,14 +1,8 @@
 #lang racket
 
-(require rackunit)
-(require "alternative.rkt" "points.rkt")
-
 (provide generate-pareto-curve)
 
 (define *pareto-ensure-convex* (make-parameter #t))
-
-(define (alt-score alt context repr)
-  (errors-score (errors (alt-program alt) context repr)))
 
 (define (paired-less? elem1 elem2)
   (let ([c1 (car elem1)] [c2 (car elem2)])
@@ -96,6 +90,8 @@
         sorted)]))
 
 (module+ test
+  (require rackunit)
+
   (define pts
     (for/list ([k (in-range 1 100)])
       (for/list ([n (in-range 1 1000 10)])

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -176,7 +176,7 @@
     (if one-real-repr?
         (merge-changelists
           (rewrite-expressions exprs (*output-repr*) #:rules (append expansive-rules normal-rules) #:roots locs)
-          (rewrite-expressions exprs (*output-repr*) #:rules reprchange-rules #:roots locs))
+          (rewrite-expressions exprs (*output-repr*) #:rules reprchange-rules #:roots locs #:once? #t))
         (merge-changelists
           (rewrite-expressions exprs (*output-repr*) #:rules normal-rules #:roots locs)
           (rewrite-expressions exprs (*output-repr*) #:rules expansive-rules #:roots locs #:once? #t)

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -131,6 +131,10 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; Splits rules into three categories
+;  - reprchange: rules that change precision
+;  - expansive: rules of the form `x -> f(x)` that are not reprchange
+;  - normal: everything else
 (define (partition-rules rules)
   (let-values ([(expansive normal)
                   (partition (compose variable? rule-input) rules)])

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -82,4 +82,3 @@
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" progs point) (raise e))])
       (for/vector ([out (in-vector (apply fn point))])
         (point-error out exact repr)))))
-

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -249,15 +249,14 @@
 ;; Miscellaneous operators ;;
 
 (define (repr-conv? expr)
-  (and (symbol? expr) (regexp-match? #px"^[\\S]+(->)[\\S]+$" (symbol->string expr))))
+  (and (symbol? expr) (set-member? (operator-all-impls 'cast) expr)))
 
 (define (rewrite-repr-op? expr)
-  (and (symbol? expr) (regexp-match? #px"^(<-)[\\S]+$" (symbol->string expr))))
+  (and (symbol? expr) (set-member? (operator-all-impls 'convert) expr)))
 
 (define (get-repr-conv irepr orepr)
   (for/or ([name (operator-all-impls 'cast)])
-    (and (repr-conv? name)
-         (equal? (operator-info name 'otype) orepr)
+    (and (equal? (operator-info name 'otype) orepr)
          (equal? (first (operator-info name 'itype)) irepr)
          name)))
 
@@ -290,6 +289,9 @@
     (dict-set dict key value)))
 
 ;; Conversions
+
+(define-operator (convert real) real
+  [bf identity] [ival identity])
 
 (define-operator (cast real) real
   [bf identity] [ival identity])


### PR DESCRIPTION
#446 introduced problems for Pherbie that unfortunately were not caught. This PR patches these issues, makes conversion syntax slightly saner, and adds an additional test to CI.

Long term, there should be a better solution to applying rewrites of the form `x -> f(x)` since this was causing issues even without introducing precision changes. The current solution is: if multiple representations with type `real` are loaded, then these rewrites are not applied in `egg` and instead go through a separate path using `rewrite-once` which is significantly less powerful.