### PR TITLE
Speed up regimes by batching calls to `errors`

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -168,21 +168,22 @@
                  [*var-reprs* (list (cons 'x repr))]
                  [*output-repr* repr])
     (define alts (map (λ (body) (make-alt `(λ (x) ,body))) (list '(fmin.f64 x 1) '(fmax.f64 x 1))))
+    (define err-lsts `((,(expt 2 53) 1) (1 ,(expt 2 53))))
 
     ;; This is a basic sanity test
     (check (λ (x y) (equal? (map si-cidx (option-split-indices x)) y))
-           (option-on-expr alts 'x repr)
+           (option-on-expr alts err-lsts 'x repr)
            '(1 0))
 
     ;; This test ensures we handle equal points correctly. All points
     ;; are equal along the `1` axis, so we should only get one
     ;; splitpoint (the second, since it is better at the further point).
     (check (λ (x y) (equal? (map si-cidx (option-split-indices x)) y))
-           (option-on-expr alts '1 repr)
+           (option-on-expr alts err-lsts '1 repr)
            '(0))
 
     (check (λ (x y) (equal? (map si-cidx (option-split-indices x)) y))
-           (option-on-expr alts '(if (==.f64 x 0.5) 1 +nan.0) repr)
+           (option-on-expr alts err-lsts '(if (==.f64 x 0.5) 1 +nan.0) repr)
            '(1 0))))
 
 ;; (pred p1) and (not (pred p2))

--- a/src/pretty-print.rkt
+++ b/src/pretty-print.rkt
@@ -97,7 +97,8 @@
       (string-pad sa (max (string-length sa) (string-length sb)) #\0)
       (string-pad sb (max (string-length sa) (string-length sb)) #\0)))]))
 
-(define (bigfloat-interval-shortest x y)
+(define/contract (bigfloat-interval-shortest x y)
+  (->i ([x bigfloat?] [y bigfloat?]) #:pre (x y) (or (bf<= x y) (bfnan? y)) [result bigfloat?])
   (define x-parts (bigfloat->normal-string x))
   (define y-parts (bigfloat->normal-string y))
   (cond


### PR DESCRIPTION
I was looking at a recent Herbie report and was stunned to discover that `option-on-expr` (the main part of regimes) spends 40% of its runtime in `errors`. It turns out that regimes is wasteful in two ways:

1. It uses `errors` instead of `batch-errors`, meaning that it doesn't get the benefits of common subexpression elimination
2. It recomputes `errors` for every branch expression, even though the only thing that changes is the sort order

This PR fixes both problems; I expect it to speed up regimes by 1.5x or so and Herbie overall by about 4%.