### PR TITLE
Work around Racket 8.6 bug in CI, and others

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-            version: stable
+            version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/egg-herbie.yml
+++ b/.github/workflows/egg-herbie.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-            version: stable
+            version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Racket
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
 
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: [ '8.0', 'stable' ]
+        racket-version: [ '8.0', '8.5' ]
         precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: [ '8.0', '8.5' ]
+        racket-version: [ '8.0', 'stable' ]
         precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:
@@ -61,7 +61,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.8
         with:
-          version: stable
+          version: 8.5
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -81,7 +81,7 @@
           (note . ,note)
           (tests . ,(map simplify-test tests))))]))
 
-  (call-with-output-file file (curry write-json data) #:exists 'replace))
+  (call-with-atomic-output-file file (curry write-json data)))
 
 (define (flags->list flags)
   (for*/list ([rec (hash->list flags)] [fl (cdr rec)])

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -81,7 +81,7 @@
           (note . ,note)
           (tests . ,(map simplify-test tests))))]))
 
-  (call-with-atomic-output-file file (curry write-json data)))
+  (call-with-atomic-output-file file (λ (p name) (write-json data p))))
 
 (define (flags->list flags)
   (for*/list ([rec (hash->list flags)] [fl (cdr rec)])

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -128,12 +128,10 @@
        (div
         ,(if merge-data
             `(div ([id "subreports"])
-                (a ([href "#about"]) "Flags")
                 (a ([href "#results"]) "Results")
                 (div ([id "with-subreports"])
                   ,(format-subreports merge-data)))
             `(div
-              (a ([href "#about"]) "Flags")
               (a ([href "#results"]) "Results")
               (div ([id "subreports"] [style "display: none"]))))))
 


### PR DESCRIPTION
The others include:

- Write the results json atomically, in case the server runs out of disk space again
- Use `8.5` instead of `stable` for the CI because `8.6` has a bug
- Hide a broken link on reports pages