### PR TITLE
Simplify nightly make routine--just install then run nightly.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,7 @@ minimal-distribution:
 	[ ! -f herbie.app ] || (raco distribute herbie-compiled herbie.app && rm herbie.app)
 	[ ! -f herbie ] || (raco distribute herbie-compiled herbie && rm herbie)
 
-nightly:
-	if raco pkg show herbie | grep -q herbie; then \
-	    $(MAKE) update egg-herbie; \
-	else \
-	    $(MAKE) install; \
-	fi;
+nightly: install
 	bash infra/nightly.sh reports
 
 start-server: install


### PR DESCRIPTION
Nightlies were failing because `update` actually always needs the new `egg-herbie` routine to run first. This is just what `install` does now, so I removed the old conditional code and just included install as a dependency of the nightly target.