### PR TITLE
Turn on profiling by default & don't redirect stdout

### DIFF
--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -34,7 +34,6 @@
   (define demo-public #f)
 
   (define threads #f)
-  (define report-profile? #f)
   (define report-note #f)
 
   (define pareto-timeout (* 1000 60 60 2))
@@ -113,9 +112,9 @@
     [("--threads") num "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
     [("--profile") "Whether to profile each run"
-     (set! report-profile? true)]
+     (void)]
     #:args (input output)
-    (make-report (list input) #:dir output #:profile report-profile? #:note report-note #:threads threads)]
+    (make-report (list input) #:dir output #:note report-note #:threads threads)]
    [reproduce "Rerun an HTML report"
     #:once-each
     [("--note") note "Add a note for this run"
@@ -123,9 +122,9 @@
     [("--threads") num "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
     [("--profile") "Whether to profile each run"
-     (set! report-profile? true)]
+     (void)]
     #:args (input output)
-    (rerun-report input #:dir output #:profile report-profile? #:note report-note #:threads threads)]
+    (rerun-report input #:dir output #:note report-note #:threads threads)]
    [replot "Regenerate plots for an HTML report"
     #:args (input output)
     (replot-report input #:dir output)]

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -114,7 +114,7 @@
         (profile-thunk
          (λ () (compute-result test))
          #:order 'total
-         #:render (λ (p order) (write-json (profile->json p) pp)))
+         #:render (λ (p order) (write-json (profile->json p) profile?)))
         (compute-result test)))
 
   ; CS versions <= 8.2: problems with scheduler

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -111,11 +111,10 @@
   (define (in-engine _)
     (set! timeline *timeline*)
     (if profile?
-        (parameterize ([current-output-port (or profile? (current-output-port))])
-          (profile-thunk
-           (λ () (compute-result test))
-           #:order 'total
-           #:render (λ (p order) (write-json (profile->json p)))))
+        (profile-thunk
+         (λ () (compute-result test))
+         #:order 'total
+         #:render (λ (p order) (write-json (profile->json p) pp)))
         (compute-result test)))
 
   ; CS versions <= 8.2: problems with scheduler

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -25,18 +25,18 @@
         (for/list ([(k v) (in-dict var-reprs)]) (cons k (representation-name v)))
         (table-row-conversions row)))
   
-(define (make-report bench-dirs #:dir dir #:profile profile? #:note note #:threads threads)
+(define (make-report bench-dirs #:dir dir #:note note #:threads threads)
   (define tests (reverse (sort (append-map load-tests bench-dirs) test<?)))
-  (run-tests tests #:dir dir #:profile profile? #:note note #:threads threads))
+  (run-tests tests #:dir dir #:note note #:threads threads))
 
-(define (rerun-report json-file #:dir dir #:profile profile? #:note note #:threads threads)
+(define (rerun-report json-file #:dir dir #:note note #:threads threads)
   (define data (read-datafile json-file))
   (define tests (map extract-test (report-info-tests data)))
   (*flags* (report-info-flags data))
   (set-seed! (report-info-seed data))
   (*num-points* (report-info-points data))
   (*num-iterations* (report-info-iterations data))
-  (run-tests tests #:dir dir #:profile profile? #:note note #:threads threads))
+  (run-tests tests #:dir dir #:note note #:threads threads))
 
 (define (replot-report json-file #:dir dir)
   (local-require "../points.rkt" "../sandbox.rkt" "../alternative.rkt"
@@ -122,12 +122,12 @@
 (define (merge-profile-jsons ps)
   (profile->json (apply profile-merge (map json->profile (dict-values ps)))))
 
-(define (run-tests tests #:dir dir #:profile profile? #:note note #:threads threads)
+(define (run-tests tests #:dir dir #:note note #:threads threads)
   (define seed (get-seed))
   (when (not (directory-exists? dir)) (make-directory dir))
 
   (define results
-    (get-test-results tests #:threads threads #:seed seed #:profile profile? #:dir dir))
+    (get-test-results tests #:threads threads #:seed seed #:profile true #:dir dir))
   (define info (make-report-info (filter values results) #:note note #:seed seed))
 
   (write-datafile (build-path dir "results.json") info)


### PR DESCRIPTION
This PR make `--profile` a no-op; it is always on for `report` mode (and `rerun` mode) and off otherwise. It also changes the internals of profiling to not redirect standard out, which should make it less likely that we'll eat tracebacks or bugs.