### PR TITLE
Compact sampling table on timeout

### DIFF
--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -127,6 +127,7 @@
       (engine-result eng)
       (parameterize ([*timeline-disabled* false])
         (timeline-load! timeline)
+        (timeline-compact! 'outcomes)
         (print-warnings)
         (test-timeout test (bf-precision) (*timeout*) (timeline-extract output-repr) '()))))
 


### PR DESCRIPTION
A tiny fix for when a benchmark 1) times out; 2) during sampling; 3) to make sure it generates a nicer table.