### PR TITLE
No long re-sample in binary search

### DIFF
--- a/src/alternative.rkt
+++ b/src/alternative.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "cost.rkt")
+(require "cost.rkt" "interface.rkt")
 (provide (struct-out change) (struct-out alt) make-alt alt?
          alt-program alt-add-event *start-prog* *all-alts*
          alt-cost alt-equal?)
@@ -23,8 +23,8 @@
 (define (alt-add-event altn event)
   (alt (alt-program altn) event (list altn)))
 
-(define (alt-cost altn)
-  (program-cost (alt-program altn)))
+(define (alt-cost altn repr)
+  (program-cost (alt-program altn) repr))
 
 (define (alt-equal? x y)
   (equal? (alt-program x) (alt-program y)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -39,13 +39,13 @@
 
 ; In normal mode, cost is not considered so we return a constant
 ; The alt table becomes "degenerate"
-(define (alt-cost* altn)
+(define (alt-cost* altn repr)
   (if (*pareto-mode*)
-      (alt-cost altn)
+      (alt-cost altn repr)
       1))
 
 (define (make-alt-table context initial-alt repr)
-  (define cost (alt-cost* initial-alt))
+  (define cost (alt-cost* initial-alt repr))
   (alt-table (make-immutable-hash
                (for/list ([(pt ex) (in-pcontext context)]
                           [err (errors (alt-program initial-alt) context repr)])
@@ -250,7 +250,7 @@
         (>= cost* mincost)))]))
 
 (define (atab-add-altn atab altn errs repr)
-  (define cost (alt-cost* altn))
+  (define cost (alt-cost* altn repr))
   (match-define (alt-table point->alts alt->points alt->done? alt->cost _ all-alts) atab)
   (define-values (best-pnts tied-pnts tied-errs) (best-and-tied-at-points atab altn cost errs))
   (cond
@@ -314,11 +314,11 @@
       (error (string-append "Reflexive invariant violated. " message))))
 
 ;; The minimality invariant states that every alt must be untied and best on at least one point.
-(define (check-minimality-invariant atab #:message [message ""])
+(define (check-minimality-invariant atab repr #:message [message ""])
   (hash-for-each (alt-table-alt->points atab)
                  (λ (k v)
                     (let ([cnt (for/list ([pt v])
-                                 (let ([cost (alt-cost* k)]
+                                 (let ([cost (alt-cost* k repr)]
                                        [cost-hash (hash-ref (alt-table-point->alts atab) pt)])
                                    (length (cost-rec-altns (hash-ref cost-hash cost)))))])
                       (when (not (= (apply min cnt) 1))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -3,7 +3,7 @@
 (require math/bigfloat)
 (require "../common.rkt" "../alternative.rkt" "../programs.rkt" "../timeline.rkt"
          "../interface.rkt" "../errors.rkt" "../points.rkt")
-(require "../sampling.rkt" "../float.rkt" "../pretty-print.rkt" "../ground-truth.rkt" rival) ; For binary search
+(require "../float.rkt" "../pretty-print.rkt" "../ground-truth.rkt") ; For binary search
 
 (provide infer-splitpoints (struct-out sp) splitpoints->point-preds combine-alts
          pareto-regimes)
@@ -215,11 +215,7 @@
         ([(pt _) (in-pcontext pcontext)]
          #:break (>= newlen length))
       (define pt* (cons val pt))
-      (define-values (result prec exs) (ival-eval f pt*))
-      (define ex*
-        (if (list? exs)
-            ((representation-bf->repr repr) (ival-lo (car exs)))
-            +nan.0))
+      (define ex* (apply f pt*))
       (if (nan? ex*)
           (values (cons pt* newpts) (cons ex* newexs) (+ 1 newlen))
           (values newpts newexs newlen))))
@@ -241,9 +237,7 @@
   (define var-reprs* (dict-set (*var-reprs*) var repr))
   (define progs (map (compose (curryr extract-subexpression var expr) alt-program) alts))
   (define start-prog (extract-subexpression (*start-prog*) var expr))
-  (define-values (_ start-fn)
-    (parameterize ([*var-reprs* var-reprs*])
-      (make-search-func `(λ ,(program-variables start-prog) (TRUE)) (list start-prog) repr)))
+  (define start-fn (parameterize ([*var-reprs* var-reprs*]) (eval-prog-real start-prog repr)))
 
   (define (find-split prog1 prog2 v1 v2)
     (define iters 0)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -164,8 +164,7 @@
   (define repr (get-representation 'binary64))
   (parameterize ([*start-prog* '(λ (x) 1)]
                  [*pcontext* (mk-pcontext '((0.5) (4.0)) '(1.0 1.0))]
-                 [*var-reprs* (list (cons 'x repr))]
-                 [*output-repr* repr])
+                 [*var-reprs* (list (cons 'x repr))])
     (define alts (map (λ (body) (make-alt `(λ (x) ,body))) (list '(fmin.f64 x 1) '(fmax.f64 x 1))))
     (define err-lsts `((,(expt 2 53) 1) (1 ,(expt 2 53))))
 
@@ -408,8 +407,7 @@
 
 (module+ test
   (parameterize ([*start-prog* '(λ (x y) (/.f64 x y))]
-                 [*var-reprs* (map (curryr cons repr) '(x y))]
-                 [*output-repr* repr])
+                 [*var-reprs* (map (curryr cons repr) '(x y))])
     (define sps
       (list (sp 0 '(/.f64 y x) -inf.0)
             (sp 2 '(/.f64 y x) 0.0)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -2,8 +2,8 @@
 
 (require math/bigfloat)
 (require "../common.rkt" "../alternative.rkt" "../programs.rkt" "../timeline.rkt"
-         "../interface.rkt" "../errors.rkt" "../preprocess.rkt" "../points.rkt")
-(require "../ground-truth.rkt" "../float.rkt" "../pretty-print.rkt") ; For binary search
+         "../interface.rkt" "../errors.rkt" "../points.rkt")
+(require "../sampling.rkt" "../float.rkt" "../pretty-print.rkt" rival) ; For binary search
 
 (provide infer-splitpoints (struct-out sp) splitpoints->point-preds combine-alts
          pareto-regimes)
@@ -120,13 +120,6 @@
     (define splitpoints** (append splitpoints* (list splitpoint*)))
     (values alts** splitpoints**)))
 
-(define (sort-errors-by-expr context errors expr variables repr)
-  (define fn (eval-prog `(λ ,variables ,expr) 'fl repr))
-  (let ([p&e (sort (for/list ([(pt ex) (in-pcontext context)]) (list pt ex))
-		   (λ (x1 x2) (</total x1 x2 repr))
-                   #:key (λ (pts) (apply fn (first pts))))])
-    (mk-pcontext (map first p&e) (map second p&e))))
-
 (define (option-on-expr alts err-lsts expr repr)
   (define timeline-stop! (timeline-start! 'branch (~a expr)))
 
@@ -216,6 +209,23 @@
       `(λ (,var ,@vars*) ,body*)
       #f))
 
+(define (prepend-argument f val pcontext #:length length)
+  (define (f* . args)
+    (list (ival #t) (apply f args)))
+  (define-values (newpts newexs newlen)
+    (for/fold ([newpts '()] [newexs '()] [newlen 0])
+        ([(pt _) (in-pcontext pcontext)]
+         #:break (>= newlen length))
+      (define pt* (cons val pt))
+      (define-values (result prec ex*) (ival-eval f* pt*))
+      (if (nan? (car ex*))
+          (values newpts newexs newlen)
+          (values (cons pt* newpts) (cons (car ex*) newexs) (+ 1 newlen)))))
+  (when (< newlen length)
+    (raise-herbie-error "Cannot sample enough valid points."
+                        #:url "faq.html#sample-valid-points"))
+  (mk-pcontext newpts newexs))
+
 ;; Accepts a list of sindices in one indexed form and returns the
 ;; proper splitpoints in float form. A crucial constraint is that the
 ;; float form always come from the range [f(idx1), f(idx2)). If the
@@ -226,8 +236,12 @@
     (eval-prog `(λ ,(program-variables (alt-program (car alts))) ,expr) 'fl repr))
 
   (define var (gensym 'branch))
+  (define var-reprs* (dict-set (*var-reprs*) var repr))
   (define progs (map (compose (curryr extract-subexpression var expr) alt-program) alts))
   (define start-prog (extract-subexpression (*start-prog*) var expr))
+  (define start-fn
+    (parameterize ([*var-reprs* var-reprs*])
+      (eval-prog start-prog 'fl repr)))
 
   (define (find-split prog1 prog2 v1 v2)
     (define iters 0)
@@ -236,24 +250,15 @@
     (define current-guess v1)
     (define sampling-fail? #f)
 
-    (define eq-repr (get-parametric-operator '== repr repr))
     (define (pred v)
       (set! iters (+ 1 iters))
       (set! best-guess current-guess)
       (set! current-guess v)
       (with-handlers ([exn:fail:user:herbie?
                        (λ (e) (set! sampling-fail? #t) 0)]) ; couldn't sample points
-        (parameterize ([*num-points* (*binary-search-test-points*)]
-                       [*timeline-disabled* true]
-                       [*var-reprs* (dict-set (*var-reprs*) var repr)])
-          (define ctx
-            (apply mk-pcontext
-                   (prepare-points start-prog
-                                   `(λ ,(program-variables start-prog)
-                                      (,eq-repr ,(caadr start-prog) ,(repr->real v repr)))
-                                   repr
-                                   (λ () (cons v (apply-preprocess (program-variables (alt-program (car alts)))
-                                                                   (sampler) (*herbie-preprocess*) repr))))))
+        (define ctx
+          (prepend-argument start-fn v (*pcontext*) #:length (*binary-search-test-points*)))
+        (parameterize ([*var-reprs* var-reprs*])
           (define acc1 (errors-score (errors prog1 ctx repr)))
           (define acc2 (errors-score (errors prog2 ctx repr)))
           (- acc1 acc2))))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -507,7 +507,6 @@
 (module+ test
   (require rackunit "../interface.rkt" "../load-plugin.rkt")
   (load-herbie-plugins)
-  (*output-repr* (get-representation 'binary64))
   (check-pred exact-integer? (car (taylor 'x '(pow x 1.0)))))
 
 (module+ test

--- a/src/cost.rkt
+++ b/src/cost.rkt
@@ -13,8 +13,8 @@
        [(? repr-conv?) 2]
        [_ 100])))
 
-(define (expr-cost expr)
-  (let loop ([expr expr] [repr (*output-repr*)])
+(define (expr-cost expr repr)
+  (let loop ([expr expr] [repr repr])
     (match expr
      [(list 'if cond ift iff)
       (+ 1 (loop cond repr) (max (loop ift repr) (loop iff repr)))]
@@ -23,6 +23,6 @@
       (apply + (operator-cost op) (map loop args ireprs))]
      [_ (representation-total-bits repr)])))
 
-(define (program-cost prog)
+(define (program-cost prog repr)
   (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
-  (expr-cost body))
+  (expr-cost body repr))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -3,7 +3,7 @@
 (require math/bigfloat rival)
 (require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt" "timeline.rkt")
 
-(provide make-search-func prepare-points sample-points ground-truth-require-convergence)
+(provide make-search-func sample-points)
 
 (define (is-infinite-interval repr interval)
   (define <-bf (representation-bf->repr repr))
@@ -59,10 +59,6 @@
      (match-define (list ival-pre ival-bodies ...) (vector->list (apply fns inputs)))
      (cons (apply ival-and ival-pre (map (curry valid-result? repr) ival-bodies))
            ival-bodies))))
-
-(define (prepare-points prog precondition repr sampler)
-  (define-values (how fn) (make-search-func precondition (list prog) repr))
-  (batch-prepare-points how fn repr sampler))
 
 (define (sample-points precondition progs repr)
   (timeline-event! 'analyze)

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -63,7 +63,7 @@
 (define (eval-prog-real prog repr)
   (define pre `(λ ,(program-variables prog) (TRUE)))
   (define-values (how fn) (make-search-func pre (list prog) repr))
-  (define (f pt)
+  (define (f . pt)
     (define-values (result prec exs) (ival-eval fn pt))
     (match exs
       [(list (ival lo hi))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -3,7 +3,7 @@
 (require math/bigfloat rival)
 (require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt" "timeline.rkt")
 
-(provide make-search-func sample-points)
+(provide sample-points eval-prog-real)
 
 (define (is-infinite-interval repr interval)
   (define <-bf (representation-bf->repr repr))
@@ -59,6 +59,18 @@
      (match-define (list ival-pre ival-bodies ...) (vector->list (apply fns inputs)))
      (cons (apply ival-and ival-pre (map (curry valid-result? repr) ival-bodies))
            ival-bodies))))
+
+(define (eval-prog-real prog repr)
+  (define pre `(λ ,(program-variables prog) (TRUE)))
+  (define-values (how fn) (make-search-func pre (list prog) repr))
+  (define (f pt)
+    (define-values (result prec exs) (ival-eval fn pt))
+    (match exs
+      [(list (ival lo hi))
+       ((representation-bf->repr repr) lo)]
+      [(? nan?)
+       +nan.0]))
+  (procedure-rename f '<eval-prog-real>))
 
 (define (sample-points precondition progs repr)
   (timeline-event! 'analyze)

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require math/bigfloat rival)
-(require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt")
+(require "errors.rkt" "programs.rkt" "interface.rkt" "sampling.rkt" "timeline.rkt")
 
 (provide make-search-func prepare-points sample-points ground-truth-require-convergence)
 
@@ -65,8 +65,10 @@
   (batch-prepare-points how fn repr sampler))
 
 (define (sample-points precondition progs repr)
+  (timeline-event! 'analyze)
   (define-values (how fn) (make-search-func precondition progs repr))
   (define sampler 
     (parameterize ([ground-truth-require-convergence #f])
       (make-sampler repr precondition progs how fn)))
+  (timeline-event! 'sample)
   (batch-prepare-points how fn repr sampler))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -4,7 +4,7 @@
          "core/alt-table.rkt" "core/localize.rkt" "core/regimes.rkt" "core/simplify.rkt"
          "alternative.rkt" "common.rkt" "conversions.rkt" "errors.rkt"
          "interface.rkt" "patch.rkt" "points.rkt" "preprocess.rkt" "ground-truth.rkt"
-         "programs.rkt" "sampling.rkt" "symmetry.rkt" "timeline.rkt")
+         "programs.rkt" "symmetry.rkt" "timeline.rkt")
 
 (provide (all-defined-out))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -35,8 +35,6 @@
   (when (not (equal? newval 'none)) (set-shellstate-patched! (^shell-state^) newval))
   (shellstate-patched (^shell-state^)))
 
-(define *sampler* (make-parameter #f))
-
 ;; Iteration 0 alts (original alt in every repr, constant alts, etc.)
 (define (starting-alts altn)
   (define prog (alt-program altn))
@@ -268,7 +266,6 @@
   (define sampler 
     (parameterize ([ground-truth-require-convergence #f])
       (make-sampler repr precondition (list specification) how fn)))
-  (*sampler* sampler)
 
   (timeline-event! 'sample)
   (define seed (get-seed))
@@ -393,10 +390,10 @@
            (not (null? (program-variables (alt-program (car all-alts))))))
       (cond
        [(*pareto-mode*)
-        (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) repr (*sampler*))]
+        (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) repr)]
        [else
         (define option (infer-splitpoints all-alts repr))
-        (list (combine-alts option repr (*sampler*)))])]
+        (list (combine-alts option repr))])]
      [else
       (list (argmin score-alt all-alts))]))
   (timeline-event! 'simplify)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -46,7 +46,7 @@
               #:when (set-member? v (*output-repr*)))
       (define rewrite (get-rewrite-operator k))
       (define prog* `(λ ,(program-variables prog) (,rewrite ,(program-body prog))))
-      (alt (apply-repr-change prog*) 'start '()))))
+      (alt (apply-repr-change prog* (*output-repr*)) 'start '()))))
 
 ;; Information
 (define (list-alts)
@@ -83,7 +83,7 @@
    [(< (length altns) (*pareto-pick-limit*)) altns] ; take max
    [else
     (define best (argmin score-alt altns))
-    (define altns* (sort (filter-not (curry alt-equal? best) altns) < #:key alt-cost))
+    (define altns* (sort (filter-not (curry alt-equal? best) altns) < #:key (curryr alt-cost (*output-repr*))))
     (define simplest (car altns*))
     (define altns** (cdr altns*))
     (define div-size (round (/ (length altns**) (- (*pareto-pick-limit*) 1))))
@@ -393,7 +393,7 @@
            (not (null? (program-variables (alt-program (car all-alts))))))
       (cond
        [(*pareto-mode*)
-        (pareto-regimes (sort all-alts < #:key alt-cost) repr (*sampler*))]
+        (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) repr (*sampler*))]
        [else
         (define option (infer-splitpoints all-alts repr))
         (list (combine-alts option repr (*sampler*)))])]
@@ -424,4 +424,4 @@
          [(not best) (values altn new-score '())]
          [(< new-score score) (values altn new-score (cons best rest))] ; kick out current best
          [else (values best score (cons altn rest))]))))
-  (cons best (sort rest > #:key alt-cost)))
+  (cons best (sort rest > #:key (curryr alt-cost repr))))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -261,26 +261,7 @@
   (when (empty? (*needed-reprs*)) ; if empty, probably debugging
     (*needed-reprs* (list repr (get-representation 'bool))))
 
-  (timeline-event! 'analyze)
-  (define-values (how fn) (make-search-func precondition (list specification) repr))
-  (define sampler 
-    (parameterize ([ground-truth-require-convergence #f])
-      (make-sampler repr precondition (list specification) how fn)))
-
-  (timeline-event! 'sample)
-  (define seed (get-seed))
-  ;; Temporary, to align with the `main` branch
-  (define reeval-pts 8000)
-  (define ctx1
-    (parameterize ([*num-points* (- (*num-points*) reeval-pts)])
-      (when seed (set-seed! seed))
-      (random)
-      (apply mk-pcontext (prepare-points specification precondition repr sampler))))
-  (define ctx2
-    (parameterize ([*num-points* reeval-pts])
-      (when seed (set-seed! seed))
-      (apply mk-pcontext (prepare-points specification precondition repr sampler))))
-  (join-pcontext ctx1 ctx2))
+  (apply mk-pcontext (sample-points precondition (list specification) repr)))
 
 (define (initialize-alt-table! prog pcontext repr)
   (define alt (make-alt prog))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -196,7 +196,7 @@
       (let loop ([cl cl] [altn altn])
         (if (null? cl)
             (cons altn done)
-            (let ([prog* (apply-repr-change (change-apply (car cl) (alt-program altn)))])
+            (let ([prog* (apply-repr-change (change-apply (car cl) (alt-program altn)) (*output-repr*))])
               (if (program-body prog*)
                   (loop (cdr cl) (alt prog* (list 'change (car cl)) (list altn)))
                   done))))))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -203,7 +203,6 @@
 
   (for ([(e p) (in-hash tests)])
     (parameterize ([bf-precision 4000])
-      ;; When we are in ival mode, we don't use repr, so pass in #f
       (define iv (apply (eval-prog e 'ival <binary64>) p))
       (define val (apply (eval-prog e 'bf <binary64>) p))
       (check-in-interval? iv val))))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -176,7 +176,7 @@
 
   (timeline-push! 'compiler (+ varc size) lt)
   (define exprvec (list->vector (reverse exprs)))
-  (λ args
+  (define (f . args)
     (define v (make-vector lt))
     (for ([arg (in-list args)] [n (in-naturals)] [repr (in-list var-reprs)])
       (vector-set! v n (arg->precision arg repr)))
@@ -186,7 +186,8 @@
           (vector-ref v arg)))
       (vector-set! v n (apply (car expr) tl)))
     (for/vector ([n (in-list names)])
-      (vector-ref v n))))
+      (vector-ref v n)))
+  (procedure-rename f (string->symbol (format "<eval-prog-~a>" mode))))
 
 (module+ test
   (define <binary64> (get-representation 'binary64))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -268,7 +268,7 @@
    '(/ (cos (* 2 x)) (* (pow (/ 1 cos) 2) (* (fabs (* sin x)) (fabs (* sin x)))))))
 
 ; Updates the repr of an expression if needed
-(define (apply-repr-change-expr expr)
+(define (apply-repr-change-expr expr output-repr)
   (let loop ([expr expr] [repr #f])
     (match expr
      [(list (? repr-conv? op) body)
@@ -293,12 +293,12 @@
               (list op (loop body irepr)))
           (if repr
               (loop (list op body) repr*)
-              (let* ([conv (get-repr-conv repr* (*output-repr*))]
+              (let* ([conv (get-repr-conv repr* output-repr)]
                      [body* (loop body repr*)])
                 (and conv body* (list conv body*)))))]
      [(list (? rewrite-repr-op? op) body)
       (define irepr (operator-info op 'otype))
-      (define orepr (or repr (*output-repr*)))
+      (define orepr (or repr output-repr))
       (cond
        [(equal? irepr orepr)
         (loop body irepr)]
@@ -307,7 +307,7 @@
         (define body* (loop body irepr))
         (and conv body* (list conv body*))])]
      [(list 'if con ift iff)
-      (define repr* (or repr (*output-repr*)))
+      (define repr* (or repr output-repr))
       (define con*
         (let loop2 ([con con])
           (cond
@@ -345,8 +345,8 @@
         (and cast (list cast expr))])]
      [_ expr])))
 
-(define (apply-repr-change prog)
+(define (apply-repr-change prog repr)
   (match prog
-   [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(apply-repr-change-expr body))]
-   [(list (or 'λ 'lambda) (list vars ...) body) `(λ ,vars ,(apply-repr-change-expr body))]
-   [_ (apply-repr-change-expr prog)]))
+   [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(apply-repr-change-expr body repr))]
+   [(list (or 'λ 'lambda) (list vars ...) body) `(λ ,vars ,(apply-repr-change-expr body repr))]
+   [_ (apply-repr-change-expr prog repr)]))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -5,7 +5,7 @@
          "float.rkt" "interface.rkt" "timeline.rkt"
          "syntax/sugar.rkt")
 
-(provide make-sampler batch-prepare-points)
+(provide make-sampler batch-prepare-points ival-eval)
 
 ;; Much of this code assumes everything supports intervals. Almost
 ;; everything does---we're still missing support for the Gamma and

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -188,6 +188,7 @@
             (loop (+ 1 sampled) 0 (cons pt points) (cons exs exactss)))]
        [else
         (when (>= skipped (*max-skipped-points*))
+          (timeline-compact! 'outcomes)
           (raise-herbie-error "Cannot sample enough valid points."
                               #:url "faq.html#sample-valid-points"))
         (loop sampled (+ 1 skipped) points exactss)])))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -107,8 +107,8 @@
                           #f)
                       baseline-errs
                       oracle-errs
-                      (program-cost (test-program test))
-                      (map alt-cost alts)
+                      (program-cost (test-program test) output-repr)
+                      (map (curryr alt-cost output-repr) alts)
                       (*all-alts*)))))
 
   (define (on-exception start-time e)
@@ -179,7 +179,7 @@
     (define end-exprs (map (λ (p) (program-body (resugar-program p (test-output-repr test)))) end-progs))
 
     (define cost&accuracy
-      (list (list (program-cost start-prog) start-score)
+      (list (list (program-cost start-prog (test-output-repr test)) start-score)
             (list (car costs) (car end-scores))
             (map list (cdr costs) (cdr end-scores) (cdr end-exprs))))
 

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -2,7 +2,7 @@
 
 (require json)
 (require "../common.rkt" "../syntax/read.rkt" "../syntax/sugar.rkt" "../datafile.rkt"
-         "../interface.rkt" "../profile.rkt" "../timeline.rkt" "../sampling.rkt"
+         "../interface.rkt" "../profile.rkt" "../timeline.rkt"
          "make-report.rkt" "thread-pool.rkt" "timeline.rkt")
 
 (provide make-report rerun-report replot-report diff-report)

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -97,7 +97,7 @@
                           (errors (test-target orig-test) test-context output-repr)
                           #f)
                       #f #f
-                      (alt-cost start-alt) (cons end-cost other-costs)
+                      (alt-cost start-alt output-repr) (cons end-cost other-costs)
                       #f))
       (define images (filter (curryr string-suffix? ".png") (all-pages result)))
       (for ([page images])


### PR DESCRIPTION
Herbie's `bsearch` step runs after regime inference and is used to fine-tune the conditionals produced by regime inference. To do so, it uses binary search. Basically, regime inference produces conditionals of the form `(<= x 1.5324897)`, but that constant is actually more like any value in a given range, say 1.5324897 to 2.342972438. `bsearch` samples new points, with `x` values at some intermediate point like 2.0, and uses them to reduce that range so as to improve the conditional.

At the moment, sampling new points in `bsearch` means actually running the sampler. However, this gets in the way of our plans to separate sampling as much as possible from the rest of Herbie. So this PR replaces actual random sampling with a simpler strategy: modifying the `x` value of existing points. Instead of sampling, we are merely re-using existing sampled points in a creative way, so sampling can be cut off more completely from the rest of Herbie.