### PR TITLE
Fix major alt-table bug, leading to more speed-ups

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -64,4 +64,4 @@ jobs:
       - name: "Install SoftPosit support"
         run: raco pkg install --no-cache --auto --name softposit-herbie plugin/
       - name: "Run posit benchmarks"
-        run: racket infra/travis.rkt --seed 0 --num-iters 2 --pareto infra/bench/posit-pherbie.fpcore
+        run: racket infra/travis.rkt --seed 0 --pareto infra/bench/posit-pherbie.fpcore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
-      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --num-iters 2 --pareto bench/hamming/
+      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 --pareto bench/hamming/

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -13,9 +13,6 @@
   (atab-pick-alt (alt-table? #:picking-func ((listof alt?) . -> . alt?)
                              #:only-fresh boolean?
                              . -> . (values alt? alt-table?)))
-  (atab-peek-alt (alt-table? #:picking-func ((listof alt?) . -> . (or/c alt? boolean?))
-                             #:only-fresh boolean?
-                             . -> . (or/c alt? boolean?)))
   (atab-completed? (alt-table? . -> . boolean?))
   (atab-context (alt-table? . -> . pcontext?))
   (atab-min-errors (alt-table? . -> . (listof real?)))
@@ -58,16 +55,11 @@
 
 (define (atab-pick-alt atab #:picking-func [pick car]
            #:only-fresh [only-fresh? #t])
-  (let* ([picked (atab-peek-alt atab #:picking-func pick #:only-fresh only-fresh?)]
-         [atab* (struct-copy alt-table atab
-                             [alt->done? (hash-set (alt-table-alt->done? atab)
-                                                   picked #t)])])
-    (values picked atab*)))
-
-(define (atab-peek-alt atab #:picking-func [pick car] #:only-fresh [only-fresh? #f])
-  (pick (if only-fresh?
-      (atab-not-done-alts atab)
-      (atab-active-alts atab))))
+  (define options (if only-fresh? (atab-not-done-alts atab) (atab-active-alts atab)))
+  (define picked (pick options))
+  (values picked
+          (struct-copy alt-table atab
+                       [alt->done? (hash-set (alt-table-alt->done? atab) picked #t)])))
 
 (define (atab-active-alts atab)
   (hash-keys (alt-table-alt->points atab)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -68,7 +68,8 @@
   (alt-table-all atab))
 
 (define (atab-completed? atab)
-  (andmap identity (hash-values (alt-table-alt->done? atab))))
+  (andmap (curry hash-ref (alt-table-alt->done? atab))
+          (hash-keys (alt-table-alt->points atab))))
 
 ;; Split the alt table into several alt tables, each of which corresponds to a pred
 ;; in 'preds', and only contains points which satisfy that pred.


### PR DESCRIPTION
This PR fixes a major bug for Pherbie in the alt-table implementation, where alts were added and not pruned away, even if they were strictly worse than other alts. Basically, when an alt was added to the alt-table, instead of checking whether it's dominated by any other alt, we just checked whether it was more accurate than all other alts with exactly that cost. Typically, there wasn't another alt with the same cost, so often it was preserved for no reason. The result was that alt-tables would be too large, so all sorts of O(alts) processes like pruning and regimes would take way too long.

The implementation here is a little naive, in that it involves a full scan of the Pareto curve, but even so it speeds up `2tan` by about 30% (this is the benchmark I've been focusing on). It might also lead to speedups in non-Pareto Herbie, but that could go either way.