### PR TITLE
Use the interval implementation of the gamma functions

### DIFF
--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -49,7 +49,7 @@
 
 (define (eval-prog-real prog repr)
   (define pre `(λ ,(program-variables prog) (TRUE)))
-  (define-values (how fn) (make-search-func pre (list prog) repr))
+  (define fn (make-search-func pre (list prog) repr))
   (define (f . pt)
     (define-values (result prec exs) (ival-eval fn pt))
     (match exs

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -37,28 +37,15 @@
                 (ival (ival-hi (is-samplable-interval repr out))))
             (ival-not (ival-error? out))))
 
-(define (eval-prog-wrapper progs repr)
-  (match (filter (compose not (curryr expr-supports? 'ival) program-body) progs)
-    ['()
-     (values 'ival (batch-eval-progs progs 'ival repr))]
-    [(list prog others ...)
-     (warn 'no-ival-operator #:url "faq.html#no-ival-operator"
-           "using unsound ground truth evaluation for program ~a" prog)
-     (define f (batch-eval-progs progs 'bf repr))
-     (define (unival x) (if (ival? x) (ival-lo x) x))
-     (values 'bf (λ args (vector-map (λ (y) (ival y)) (apply f (map unival args)))))]))
-
 ;; Returns a function that maps an ival to a list of ivals
 ;; The first element of that function's output tells you if the input is good
 ;; The other elements of that function's output tell you the output values
 (define (make-search-func precondition programs repr)
-  (define-values (how fns) (eval-prog-wrapper (cons precondition programs) repr))
-  (values
-   how 
-   (λ inputs
-     (match-define (list ival-pre ival-bodies ...) (vector->list (apply fns inputs)))
-     (cons (apply ival-and ival-pre (map (curry valid-result? repr) ival-bodies))
-           ival-bodies))))
+  (define fns (batch-eval-progs (cons precondition programs) 'ival repr))
+  (λ inputs
+    (match-define (list ival-pre ival-bodies ...) (vector->list (apply fns inputs)))
+    (cons (apply ival-and ival-pre (map (curry valid-result? repr) ival-bodies))
+          ival-bodies)))
 
 (define (eval-prog-real prog repr)
   (define pre `(λ ,(program-variables prog) (TRUE)))
@@ -74,9 +61,9 @@
 
 (define (sample-points precondition progs repr)
   (timeline-event! 'analyze)
-  (define-values (how fn) (make-search-func precondition progs repr))
+  (define fn (make-search-func precondition progs repr))
   (define sampler 
     (parameterize ([ground-truth-require-convergence #f])
-      (make-sampler repr precondition progs how fn)))
+      (make-sampler repr precondition progs fn)))
   (timeline-event! 'sample)
-  (batch-prepare-points how fn repr sampler))
+  (batch-prepare-points fn repr sampler))

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -31,7 +31,7 @@
     "web-server-lib"
     "draw-lib"
     ("egg-herbie" #:version "1.6")
-    ("rival" #:version "1.4")
+    ("rival" #:version "1.7")
     ("fpbench" #:version "2.0.3")))
 
 (define build-deps

--- a/src/reprs/binary32.rkt
+++ b/src/reprs/binary32.rkt
@@ -166,8 +166,6 @@
  expm1
  fabs
  floor
- j0
- j1
  lgamma
  log
  log10
@@ -182,9 +180,7 @@
  tan
  tanh
  tgamma
- trunc
- y0
- y1)
+ trunc)
 
 (define-2ary-libm-operators
  atan2

--- a/src/reprs/binary64.rkt
+++ b/src/reprs/binary64.rkt
@@ -91,8 +91,6 @@
  expm1
  fabs
  floor
- j0
- j1
  lgamma
  log
  log10
@@ -107,9 +105,7 @@
  tan
  tanh
  tgamma
- trunc
- y0
- y1)
+ trunc)
 
 (define-2ary-libm-operators
  atan2

--- a/src/reprs/fallback.rkt
+++ b/src/reprs/fallback.rkt
@@ -146,35 +146,3 @@
 (define-operator-impl (>= >=.rkt racket racket) bool
   [fl >=])
 
-;; Deprecated
-
-;; copied from <herbie>/syntax/syntax.rkt
-(module hairy racket/base
-  (require ffi/unsafe)
-  (provide check-native-1ary-exists?)
-
-  (define (check-native-1ary-exists? op)
-    (let ([f32-name (string->symbol (string-append (symbol->string op) "f"))])
-      (or (get-ffi-obj op #f (_fun _double -> _double) (λ () #f))
-          (get-ffi-obj f32-name #f (_fun _float -> _float) (λ () #f)))))
-)
-
-(require (submod "." hairy))
-
-; can't load these without native support
-
-(when (check-native-1ary-exists? 'j0)
-  (define-operator-impl (j0 j0.rkt racket) racket
-    [fl (from-bigfloat bfbesj0)]))
-
-(when (check-native-1ary-exists? 'j1)
-  (define-operator-impl (j1 j1.rkt racket) racket
-    [fl (from-bigfloat bfbesj1)]))
- 
-(when (check-native-1ary-exists? 'y0)
-  (define-operator-impl (y0 y0.rkt racket) racket
-    [fl (from-bigfloat bfbesy0)]))
-
-(when (check-native-1ary-exists? 'y1)
-  (define-operator-impl (y1 y1.rkt racket) racket
-    [fl (from-bigfloat bfbesy1)]))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -7,22 +7,6 @@
 
 (provide make-sampler batch-prepare-points ival-eval)
 
-;; Much of this code assumes everything supports intervals. Almost
-;; everything does---we're still missing support for the Gamma and
-;; Bessel functions. But at least none of the benchmarks use those.
-(module+ test
-  (require "syntax/read.rkt")
-  (require racket/runtime-path)
-  (require rackunit "load-plugin.rkt")
-
-  (define-runtime-path benchmarks "../bench/")
-  (load-herbie-builtins)
-  
-  (define exprs
-    (let ([tests (load-tests benchmarks)])
-      (append (map test-program tests) (map test-precondition tests))))
-  (check-true (andmap (compose (curryr expr-supports? 'ival) program-body) exprs)))
-
 ;; Part 1: use FPBench's condition->range-table to create initial hyperrects
 
 (define (precondition->hyperrects precondition reprs repr)
@@ -106,10 +90,10 @@
    (andmap (curry set-member? '(0.0 1.0))
            ((make-hyperrect-sampler two-point-hyperrects (list repr repr))))))
 
-(define (make-sampler repr precondition programs how search-func)
+(define (make-sampler repr precondition programs search-func)
   (define reprs (map (curry dict-ref (*var-reprs*)) (program-variables precondition)))
   (cond
-   [(and (flag-set? 'setup 'search) (equal? how 'ival) (not (empty? reprs))
+   [(and (flag-set? 'setup 'search) (not (empty? reprs))
          (andmap (compose (curry equal? 'real) representation-type) (cons repr reprs)))
     (timeline-push! 'method "search")
     (define hyperrects-analysis (precondition->hyperrects precondition reprs repr))
@@ -165,10 +149,9 @@
      [else
       (loop precision*)])))
 
-(define (batch-prepare-points how fn repr sampler)
+(define (batch-prepare-points fn repr sampler)
   ;; If we're using the bf fallback, start at the max precision
-  (define starting-precision
-    (match how ['ival (bf-precision)] ['bf (*max-mpfr-prec*)]))
+  (define starting-precision (bf-precision))
   (define <-bf (representation-bf->repr repr))
   (define logger (point-logger 'body (map car (*var-reprs*))))
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -103,7 +103,7 @@
  [expm1 bfexpm1 ival-expm1]
  [fabs bfabs ival-fabs]
  [floor bffloor ival-floor]
- [lgamma bflog-gamma #f]
+ [lgamma bflog-gamma ival-lgamma]
  [log bflog ival-log]
  [log10 bflog10 ival-log10]
  [log1p bflog1p ival-log1p]
@@ -116,7 +116,7 @@
  [sqrt bfsqrt ival-sqrt]
  [tan bftan ival-tan]
  [tanh bftanh ival-tanh]
- [tgamma bfgamma #f]
+ [tgamma bfgamma ival-tgamma]
  [trunc bftruncate ival-trunc])
 
 (define-2ary-real-operators

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -151,22 +151,6 @@
 
 (require (submod "." hairy))
 
-(when (check-native-1ary-exists? 'j0)
-  (define-operator (j0 real) real
-    [bf bfbesj0] [ival #f] [deprecated #t]))
-
-(when (check-native-1ary-exists? 'j1)
-  (define-operator (j1 real) real
-    [bf bfbesj1] [ival #f] [deprecated #t]))
- 
-(when (check-native-1ary-exists? 'y0)
-  (define-operator (y0 real) real
-    [bf bfbesy0] [ival #f] [deprecated #t]))
-
-(when (check-native-1ary-exists? 'y1)
-  (define-operator (y1 real) real
-    [bf bfbesy1] [ival #f] [deprecated #t]))
-
 ;; Operator implementations
 
 (struct operator-impl (name op itype otype fl bf ival))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -71,10 +71,6 @@
   (*needed-reprs* (map get-representation '(binary64 binary32 bool)))
   (define _ (*simplify-rules*))  ; force an update
   (for* ([test-ruleset (*rulesets*)] [test-rule (first test-ruleset)])
-    (unless (and (expr-supports? (rule-input test-rule) 'ival)
-                 (expr-supports? (rule-output test-rule) 'ival))
-      (fail-check "Rule does not support ival sampling"))
-
     (test-case (~a (rule-name test-rule))
       (check-rule-correct test-rule)))
 

--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -6,8 +6,8 @@ FUNCTIONS = {}
     FUNCTIONS[op] = [["real", "real"], "real"];
 });
 ("fabs sqrt exp log sin cos tan asin acos atan sinh cosh tanh asinh acosh atanh " +
- "cbrt ceil erf erfc exp2 expm1 floor j0 j1 lgamma log10 log1p log2 logb rint " + 
- "round tgamma trunc y0 y1").split(" ").forEach(function(op) {
+ "cbrt ceil erf erfc exp2 expm1 floor lgamma log10 log1p log2 logb rint " + 
+ "round tgamma trunc").split(" ").forEach(function(op) {
      FUNCTIONS[op] = [["real"], "real"];
 });
 FUNCTIONS["fma"] = [["real", "real", "real"], "real"];

--- a/www/doc/1.7/faq.html
+++ b/www/doc/1.7/faq.html
@@ -74,25 +74,6 @@
     as <code>:pre (&lt; -100 x 100)</code>, to prevent large inputs.
   </p>
 
-  <h3 id="no-ival-operator">Using unsound ground truth evaluation</h3>
-
-  <p>
-    Herbie's ground truth evaluation does not directly support the
-    Gamma and Bessel functions. Thus, any input containing these
-    operators triggers this warning and causes Herbie to fall back to
-    a slower and unsound ground truth evaluation strategy. There is
-    currently no workaround.
-  </p>
-
-  <h3 id="deprecated-ops">Operator <var>op</var> is deprecated</h3>
-
-  <p>
-    Herbie raises this warning when an operation is no longer supported.
-    Input expressions containing these operators may not be portable
-      across different platforms.
-    Consider creating a plugin to support them.
-  </p>
-
   <h3 id="value-to-string">Could not uniquely print <var>val</var></h3>
 
   <p>


### PR DESCRIPTION
This PR is related to [herbie-fp/rival PR #7](https://github.com/herbie-fp/rival/pull/7), which implements `ival-lgamma` and `ival-tgamma`. To that end, this PR removes support for the Bessel functions and uses interval implementations for the Gamma functions, thereby ensuring that all Herbie-supported operators have interval variants. The PR thus also removes all fallback options if an interval implementation is not available.