### PR TITLE
Rewrite localize to work on one input at a time

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -5,65 +5,16 @@
 
 (provide localize-error get-locations)
 
-(define *analyze-cache* (make-hash))
-(define *analyze-context* (make-parameter #f))
-
-(register-reset
- (λ ()
-  (*analyze-context* (*pcontext*))
-  (set! *analyze-cache* (make-hash))))
-
-(define (repeat c)
-  (for/list ([(p e) (in-pcontext (*pcontext*))])
-    c))
-
-(define (localize-on-expression expr vars cache ctx repr)
-  (hash-ref! cache expr
-             (λ ()
-                (match expr
-                  [(? number?)
-                   (cons (repeat (bf expr)) (repeat 1))]
-                  [(? variable?)
-                   (cons (map (curryr representation-repr->bf (context-lookup ctx expr))
-                              (dict-ref vars expr))
-                         (repeat 1))]
-                  [`(if ,c ,ift ,iff)
-                   (let ([exact-ift (car (localize-on-expression ift vars cache ctx repr))]
-                         [exact-iff (car (localize-on-expression iff vars cache ctx repr))]
-                         [exact-cond (for/list ([(p _) (in-pcontext (*pcontext*))])
-				       (apply (eval-prog `(λ ,(map car vars) ,c) 'bf ctx) p))])
-                     (cons (for/list ([c exact-cond] [t exact-ift] [f exact-iff]) (if c t f))
-                           (repeat 1)))]
-                  [`(,f)
-                   (define repr (operator-info f 'otype))
-                   (define <-bf (representation-bf->repr repr))
-                   (define exact ((operator-info f 'bf)))
-                   (define approx ((operator-info f 'fl)))
-                   (cons (repeat exact) (repeat (ulp-difference (<-bf exact) approx repr)))]
-                  [`(,f ,args ...)
-                   (define repr (operator-info f 'otype))
-                   (define argreprs (operator-info f 'itype))
-                   (define <-bf (representation-bf->repr repr))
-                   (define arg<-bfs (map representation-bf->repr argreprs))
-
-                   (define argexacts
-                     (flip-lists
-                      (for/list ([arg args] [repr argreprs])
-                        (car (localize-on-expression arg vars cache ctx repr)))))
-                   (define argapprox
-                     (for/list ([pt argexacts])
-                       (for/list ([val pt] [arg<-bf arg<-bfs])
-                         (arg<-bf val))))
-
-                   (define exact (map (curry apply (operator-info f 'bf)) argexacts))
-                   (define approx (map (curry apply (operator-info f 'fl)) argapprox))
-                   (cons exact (map (λ (ex ap) (ulp-difference (<-bf ex) ap repr))
-                                    exact approx))]))))
-
-(register-reset
- (λ ()
-  (*analyze-context* (*pcontext*))
-  (set! *analyze-cache* (make-hash))))
+(define (all-subexpressions expr)
+  (remove-duplicates
+   (reap [sow]
+         (let loop ([expr expr])
+           (sow expr)
+           (match expr
+             [(? number?) (void)]
+             [(? variable?) (void)]
+             [(list op args ...)
+              (for-each loop args)])))))
 
 ;; Returns the locations of `subexpr` within `expr`
 (define (get-locations expr subexpr)
@@ -79,23 +30,36 @@
       [_
        (list)])))
 
-;; Returns a list of locations and errors sorted
-;; by error scores in descending order
 (define (localize-error prog ctx)
-  (define repr (context-repr ctx))
-  (define varmap (map cons (program-variables prog)
-		      (flip-lists (for/list ([(p e) (in-pcontext (*pcontext*))])
-				    p))))
-  (define cache
-    (if (eq? (*analyze-context*) (*pcontext*))
-        *analyze-cache*
-        (make-hash)))
+  (define expr (program-body prog))
+  (define subexprs (all-subexpressions expr))
+  (define subprogs
+    (for/list ([expr (in-list subexprs)])
+      `(λ ,(program-variables prog) ,expr)))
+  (define exact-fn (batch-eval-progs subprogs 'bf ctx))
+  (define errs (make-hash (map (curryr cons '()) subexprs)))
+  (for ([(pt ex) (in-pcontext (*pcontext*))])
+    (define bf-values (apply exact-fn pt))
+    (define bfhash (make-hash (map cons subexprs (vector->list bf-values))))
+    (for ([expr (in-list subexprs)])
+      (define err
+        (match expr
+          [(? number?) 1]
+          [(? variable?) 1]
+          [`(if ,c ,ift ,iff) 1]
+          [(list f args ...)
+           (define repr (operator-info f 'otype))
+           (define <-bf (representation-bf->repr repr))
+           (define argapprox
+             (for/list ([arg (in-list args)] [repr (in-list (operator-info f 'itype))])
+               ((representation-bf->repr repr) (hash-ref bfhash arg))))
+           (ulp-difference (<-bf (hash-ref bfhash expr))
+                           (apply (operator-info f 'fl) argapprox) repr)]))
+      (hash-update! errs expr (curry cons err))))
 
-  (localize-on-expression (program-body prog) varmap cache ctx repr)
   (sort
-    (reap [sow]
-      (for ([(expr ex&err) (in-hash cache)])
-        (define err (cdr ex&err))
-        (unless (andmap (curry = 1) err)
-          (sow (cons err expr)))))
-    > #:key (compose errors-score car)))
+   (reap [sow]
+         (for ([(expr err) (in-hash errs)])
+           (unless (andmap (curry = 1) err)
+             (sow (cons err expr)))))
+   > #:key (compose errors-score car)))


### PR DESCRIPTION
This PR rewrites our localizer. There are a few big changes:

- We no longer have a cache mechanism. It broke at some point and wasn't operative anyway.
- The localizer now works on one point at a time, instead of on a pcontext at a time. This makes the code way simpler.
- The localizer no longer contains an interpreter. It uses `batch-eval-progs` for the bigfloat evaluation instead. This should make it way easier to upgrade to intervals later on.