### PR TITLE
Conservatively tweak some defaults to get better results

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -73,7 +73,7 @@
 (define *num-iterations* (make-parameter 4))
 
 ;; The maximum depth for splitting the space when searching for valid areas of points.
-(define *max-find-range-depth* (make-parameter 14))
+(define *max-find-range-depth* (make-parameter 12))
 
 ;; The maximum number of consecutive skipped points for sampling valid points
 (define *max-skipped-points* (make-parameter 100))
@@ -82,7 +82,7 @@
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph
-(define *node-limit* (make-parameter 5000))
+(define *node-limit* (make-parameter 8000))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -79,6 +79,7 @@
 (define *max-skipped-points* (make-parameter 100))
 
 ;; Maximum MPFR precision allowed during exact evaluation
+(define *starting-prec* (make-parameter 256))
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -134,7 +134,7 @@
   (define ival-close-enough? (close-enough->ival close-enough))
   (not (ival-hi (ival-close-enough? v))))
 
-(define (ival-eval fn pt #:precision [precision 80])
+(define (ival-eval fn pt #:precision [precision 64])
   (let loop ([precision precision])
     (match-define (list valid exs ...) (parameterize ([bf-precision precision]) (apply fn pt)))
     (define precision* (exact-floor (* precision 2)))
@@ -153,7 +153,7 @@
 (define (batch-prepare-points fn ctx sampler)
   ;; If we're using the bf fallback, start at the max precision
   (define repr (context-repr ctx))
-  (define starting-precision (bf-precision))
+  (define starting-precision 64)
   (define <-bf (representation-bf->repr repr))
   (define logger (point-logger 'body (context-vars ctx)))
 

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -134,7 +134,7 @@
   (define ival-close-enough? (close-enough->ival close-enough))
   (not (ival-hi (ival-close-enough? v))))
 
-(define (ival-eval fn pt #:precision [precision 64])
+(define (ival-eval fn pt #:precision [precision (*starting-prec*)])
   (let loop ([precision precision])
     (match-define (list valid exs ...) (parameterize ([bf-precision precision]) (apply fn pt)))
     (define precision* (exact-floor (* precision 2)))
@@ -153,7 +153,7 @@
 (define (batch-prepare-points fn ctx sampler)
   ;; If we're using the bf fallback, start at the max precision
   (define repr (context-repr ctx))
-  (define starting-precision 64)
+  (define starting-precision (*starting-prec*))
   (define <-bf (representation-bf->repr repr))
   (define logger (point-logger 'body (context-vars ctx)))
 

--- a/www/doc/1.7/options.html
+++ b/www/doc/1.7/options.html
@@ -96,11 +96,15 @@
 
     <dt><code>--num-analysis N</code></dt>
     <dd>The number of input subdivisions to use when searching for
-      valid input points. The default is 14. Increasing this option
+      valid input points. The default is 12. Increasing this option
       will slow Herbie down, but may fix the
       "<a href="faq.html#sample-valid-points">Cannot sample enough
-      valid points</a>" error.
-    </dd>
+      valid points</a>" error.</dd>
+    
+    <dt><code>--num-enodes N</code></dt>
+    <dd>The number of equivalence graph nodes to use when doing
+    algebraic reasoning. The default is 8000. Increasing this option
+    will slow Herbie down, but may improve results slightly.</dd>
     
     <dt><code>--timeout T</code></dt>
     <dd>The timeout to use per-input, in seconds. A fractional number


### PR DESCRIPTION
The tweaks are:

- Start sampling with 256, not 128, mantissa bits. It turns out that MPFR isn't much faster with 128 bits than 256 bits (mostly fixed costs I guess) so this lets us skip an iteration, saving time overall. I guess?
- Use 8000 enodes in eclass steps. This leads to more generated expressions and also simpler results (both good). Increasing this further is really bad for performance, however, since we start discovering a lot of unsound merges and need to do the rewrite step much more slowly.
- Use 12, not 14, analysis iterations. This parameter is exponential, so the tweak reduces analysis time about 4x without increasing sampling time much at all.