### PR TITLE
Remove the retirement community

### DIFF
--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -43,7 +43,7 @@
       [(test-success test bits time timeline warnings
                      start-alt end-alts preprocess points exacts start-est-error end-est-error
                      newpoints newexacts start-error end-errors target-error
-                     start-cost costs all-alts)
+                     start-cost costs)
        (define end-error (car end-errors))
        (printf "[ ~as]   ~a→~a\t~a\n"
                (~r (/ time 1000) #:min-width 7 #:precision '(= 3))

--- a/src/alternative.rkt
+++ b/src/alternative.rkt
@@ -2,7 +2,7 @@
 
 (require "cost.rkt")
 (provide (struct-out change) (struct-out alt) make-alt alt?
-         alt-program alt-add-event *start-prog* *all-alts*
+         alt-program alt-add-event *start-prog*
          alt-cost alt-equal?)
 
 ;; Alts are a lightweight audit trail.
@@ -34,4 +34,3 @@
 ;; exorcised
 
 (define *start-prog* (make-parameter '()))
-(define *all-alts* (make-parameter '()))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -376,8 +376,7 @@
 (define (extract!)
   (define ctx (*context*))
   (define repr (context-repr ctx))
-  (define all-alts (atab-all-alts (^table^)))
-  (*all-alts* (atab-active-alts (^table^)))
+  (define all-alts (atab-active-alts (^table^)))
 
   (define ndone-alts (atab-not-done-alts (^table^)))
   (for ([alt (atab-active-alts (^table^))])

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -17,7 +17,7 @@
   (start-alt end-alts preprocess points exacts
    start-est-error end-est-error newpoints newexacts
    start-error end-errors target-error
-   start-cost end-costs all-alts))
+   start-cost end-costs))
 (struct test-failure test-result (exn))
 (struct test-timeout test-result ())
 
@@ -97,8 +97,7 @@
                           (errors (test-target test) processed-test-context context)
                           #f)
                       (program-cost (test-program test) output-repr)
-                      (map (curryr alt-cost output-repr) alts)
-                      (*all-alts*)))))
+                      (map (curryr alt-cost output-repr) alts)))))
 
   (define (on-exception start-time e)
     (parameterize ([*timeline-disabled* false])

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -63,7 +63,7 @@
    (test-success test bits time timeline warnings
                  start-alt end-alts preprocess points exacts start-est-error end-est-error
                  newpoints newexacts start-error end-errors target-error
-                 start-cost costs all-alts)
+                 start-cost costs)
    result)
   (define repr (test-output-repr test))
   (define end-alt (car end-alts))


### PR DESCRIPTION
This PR removes the "retirement community" in an alt table. That was added way long ago to deal with the issue of overly-complicated outputs from Herbie. Now that Pherbie is default, that issue is handled in a simpler and more complete way, and the retirement community is needless complexity.