### PR TITLE
Use `batch-errors` in place of `oracle-errors` and `baseline-errors`

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -228,9 +228,10 @@
 
 (define (atab-add-altns atab altns repr)
   (define progs (map alt-program altns))
-  (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
-  (for/fold ([atab atab]) ([altn (in-list altns)] [errs (in-vector errss)])
-    (atab-add-altn atab altn errs repr)))
+  (define errss (flip-lists (batch-errors progs (alt-table-context atab) repr)))
+  (minimize-alts
+   (for/fold ([atab atab]) ([altn (in-list altns)] [errs (in-list errss)])
+     (atab-add-altn atab altn errs repr))))
 
 (define (worse-than? point->alts altn cost tied-pnts tied-errs)
   (cond
@@ -265,8 +266,8 @@
     (define alts->done?* (hash-set alt->done? altn #f))
     (define alt->cost* (hash-set alt->cost altn cost))
     (define all-alts* (cons altn all-alts))
-    (minimize-alts (alt-table pnts->alts*2 alts->pnts*2 alts->done?*
-                              alt->cost* (alt-table-context atab) all-alts*))]))
+    (alt-table pnts->alts*2 alts->pnts*2 alts->done?*
+               alt->cost* (alt-table-context atab) all-alts*)]))
 
 (define (atab-not-done-alts atab)
   (filter (negate (curry hash-ref (alt-table-alt->done? atab)))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -42,7 +42,7 @@
     (if (flag-set? 'reduce 'branch-expressions)
         (exprs-to-branch-on alts repr)
         (program-variables (alt-program (first alts)))))
-  (define err-lsts (map vector->list (batch-errors (map alt-program alts) (*pcontext*) repr)))
+  (define err-lsts (batch-errors (map alt-program alts) (*pcontext*) repr))
   (define options
     ;; We can only combine alts for which the branch expression is
     ;; critical, to enable binary search.

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -73,17 +73,16 @@
         (define processed-test-context
           (preprocess-pcontext (test-vars test) test-context (*herbie-preprocess*) output-repr))
 
-        (define fns
-          (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr))
-               (remove-duplicates (*all-alts*))))
+        (define all-errss
+          (flip-lists
+           (batch-errors (map alt-program (append alts (*all-alts*)))
+                         processed-test-context output-repr)))
 
-        (define end-errss (map (λ (x) (errors (alt-program x) processed-test-context output-repr)) alts))
-        (define baseline-errs (baseline-error fns train-context processed-test-context output-repr))
-        (define oracle-errs (oracle-error fns processed-test-context output-repr))
-        (define end-score (errors-score (car end-errss)))
-
+        (define-values (end-errs other-errs) (split-at all-errss (length alts)))
+        (define baseline-errs (argmax errors-score other-errs))
+        (define oracle-errs (map (curry apply max) (flip-lists other-errs)))
         (timeline-adjust! 'regimes 'oracle (errors-score oracle-errs))
-        (timeline-adjust! 'regimes 'accuracy end-score)
+        (timeline-adjust! 'regimes 'accuracy (errors-score (first end-errs)))
         (timeline-adjust! 'regimes 'baseline (errors-score baseline-errs))
         (timeline-adjust! 'regimes 'name (test-name test))
         (timeline-adjust! 'regimes 'link ".")
@@ -101,7 +100,7 @@
                       (errors (alt-program (car alts)) train-context output-repr)
                       newpoints newexacts
                       (errors (test-program test) processed-test-context output-repr)
-                      end-errss
+                      end-errs
                       (if (test-output test)
                           (errors (test-target test) processed-test-context output-repr)
                           #f)

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -425,12 +425,12 @@
                #:y-min 0 #:y-max y-max)))
 
 
-(define (make-alt-plots point-alt-idxs alt-idxs title out result)
+#;(define (make-alt-plots point-alt-idxs alt-idxs title out result)
   (define best-alt-point-renderers (best-alt-points point-alt-idxs alt-idxs))
   (define repr (test-output-repr (test-result-test result)))
   (alt-plot best-alt-point-renderers repr #:port out #:kind 'png #:title title))
 
-(define (make-point-alt-idxs result)
+#;(define (make-point-alt-idxs result)
   (define repr (test-output-repr (test-result-test result)))
   (define all-alts (test-success-all-alts result))
   (define all-alt-bodies (map (λ (alt) (eval-prog (alt-program alt) 'fl repr)) all-alts))
@@ -438,7 +438,7 @@
   (define newexacts (test-success-newexacts result))
   (oracle-error-idx all-alt-bodies newpoints newexacts repr))
 
-(define (make-contour-plot point-colors var-idxs title out result)
+#;(define (make-contour-plot point-colors var-idxs title out result)
   (define point-renderers (herbie-ratio-point-renderers point-colors var-idxs))
   (define repr (test-output-repr (test-result-test result)))
   (alt-plot point-renderers repr #:port out #:kind 'png #:title title))


### PR DESCRIPTION
This PR replaces  `oracle-errors` and `baseline-errors` with a new inlined implementation in terms of `batch-errors`. It turns out that when run in Pareto mode, Herbie spends almost 30% of its runtime in `oracle-errors`, basically because it evaluates every useful alt Herbie has ever seen on every point. By using `batch-errors` we avoid re-evaluating an alt multiple times on the same point, and also gain the benefit of some common subexpression elimination.

Along the way, this PR also implements `errors` in terms of `batch-errors` and changes the later to use lists in place of vectors (it turns out all callers convert the vectors to lists anyway).