### PR TITLE
Fix rare bug

### DIFF
--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -127,18 +127,15 @@
                      (map negate-term (append-map cdr dens)))))]
     [`(sqrt ,arg)
      (let ([terms (gather-multiplicative-terms arg)])
-       (cond
-        [(negative? (car terms))
-         `(1 (1 . ,expr))]
-        [(exact? (sqrt (car terms)))
-         (cons (sqrt (car terms))
-               (for/list ([term (cdr terms)])
-                 (cons (/ (car term) 2) (cdr term))))]
-        [else
-         (list* 1
-                (cons 1 `(sqrt ,(car terms)))
-                (for/list ([term (cdr terms)])
-                  (cons (/ (car term) 2) (cdr term))))]))]
+       (define exact-sqrt (eval-application 'sqrt (car terms)))
+       (if exact-sqrt
+           (cons exact-sqrt
+                 (for/list ([term (cdr terms)])
+                   (cons (/ (car term) 2) (cdr term))))
+           (list* 1
+                  (cons 1 `(sqrt ,(car terms)))
+                  (for/list ([term (cdr terms)])
+                    (cons (/ (car term) 2) (cdr term))))))]
     [`(cbrt ,arg)
      (let ([terms (gather-multiplicative-terms arg)])
        (define exact-cbrt (eval-application 'cbrt (car terms)))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -141,19 +141,15 @@
                   (cons (/ (car term) 2) (cdr term))))]))]
     [`(cbrt ,arg)
      (let ([terms (gather-multiplicative-terms arg)])
-       (define head-cbrt (expt (car terms) 1/3))
-       (cond
-        [(and
-          (not (nan? head-cbrt)) (not (infinite? head-cbrt))
-          (equal? (expt (inexact->exact head-cbrt) 3) (car terms)))
-         (cons head-cbrt
-               (for/list ([term (cdr terms)])
-                 (cons (/ (car term) 3) (cdr term))))]
-        [else
-         (list* 1
-                (cons 1 `(cbrt ,(car terms)))
-                (for/list ([term (cdr terms)])
-                  (cons (/ (car term) 3) (cdr term))))]))]
+       (define exact-cbrt (eval-application 'cbrt (car terms)))
+       (if exact-cbrt
+           (cons exact-cbrt
+                 (for/list ([term (cdr terms)])
+                   (cons (/ (car term) 3) (cdr term))))
+           (list* 1
+                  (cons 1 `(cbrt ,(car terms)))
+                  (for/list ([term (cdr terms)])
+                    (cons (/ (car term) 3) (cdr term))))))]
     [`(pow ,arg ,(? real? a))
      (let ([terms (gather-multiplicative-terms arg)])
        (cond

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -147,6 +147,8 @@
                   (cons 1 `(cbrt ,(car terms)))
                   (for/list ([term (cdr terms)])
                     (cons (/ (car term) 3) (cdr term))))))]
+    [`(pow ,arg 0)
+     '(1)]
     [`(pow ,arg ,(? real? a))
      (let ([terms (gather-multiplicative-terms arg)])
        (define exact-pow (eval-application 'pow (car terms) a))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -143,7 +143,9 @@
      (let ([terms (gather-multiplicative-terms arg)])
        (define head-cbrt (expt (car terms) 1/3))
        (cond
-        [(equal? (expt (inexact->exact head-cbrt) 3) (car terms))
+        [(and
+          (not (nan? head-cbrt)) (not (infinite? head-cbrt))
+          (equal? (expt (inexact->exact head-cbrt) 3) (car terms)))
          (cons head-cbrt
                (for/list ([term (cdr terms)])
                  (cons (/ (car term) 3) (cdr term))))]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -149,16 +149,15 @@
                     (cons (/ (car term) 3) (cdr term))))))]
     [`(pow ,arg ,(? real? a))
      (let ([terms (gather-multiplicative-terms arg)])
-       (cond
-        [(and (real? (expt (car terms) a)) (exact? (expt (car terms) a)))
-         (cons (expt (car terms) a)
-               (for/list ([term (cdr terms)])
-                 (cons (* a (car term)) (cdr term))))]
-        [else
-         (list* 1
-                (cons a (car terms))
-                (for/list ([term (cdr terms)])
-                  (cons (* a (car term)) (cdr term))))]))]
+       (define exact-pow (eval-application 'pow (car terms) a))
+       (if exact-pow
+           (cons exact-pow
+                 (for/list ([term (cdr terms)])
+                   (cons (* a (car term)) (cdr term))))
+           (list* 1
+                  (cons a (car terms))
+                  (for/list ([term (cdr terms)])
+                    (cons (* a (car term)) (cdr term))))))]
     [else
      `(1 (1 . ,expr))]))
 

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -224,6 +224,13 @@
         (real? s1) (real? s2)
         (exact? s1) (exact? s2)
         (/ s1 s2)))]
+    [(list 'cbrt (? exact-value? a))
+     (define inexact-num (inexact->exact (expt (numerator a) 1/3)))
+     (define inexact-den (inexact->exact (expt (denominator a) 1/3)))
+     (and (real? inexact-num) (real? inexact-den)
+          (= (expt inexact-num 3) (numerator a))
+          (= (expt inexact-den 3) (denominator a))
+          (/ inexact-num inexact-den))]
     [(list 'fabs (? exact-value? a)) (abs a)]
     [(list 'floor (? exact-value? a)) (floor a)]
     [(list 'ceil (? exact-value? a)) (ceiling a)]
@@ -231,7 +238,6 @@
     ;; Added
     [(list 'exp 0) 1]
     [(list 'log 1) 0]
-    [(list 'cbrt 1) 1]
     [_ #f]))
 
 (module+ test


### PR DESCRIPTION
It turns out that in rare cases, Herbie tries to simplify `(cbrt +inf.0)` using the backup simplifier, which crashes it (because Herbie tries to call `inexact->exact` on `+inf.0`, a weird edge case). This PR fixes it by moving all of this tricky logic to `eval-application`.

I'm not even sure what I did to see this bug. It is super duper rare.