### PR TITLE
Measure regimes metrics during regimes

### DIFF
--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -43,7 +43,7 @@
       [(test-success test bits time timeline warnings
                      start-alt end-alts preprocess points exacts start-est-error end-est-error
                      newpoints newexacts start-error end-errors target-error
-                     baseline-error oracle-error start-cost costs all-alts)
+                     start-cost costs all-alts)
        (define end-error (car end-errors))
        (printf "[ ~as]   ~a→~a\t~a\n"
                (~r (/ time 1000) #:min-width 7 #:precision '(= 3))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -57,6 +57,10 @@
           (sow (option-on-expr sound-alts err-lsts bexpr ctx))))))
   (define best (argmin (compose errors-score option-errors) options))
   (timeline-push! 'count (length alts) (length (option-split-indices best)))
+  (define err-lsts* (flip-lists err-lsts))
+  (timeline-push! 'baseline (apply min (map errors-score err-lsts*)))
+  (timeline-push! 'accuracy (errors-score (option-errors best)))
+  (timeline-push! 'oracle (errors-score (map (curry apply max) err-lsts)))
   best)
 
 (define (exprs-to-branch-on alts ctx)

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -17,7 +17,7 @@
   (start-alt end-alts preprocess points exacts
    start-est-error end-est-error newpoints newexacts
    start-error end-errors target-error
-   baseline-error oracle-error start-cost end-costs all-alts))
+   start-cost end-costs all-alts))
 (struct test-failure test-result (exn))
 (struct test-timeout test-result ())
 
@@ -72,17 +72,10 @@
         (define processed-test-context
           (preprocess-pcontext test-context (*herbie-preprocess*) context))
 
-        (define all-errss
+        (define end-errs
           (flip-lists
-           (batch-errors (map alt-program (append alts (*all-alts*)))
-                         processed-test-context context)))
+           (batch-errors (map alt-program alts) processed-test-context context)))
 
-        (define-values (end-errs other-errs) (split-at all-errss (length alts)))
-        (define baseline-errs (argmax errors-score other-errs))
-        (define oracle-errs (map (curry apply max) (flip-lists other-errs)))
-        (timeline-adjust! 'regimes 'oracle (errors-score oracle-errs))
-        (timeline-adjust! 'regimes 'accuracy (errors-score (first end-errs)))
-        (timeline-adjust! 'regimes 'baseline (errors-score baseline-errs))
         (timeline-adjust! 'regimes 'name (test-name test))
         (timeline-adjust! 'regimes 'link ".")
         (print-warnings)
@@ -103,8 +96,6 @@
                       (if (test-output test)
                           (errors (test-target test) processed-test-context context)
                           #f)
-                      baseline-errs
-                      oracle-errs
                       (program-cost (test-program test) output-repr)
                       (map (curryr alt-cost output-repr) alts)
                       (*all-alts*)))))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -63,7 +63,7 @@
    (test-success test bits time timeline warnings
                  start-alt end-alts preprocess points exacts start-est-error end-est-error
                  newpoints newexacts start-error end-errors target-error
-                 baseline-error oracle-error start-cost costs all-alts)
+                 start-cost costs all-alts)
    result)
   (define repr (test-output-repr test))
   (define end-alt (car end-alts))


### PR DESCRIPTION
This PR is complicated.

Regimes is the pass that determines which alt to use on which point. Regimes metrics measure how good a job it does. Right now, this measurement is done after Herbie is done, on the resampled points. To do so Herbie measures an _oracle_ value by finding the best alt on any new point. It also measures a _baseline_ value by picking the best single alt overall. The regime metric is then somewhere between these two values (hopefully).

This PR changes the calculation to use _old_, not _new_, points. This makes it faster, because we already evaluate all alts on all points during regimes, and can now reuse those points for metrics.

Now the tricky bit is that this changes the meaning of those metrics. Regimes can fail by _underfitting_, where there's a program that is better on both old and new points, but regimes can't find it. But it can also fail by _overfitting_, where it finds a program that is good on old points but does not generalize. The old metrics captured both types of errors; the new metrics will only capture underfitting, not overfitting.

This seems bad, but there are a couple of reasons I still think this should be merged:

1. It makes P-Herbie a lot faster. Computing regimes metrics takes something like 30% of runtime. By reusing already-computed points, this PR makes it basically free. Importantly, there's a separate effort under way to speed up the _other_ 70% of runtime by a lot.
2. Overfitting seems to never be much of an issue for regimes. If it becomes an issue in the future, removing it from metrics is bad, but we don't plan to work on regimes in the near future.

So on the balance I think we should merge this PR and move on to more alt-table optimizations.