### PR TITLE
Remove distributivity and pow-distributivity from reducer

### DIFF
--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -6,20 +6,15 @@
 (provide simplify load-rule-hacks)
 
 ;; Cancellation's goal is to cancel (additively or multiplicatively) like terms.
-;; It uses commutativity, identities, inverses, associativity,
-;; distributativity, and function inverses.
+;; It uses commutativity, cancellation, associativity, and function inverses.
 
 (define fn-inverses '())
 (define fn-evaluations (make-hash))
-(define simplify-cache (make-hash))
-(define simplify-node-cache (make-hash))
 
 (register-reset
  (λ ()
   (set! fn-inverses '())
-  (set! fn-evaluations (make-hash))
-  (set! simplify-cache (make-hash))
-  (set! simplify-node-cache (make-hash))))
+  (set! fn-evaluations (make-hash))))
 
 (define (load-rule-hacks)
   (set! fn-inverses
@@ -34,9 +29,6 @@
            (resugar-program (rule-output r) (rule-otype r) #:full #f)))))
 
 (define (simplify expr)
-  (hash-ref! simplify-cache expr (λ () (simplify* expr))))
-
-(define (simplify* expr)
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
@@ -56,9 +48,6 @@
      (or val (simplify-node (list* op args*)))]))
 
 (define (simplify-node expr)
-  (hash-ref! simplify-node-cache expr (λ () (simplify-node* expr))))
-
-(define (simplify-node* expr)
   (match expr
     [(? (curry hash-has-key? fn-evaluations)) (hash-ref fn-evaluations expr)]
     [(? number?) expr]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -6,15 +6,20 @@
 (provide simplify load-rule-hacks)
 
 ;; Cancellation's goal is to cancel (additively or multiplicatively) like terms.
-;; It uses commutativity, cancellation, associativity, and function inverses.
+;; It uses commutativity, identities, inverses, associativity,
+;; distributativity, and function inverses.
 
 (define fn-inverses '())
 (define fn-evaluations (make-hash))
+(define simplify-cache (make-hash))
+(define simplify-node-cache (make-hash))
 
 (register-reset
  (λ ()
   (set! fn-inverses '())
-  (set! fn-evaluations (make-hash))))
+  (set! fn-evaluations (make-hash))
+  (set! simplify-cache (make-hash))
+  (set! simplify-node-cache (make-hash))))
 
 (define (load-rule-hacks)
   (set! fn-inverses
@@ -29,6 +34,9 @@
            (resugar-program (rule-output r) (rule-otype r) #:full #f)))))
 
 (define (simplify expr)
+  (hash-ref! simplify-cache expr (λ () (simplify* expr))))
+
+(define (simplify* expr)
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
@@ -48,6 +56,9 @@
      (or val (simplify-node (list* op args*)))]))
 
 (define (simplify-node expr)
+  (hash-ref! simplify-node-cache expr (λ () (simplify-node* expr))))
+
+(define (simplify-node* expr)
   (match expr
     [(? (curry hash-has-key? fn-evaluations)) (hash-ref fn-evaluations expr)]
     [(? number?) expr]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -95,25 +95,14 @@
        (append (recurse arg)
                (map negate-term (append-map recurse args)))]
 
-      [`(* ,args ...)
-       (for/list ([term-list (apply cartesian-product (map recurse args))])
-         (list* (apply * (map car term-list))
-                (simplify-node (cons '* (map cadr term-list)))
-                (cons label (append-map cddr term-list))))]
       [`(/ ,arg) ; Prevent fall-through to the next case
        `((1 ,expr))]
       [`(/ ,arg ,args ...)
        (for/list ([term (recurse arg)])
          (list* (car term) (simplify-node (list* '/ (cadr term) args)) (cons label (cddr term))))]
 
-      [`(pow ,arg ,(? integer? n))
-       (cond
-        [(positive? n)
-         (recurse (cons '* (build-list (inexact->exact n) (const arg))) #:label expr)]
-        [(negative? n)
-         `((1 ,expr))]
-        [(zero? n)
-         `((1 1))])]
+      [`(pow ,arg 1)
+       `((1 1))]
       [else
        `((1 ,expr))])))
 


### PR DESCRIPTION
This PR makes `reduce.rkt` dumber, thereby making it much faster. A bit of backstory. The reducer, or backup simplifier, is used only in the series expander. It's much faster than e-graph based simplification, but also a lot dumber. In fact, it predates the e-graph based simplifier—it was written in summer 2014 when Alex and I were looking to replace the existing simplifier, which was very brittle. Anyway, this means it was originally written to be Herbie's general-purpose simplifier, at a time when we thought we needed a pretty smart simplifier. This means that it's probably working too hard for its current task.

In this PR, I remove the reducer's understanding of distributivity, meaning that it will no longer expand `(a + b) * c` into `a * c + b * c`. This is bad in some ways, because distributivity is sometimes necessary to cancel terms (as in `(a + b) * c - a * c`). But distributivity is the cause of all major slowdowns in the reducer, because it can sometimes lead to expanding products of sums into truly massive sums that are then traversed over and over. In fact, `simplify-node*` (the core of the reducer) currently takes up 3% of Herbie's runtime. In this PR that drops to 0.12%, which is also low enough that we can probably remove the cache that @bksaiki added in #463. A particularly bad part of distributivity is that the reducer also had special logic for `pow`, so that something like `pow(a + b, 5)` would expand into a massive sum of 32 terms. That's also removed.