### PR TITLE
Switches to building egg-herbie with Rust.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Build image
 # Builds output under /herbie/egg-herbie
-FROM rust:latest as egg-herbie-builder
+FROM rust:1.61.0 as egg-herbie-builder
 WORKDIR /herbie
 COPY . .
 RUN cargo build --release --manifest-path=egg-herbie/Cargo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
-FROM racket/racket:8.5-full
+# Multistage build: https://docs.docker.com/develop/develop-images/multistage-build/
+# We build necessary binaries in one image, then COPY them to a second production 
+# image to save some space.
+
+# Build image
+# Builds output under /herbie/egg-herbie
+FROM rust:latest as egg-herbie-builder
+WORKDIR /herbie
+COPY . .
+RUN cargo build --release --manifest-path=egg-herbie/Cargo.toml
+
+# Production image
+FROM racket/racket:8.5-full AS production
 MAINTAINER Pavel Panchekha <me@pavpanchekha.com>
+COPY --from=egg-herbie-builder /herbie/egg-herbie /src/egg-herbie
+RUN raco pkg install /src/egg-herbie
 ADD src /src/herbie
 RUN raco pkg install --auto /src/herbie
 ENTRYPOINT ["racket", "/src/herbie/herbie.rkt"]
-CMD ["web", "--port", "80", "--quiet", "--demo"]
+EXPOSE 80
+# NOTE --public allows the Docker host to interact with the demo,
+# typical users shouldn't need to use it.
+CMD ["web", "--public", "--port", "80", "--quiet", "--demo"]


### PR DESCRIPTION
We use a multistage build to avoid including Rust in the final image.

Also fixes an issue which may have prevented users from accessing
the web demo from the container by including the --public flag.
Adds EXPOSE annotation to note that port 80 is exposed.