### PR TITLE
Fix raco calls in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: egg-herbie update
 
 update:
 	raco pkg install --skip-installed --auto --name herbie src/
-	raco pkg update --name herbie src/
+	raco pkg update --name herbie --deps search-auto src/
 
 egg-herbie:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ help:
 install: clean egg-herbie update
 
 clean:
-	raco pkg remove --force herbie && echo "Warning: uninstalling old herbie" || :
-	raco pkg remove --force egg-herbie && echo "Warning: uninstalling old egg-herbie" || :
-	raco pkg remove --force egg-herbie-linux && echo "Warning: uninstalling old egg-herbie" || :
-	raco pkg remove --force egg-herbie-windows && echo "Warning: uninstalling old egg-herbie" || :
-	raco pkg remove --force egg-herbie-osx && echo "Warning: uninstalling old egg-herbie" || :
+	raco pkg remove --force herbie && echo "Uninstalled old herbie" || :
+	raco pkg remove --force egg-herbie && echo "Uninstalled old egg-herbie" || :
+	raco pkg remove --force egg-herbie-linux && echo "Uninstalled old egg-herbie" || :
+	raco pkg remove --force egg-herbie-windows && echo "Uninstalled old egg-herbie" || :
+	raco pkg remove --force egg-herbie-osx && echo "Uninstalled old egg-herbie" || :
 
 update:
 	raco pkg install --skip-installed --auto --name herbie src/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,14 @@ help:
 	@echo "Type 'make install' to install Herbie"
 	@echo "Then type 'racket src/herbie.rkt web' to run it."
 
-install: egg-herbie update
+install: clean egg-herbie update
+
+clean:
+	raco pkg remove --force herbie && echo "Warning: uninstalling old herbie" || :
+	raco pkg remove --force egg-herbie && echo "Warning: uninstalling old egg-herbie" || :
+	raco pkg remove --force egg-herbie-linux && echo "Warning: uninstalling old egg-herbie" || :
+	raco pkg remove --force egg-herbie-windows && echo "Warning: uninstalling old egg-herbie" || :
+	raco pkg remove --force egg-herbie-osx && echo "Warning: uninstalling old egg-herbie" || :
 
 update:
 	raco pkg install --skip-installed --auto --name herbie src/


### PR DESCRIPTION
This fixes 2 raco-related bugs in the Makefile that interfere with the routine of the nightly runs.

Bug 1 reproduction:
* Clone herbie into 2 directories
* make install in the first directory
* remove the first directory
* make install in the second directory -- this fails

Cause: trying to install a new egg-herbie leads `raco pkg` to panic because the directory for a dependent package (herbie) no longer exists. This occurs on the nightly server when a branch is deleted and the directory the branch was cloned to happens to be the last directory from which herbie was installed.

Solution: always remove the herbie and egg-herbie packages before installing.

I'm not sure if this is something the Racket package manager should be smarter about. It is related to https://github.com/racket/racket/issues/1808, though that involves deleting a dependency rather than a dependent. Basically, it seems like the Racket package manager is very sensitive to missing package directories.

Bug 2 reproduction:
* bump the version of a dependency of Herbie, like rival
* make install is no longer automatic because raco will prompt to update dependencies

Solution: add --deps search-auto to automatically update dependencies.