### PR TITLE
Rewritten Pareto frontier library

### DIFF
--- a/src/pareto.rkt
+++ b/src/pareto.rkt
@@ -31,9 +31,9 @@
 
 ;; Takes two lists of `pareto-point` structs that are Pareto-optimal
 ;; and returns the Pareto-optimal subset of their union.
+;; The curves most be sorted using the same method.
 (define (pareto-union curve1 curve2)
   (let loop ([curve1 curve1] [curve2 curve2])
-    ; The curve is sorted so that highest accuracy is first
     (match* (curve1 curve2)
       [('() _) curve2]
       [(_ '()) curve1]
@@ -52,7 +52,8 @@
               (cons ppt1 (loop rest1 curve2))
               (cons ppt2 (loop curve1 rest2)))])])))
 
-;; Takes a pareto frontier and returns the points that form a convex frontier.
+;; Takes a Pareto frontier and returns the subset of
+;; points that are convex.
 (define (pareto-convex ppts)
   (let loop ([ppts* '()] [ppts ppts])
     (match ppts
@@ -69,7 +70,7 @@
       (match* ((> m12 m01) (null? ppts*))
         [(#t #t) (loop ppts* (append (list p0 p2) pns))]
         [(#t #f) (loop (rest ppts*) (append (list (first ppts*) p0 p2) pns))]
-        [(#f _) (loop (cons p0 ppts*) (append (list p1 p2) pns))])]
+        [(#f _)  (loop (cons p0 ppts*) (append (list p1 p2) pns))])]
      [_ (append (reverse ppts*) ppts)])))
 
 ;; Takes a list of `pareto-point` structs

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -20,12 +20,9 @@
   (define start
     (for/fold ([x 0] [y 0] #:result (cons x y)) ([s starts])
       (values (+ x (first s)) (+ y (second s)))))
-  (define ptss*
-    (for/list ([pts ptss])
-      (for/list ([pt pts])
-        (cons (first pt) (second pt)))))
   (define ymax (apply + (map representation-total-bits reprs)))
-  (values start (generate-pareto-curve ptss*) ymax))
+  (define frontier (map (λ (pt) (cons (first pt) (second pt))) (pareto-combine ptss #:convex? #t)))
+  (values start frontier ymax))
 
 (define (badge-label result)
   (match (table-row-status result)


### PR DESCRIPTION
This PR adds new functions to the Pareto frontier library and adds new functions.
The interface is now:
 pareto-map : frontier, fn -> list => classic map idiom but over a frontier
 pareto-union : frontier, frontier -> frontier => merges two frontiers (like "minimum")
 pareto-convex: frontier -> frontier => returns the convex subset of a frontier
 pareto-minimize: points -> frontier => returns the Pareto-optimal subset of points
 pareto-combine: adds multiple frontiers (see ARITH '21 paper)