### PR TITLE
Svg pareto plots

### DIFF
--- a/pareto
+++ b/pareto
@@ -1,2 +1,0 @@
-src/web/make-report.rkt:(define (trs->pareto trs)
-src/web/make-report.rkt:  (define-values (pareto-start pareto-points pareto-max) (trs->pareto tests))

--- a/pareto
+++ b/pareto
@@ -1,0 +1,2 @@
+src/web/make-report.rkt:(define (trs->pareto trs)
+src/web/make-report.rkt:  (define-values (pareto-start pareto-points pareto-max) (trs->pareto tests))

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -48,7 +48,8 @@
       (for/list ([pt pts])
         (cons (first pt) (second pt)))))
   (define ymax (apply + (map representation-total-bits reprs)))
-  (values start (generate-pareto-curve ptss*) ymax))
+  (define frontier (map (λ (pt) (cons (first pt) (second pt))) (pareto-combine ptss #:convex? #t)))
+  (values start frontier ymax))
 
 (define (write-datafile file info)
   (define (simplify-test test)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -161,6 +161,7 @@
       ,(if (not (null? other-alts))
           `(section ([id "cost-accuracy"])
             (h1 "Error")
+            (div ([id "graphs-content"]))
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
             "")

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -162,6 +162,7 @@
           `(section ([id "cost-accuracy"])
             (h1 "Error")
             (div ([id "pareto-content"]))
+            (p "cost estimate")
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
             "")

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -161,7 +161,7 @@
       ,(if (not (null? other-alts))
           `(section ([id "cost-accuracy"])
             (h1 "Error")
-            (div ([id "graphs-content"]))
+            (div ([id "pareto-content"]))
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
             "")

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -161,7 +161,7 @@
       ,(if (not (null? other-alts))
           `(section ([id "cost-accuracy"])
             (h1 "Error")
-            (div ([id "pareto-content"])))
+            (div ([id "pareto-content"] [data-benchmark-name ,(~a (test-name test))])))
             "")
 
       ,(render-reproduction test)))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -162,7 +162,6 @@
           `(section ([id "cost-accuracy"])
             (h1 "Error")
             (div ([id "pareto-content"]))
-            (p "cost estimate")
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
             "")

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -161,9 +161,7 @@
       ,(if (not (null? other-alts))
           `(section ([id "cost-accuracy"])
             (h1 "Error")
-            (div ([id "pareto-content"]))
-            (img ([width "800"] [height "300"] [title "cost-accuracy"]
-                  [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
+            (div ([id "pareto-content"])))
             "")
 
       ,(render-reproduction test)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -184,7 +184,6 @@
           `(section ([id "merged-cost-accuracy"])
             (h1 "Error")
             (div ([id "pareto-content"]))
-            (p "Sum of cost estimate")
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
            "")))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -6,9 +6,6 @@
 
 (provide make-report-page)
 
-(define (try-list-accessor acc fail)
-  (λ (l) (if (null? l) fail (acc l))))
-
 (define (badge-label result)
   (match (table-row-status result)
     ["error" "ERR"]

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -67,15 +67,9 @@
   (cond
    [(not dir) (void)]
    [(> (length pareto-points) 1) ; generate the scatterplot if necessary
-    (call-with-output-file (build-path dir "cost-accuracy.png")
-      #:exists 'replace
-      (λ (out) (make-full-cost-accuracy-plot pareto-max pareto-start pareto-points out)))
     (call-with-output-file (build-path dir "cost-accuracy.json")
       #:exists 'replace
-      (λ (out) (make-full-cost-accuracy-json pareto-max pareto-start pareto-points out)))]
-   [else
-    (when (file-exists? (build-path dir "cost-accuracy.png"))
-      (delete-file (build-path dir "cost-accuracy.png")))])
+      (λ (out) (make-full-cost-accuracy-json pareto-max pareto-start pareto-points out)))])
 
   (define table-labels
     '("Test" "Start" "Result" "Target" "Time"))
@@ -183,8 +177,6 @@
      ,(if (> (length pareto-points) 1)
           `(section ([id "merged-cost-accuracy"])
             (h1 "Error")
-            (div ([id "pareto-content"]))
-            (img ([width "800"] [height "300"] [title "cost-accuracy"]
-                  [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
+            (div ([id "pareto-content"])))
            "")))
    out))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -181,9 +181,10 @@
                           "»"))
                      "")))))
      ,(if (> (length pareto-points) 1)
-          `(section ([id "cost-accuracy"])
+          `(section ([id "merged-cost-accuracy"])
             (h1 "Error")
             (div ([id "pareto-content"]))
+            (p "Sum of cost estimate")
             (img ([width "800"] [height "300"] [title "cost-accuracy"]
                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
            "")))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -69,7 +69,10 @@
    [(> (length pareto-points) 1) ; generate the scatterplot if necessary
     (call-with-output-file (build-path dir "cost-accuracy.png")
       #:exists 'replace
-      (λ (out) (make-full-cost-accuracy-plot pareto-max pareto-start pareto-points out)))]
+      (λ (out) (make-full-cost-accuracy-plot pareto-max pareto-start pareto-points out)))
+    (call-with-output-file (build-path dir "cost-accuracy.json")
+      #:exists 'replace
+      (λ (out) (make-full-cost-accuracy-json pareto-max pareto-start pareto-points out)))]
    [else
     (when (file-exists? (build-path dir "cost-accuracy.png"))
       (delete-file (build-path dir "cost-accuracy.png")))])
@@ -118,7 +121,9 @@
       (meta ((charset "utf-8")))
       (link ((rel "stylesheet") (type "text/css") (href "report.css")))
       (script ((src "report.js")))
-      (script ((src "https://d3js.org/d3.v3.min.js") (charset "utf-8")))
+      (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"]))
+      (script ([src "https://unpkg.com/d3@6.7.0/dist/d3.min.js"]))
+      (script ([src "https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"]))
       (script ((type "text/javascript") (src "arrow-chart.js"))))
  
      (body
@@ -176,8 +181,10 @@
                           "»"))
                      "")))))
      ,(if (> (length pareto-points) 1)
-         `(div ([id "scatterplot"] [style "margin-top: 2.5em"])
-             (img ([width "800"] [height "300"] [title "cost-accuracy"]
-                   [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
+          `(section ([id "cost-accuracy"])
+            (h1 "Error")
+            (div ([id "pareto-content"]))
+            (img ([width "800"] [height "300"] [title "cost-accuracy"]
+                  [data-name "Cost Accuracy"] [src "cost-accuracy.png"])))
            "")))
    out))

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -25,8 +25,7 @@
     `("graph.html"
       ,(and good? "interactive.js")
       "timeline.html" "timeline.json"
-      ,(and good? "points.json")
-      ,(and good? "cost-accuracy.json")))
+      ,(and good? "points.json")))
   (filter identity pages))
 
 (define ((page-error-handler result page) e)
@@ -50,8 +49,6 @@
      (make-timeline (test-name test) (test-result-timeline result) out)]
     ["timeline.json"
      (write-json (test-result-timeline result) out)]
-    ["cost-accuracy.json"
-     (make-cost-accuracy-json result out)]
     ["points.json"
      (make-points-json result out repr)]))
 

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -25,7 +25,6 @@
     `("graph.html"
       ,(and good? "interactive.js")
       "timeline.html" "timeline.json"
-      ,(and good? (>= (length (test-success-end-alts result)) 2) "cost-accuracy.png")
       ,(and good? "points.json")
       ,(and good? "cost-accuracy.json")))
   (filter identity pages))
@@ -51,8 +50,6 @@
      (make-timeline (test-name test) (test-result-timeline result) out)]
     ["timeline.json"
      (write-json (test-result-timeline result) out)]
-    ["cost-accuracy.png"
-     (make-cost-accuracy-plot result out)]
     ["cost-accuracy.json"
      (make-cost-accuracy-json result out)]
     ["points.json"

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -26,7 +26,8 @@
       ,(and good? "interactive.js")
       "timeline.html" "timeline.json"
       ,(and good? (>= (length (test-success-end-alts result)) 2) "cost-accuracy.png")
-      ,(and good? "points.json")))
+      ,(and good? "points.json")
+      ,(and good? "cost-accuracy.json")))
   (filter identity pages))
 
 (define ((page-error-handler result page) e)
@@ -52,6 +53,8 @@
      (write-json (test-result-timeline result) out)]
     ["cost-accuracy.png"
      (make-cost-accuracy-plot result out)]
+    ["cost-accuracy.json"
+     (make-cost-accuracy-json result out)]
     ["points.json"
      (make-points-json result out repr)]))
 

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -5,7 +5,7 @@
          "../syntax/types.rkt" "../syntax/syntax.rkt" "../syntax/read.rkt"
          "../alternative.rkt" "../core/regimes.rkt" "../sandbox.rkt")
 
-(provide make-cost-accuracy-plot make-cost-accuracy-json make-full-cost-accuracy-plot make-full-cost-accuracy-json
+(provide make-cost-accuracy-plot make-full-cost-accuracy-plot make-full-cost-accuracy-json
          real->ordinal regime-splitpoints choose-ticks regime-var)
 
 ;; Racket 8.1 compatability
@@ -131,26 +131,6 @@
   (-> alt? (or/c expr? #f))
   (define info (regime-info altn))
   (and info (sp-bexpr (car info))))
-
-;;; Cost vs. Accuracy JSON (internal, single benchmark)
-(define (make-cost-accuracy-json result out)
-  (define repr (test-output-repr (test-result-test result)))
-  (define bits (representation-total-bits repr))
-  (define costs (test-success-end-costs result))
-  (define errs (map errors-score (test-success-end-errors result)))
-
-  (define cost0 (test-success-start-cost result))
-  (define err0 (errors-score (test-success-start-error result)))
-
-  (define xmax (argmax identity (cons cost0 costs)))
-  (define xmin (argmax identity (cons cost0 costs)))
-
-  (define json-obj `#hasheq(
-    (first . ,(list cost0 err0))
-    (best . ,(list (* 2 xmax) bits))
-    (points . ,
-      (for/list ([acost costs] [aerr errs]) (list acost aerr)))))
-  (write-json json-obj out))
 
 ;;; Cost vs. Accuracy JSON (internal, entire suite)
 (define (make-full-cost-accuracy-json y-max start pts out)

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -5,7 +5,7 @@
          "../syntax/types.rkt" "../syntax/syntax.rkt" "../syntax/read.rkt"
          "../alternative.rkt" "../core/regimes.rkt" "../sandbox.rkt")
 
-(provide make-cost-accuracy-plot make-full-cost-accuracy-plot make-full-cost-accuracy-json
+(provide make-cost-accuracy-plot make-full-cost-accuracy-plot 
          real->ordinal regime-splitpoints choose-ticks regime-var)
 
 ;; Racket 8.1 compatability
@@ -132,18 +132,6 @@
   (define info (regime-info altn))
   (and info (sp-bexpr (car info))))
 
-;;; Cost vs. Accuracy JSON (internal, entire suite)
-(define (make-full-cost-accuracy-json y-max start pts out)
-  (match-define (list (cons costs scores) ...) pts)
-  (define x-max (argmax identity (cons (car start) costs)))
-  
-  (define json-obj `#hasheq(
-    (first . ,(list (car start) (cdr start)))
-    (best . ,(list x-max y-max))
-    (points . ,
-      (for/list ([acost costs] [aerr scores]) (list acost aerr)))))
-  (write-json json-obj out))
-  
 ;;; Cost vs. Accuracy (internal, single benchmark)
 (define (make-cost-accuracy-plot result out)
   (define repr (test-output-repr (test-result-test result)))

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -5,7 +5,7 @@
          "../syntax/types.rkt" "../syntax/syntax.rkt" "../syntax/read.rkt"
          "../alternative.rkt" "../core/regimes.rkt" "../sandbox.rkt")
 
-(provide make-cost-accuracy-plot make-cost-accuracy-json make-full-cost-accuracy-plot
+(provide make-cost-accuracy-plot make-cost-accuracy-json make-full-cost-accuracy-plot make-full-cost-accuracy-json
          real->ordinal regime-splitpoints choose-ticks regime-var)
 
 ;; Racket 8.1 compatability
@@ -147,7 +147,7 @@
 
   (define json-obj `#hasheq(
     (first . ,(list cost0 err0))
-    (best . ,(list xmax bits))
+    (best . ,(list (* 2 xmax) bits))
     (points . ,
       (for/list ([acost costs] [aerr errs]) (list acost aerr)))))
   (write-json json-obj out))

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -132,9 +132,8 @@
   (define info (regime-info altn))
   (and info (sp-bexpr (car info))))
 
-;;; Cost vs. Accuracy (internal, single benchmark)
+;;; Cost vs. Accuracy JSON (internal, single benchmark)
 (define (make-cost-accuracy-json result out)
-  (displayln "cost accuracy")
   (define repr (test-output-repr (test-result-test result)))
   (define bits (representation-total-bits repr))
   (define costs (test-success-end-costs result))
@@ -144,15 +143,27 @@
   (define err0 (errors-score (test-success-start-error result)))
 
   (define xmax (argmax identity (cons cost0 costs)))
+  (define xmin (argmax identity (cons cost0 costs)))
 
   (define json-obj `#hasheq(
     (first . ,(list cost0 err0))
     (best . ,(list xmax bits))
     (points . ,
       (for/list ([acost costs] [aerr errs]) (list acost aerr)))))
-  (displayln json-obj)
   (write-json json-obj out))
 
+;;; Cost vs. Accuracy JSON (internal, entire suite)
+(define (make-full-cost-accuracy-json y-max start pts out)
+  (match-define (list (cons costs scores) ...) pts)
+  (define x-max (argmax identity (cons (car start) costs)))
+  
+  (define json-obj `#hasheq(
+    (first . ,(list (car start) (cdr start)))
+    (best . ,(list x-max y-max))
+    (points . ,
+      (for/list ([acost costs] [aerr scores]) (list acost aerr)))))
+  (write-json json-obj out))
+  
 ;;; Cost vs. Accuracy (internal, single benchmark)
 (define (make-cost-accuracy-plot result out)
   (define repr (test-output-repr (test-result-test result)))

--- a/src/web/resources/arrow-chart.js
+++ b/src/web/resources/arrow-chart.js
@@ -76,8 +76,7 @@ function make_graph(node, data, start, end) {
 }
 
 function draw_results(node) {
-    d3.json("results.json", function(err, data) {
-        if (err) return console.error(err);
+    d3.json("results.json").then(function(data) {
         precision = data.bit_width;
         precision_step = Math.round(precision / 8);
 
@@ -140,7 +139,7 @@ function draw_results(node) {
                 ARROWS[i].addEventListener("mouseout", clear);
             })(i);
         }
-    });
+    }).catch(function (err) { if (err) return console.error(err) });
 }
 
 var ArrowChart = new Component("svg.arrow-chart", {

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -322,19 +322,9 @@ const MergedCostAccuracy = new Component('#merged-cost-accuracy', {
         async function render() {
             const options_view = html(`
                 <div id="plot_options">
-                <div id="variables">
-                </div>
-                <div id="functions">
-                </div>
                 </div>
             `)
             const toggle = (option, options) => options.includes(option) ? options.filter(o => o != option) : [...options, option]
-            options_view.querySelectorAll('.variable').forEach(e => e.onclick = () => {
-                render()
-            })
-            options_view.querySelectorAll('.function').forEach(e => e.onclick = () => {
-                render()
-            })
             document.querySelector('#pareto-content').replaceChildren(await plot(), options_view)
         }
         render()
@@ -438,21 +428,9 @@ const CostAccuracy = new Component('#cost-accuracy', {
         async function render() {
             const options_view = html(`
                 <div id="plot_options">
-                <div id="variables">
-                </div>
-                <div id="functions">
-                </div>
                 </div>
             `)
             const toggle = (option, options) => options.includes(option) ? options.filter(o => o != option) : [...options, option]
-            options_view.querySelectorAll('.variable').forEach(e => e.onclick = () => {
-                render()
-            })
-            options_view.querySelectorAll('.function').forEach(e => e.onclick = () => {
-                render()
-            })
-
-            
 
             content.replaceChildren(await plot(), options_view)
         }

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -272,7 +272,7 @@ const MergedCostAccuracy = new Component('#merged-cost-accuracy', {
             
             const get_points_memo = async () => {
                 if (get_points_store.value) { return get_points_store.value }
-                const ps = await get_json('../results.json');
+                const ps = await get_json('results.json');
                 get_points_store.value = ps;
                 return get_points_store.value;
             }

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -308,7 +308,7 @@ const MergedCostAccuracy = new Component('#merged-cost-accuracy', {
                     },
                     y: {
                         label: "Sum of error bits",
-                        domain: [0, best[1]]
+                        domain: [0, best[1]],
                     },
             })
             out.setAttribute('viewBox', '0 0 800 460')
@@ -383,7 +383,9 @@ const CostAccuracy = new Component('#cost-accuracy', {
                     },
                     y: {
                         label: "Bits of error",
-                        domain: [0, best[1]]
+                        domain: [0, best[1]],
+                        ticks: new Array(best[1] / 4 + 1).fill(0).map((_, i) => i * 4),
+                        tickFormat: d => d % 8 != 0 ? '' : d
                     },
             })
             out.setAttribute('viewBox', '0 0 800 430')

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -100,6 +100,7 @@ var TryIt = new Component("#try-it", {
 
 const ClientGraph = new Component('#graphs', {
     setup: async () => {
+        console.log("make error graph");
         const points_json = await (async () => {
             const get_points_store = {}
             
@@ -265,6 +266,12 @@ const ClientGraph = new Component('#graphs', {
     }
 })
 
+
+const CostAccuracy = new Component('#cost-accuracy', {
+    setup: function() {
+        console.log("make cost accuracy");
+    }
+})
 var RenderMath = new Component(".math", {
     depends: function() {
         if (typeof window.renderMathInElement === "undefined") throw "KaTeX unavailable";

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -291,9 +291,11 @@ const MergedCostAccuracy = new Component('#merged-cost-accuracy', {
         const plot = async () => {
             // NOTE ticks and splitpoints include all vars, so we must index
             const costAccuracy = points_json["cost-accuracy"];
+            const sortLine = [...costAccuracy[2]];
+            sortLine.sort((a, b) => {return a[0]-b[0]});
             const out = Plot.plot({
                 marks: [
-                    Plot.line(costAccuracy[2], {x: d => d[0], y: d => d[1], stroke: "red"}),
+                    Plot.line(sortLine, {x: d => d[0], y: d => d[1], stroke: "red"}),
                     Plot.dot(costAccuracy[2], {x: d => d[0], y: d => d[1], fill: "red", stroke: "black"}),
                     Plot.dot(costAccuracy[1], {x: costAccuracy[1][0], y: costAccuracy[1][1], fill: "black"})
                 ],
@@ -391,7 +393,6 @@ const CostAccuracy = new Component('#cost-accuracy', {
             if (costAccuracy[1][1] > ymax) ymax = costAccuracy[1][1];
             
             for (let point of costAccuracy[2]) {
-                console.log(`x: ${point[0]} y: ${point[1]}`)
                 if (point[0] > xmax) xmax = point[0];
                 if (point[1] > ymax) ymax = point[1];
             }
@@ -402,11 +403,13 @@ const CostAccuracy = new Component('#cost-accuracy', {
             // composite array for both best and other points so the line graph
             // contains the best point as well.
             const allpoints = [costAccuracy[1], ...costAccuracy[2]];
+            allpoints.sort((a, b) => {return a[0]-b[0]});
+            console.log(allpoints);
 
             const out = Plot.plot({
                 marks: [
                     Plot.dot(costAccuracy[0], {x: costAccuracy[0][0], y: costAccuracy[0][1], fill: "black"}),
-                    Plot.dot(costAccuracy[1], {x: costAccuracy[1][0], y: costAccuracy[1][1], fill: "red", stroke: "blue", title: d => "best"}),
+                    Plot.dot(costAccuracy[1], {x: costAccuracy[1][0], y: costAccuracy[1][1], fill: "red", stroke: "blue", title: d => `x: ${costAccuracy[1][0]} y: ${costAccuracy[1][1]} best`}),
                     Plot.dot(costAccuracy[2], {x: d => d[0], y: d => d[1], fill: "red", stroke: "black", title: d => `x: ${d[0]} y: ${d[1]} exp: ${d[2]}`}),
                     Plot.line(allpoints, {x: d => d[0], y: d => d[1], stroke: "red"})
                 ],

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -266,6 +266,80 @@ const ClientGraph = new Component('#graphs', {
     }
 })
 
+const MergedCostAccuracy = new Component('#merged-cost-accuracy', {
+    setup: async () => {
+        console.log("make cost accuracy");
+        const points_json = await (async () => {
+            const get_points_store = {}
+            
+            const get_points_memo = async () => {
+                if (get_points_store.value) { return get_points_store.value }
+                const ps = await get_json('cost-accuracy.json');
+                get_points_store.value = ps;
+                return get_points_store.value;
+            }
+            const get_json = url => fetch(url, {
+                // body: `_body_`,
+                headers: {"content-type": "text/plain"},
+                method: "GET",
+                mode: 'cors'
+                }).then(async response => {
+                //await new Promise(r => setTimeout(() => r(), 200) )  // model network delay
+                return await response.json()
+            })
+            return get_points_memo()
+        })()
+
+        const plot = async () => {
+            // NOTE ticks and splitpoints include all vars, so we must index
+            const { best, first, points } = points_json;
+
+            const out = Plot.plot({
+                marks: [
+                    Plot.line(points, {x: d => d[0], y: d => d[1], stroke: "red"}),
+                    Plot.dot(first, {x: first[0], y: first[1], fill: "black"})
+                ],
+                grid: true,
+                width: '800',
+                height: '400',                
+                    x: {
+                        label: `Cost`,
+                        domain: [0, best[0]]
+                    },
+                    y: {
+                        label: "Sum of error bits",
+                        domain: [0, best[1]]
+                    },
+            })
+            out.setAttribute('viewBox', '0 0 800 460')
+            return out
+        }
+        function html(string) {
+            const t = document.createElement('template');
+            t.innerHTML = string;
+            return t.content;
+        }
+        async function render() {
+            const options_view = html(`
+                <div id="plot_options">
+                <div id="variables">
+                </div>
+                <div id="functions">
+                </div>
+                </div>
+            `)
+            const toggle = (option, options) => options.includes(option) ? options.filter(o => o != option) : [...options, option]
+            options_view.querySelectorAll('.variable').forEach(e => e.onclick = () => {
+                render()
+            })
+            options_view.querySelectorAll('.function').forEach(e => e.onclick = () => {
+                render()
+            })
+            document.querySelector('#pareto-content').replaceChildren(await plot(), options_view)
+        }
+        render()
+    }
+})
 
 const CostAccuracy = new Component('#cost-accuracy', {
     setup: async () => {

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -305,7 +305,7 @@ const CostAccuracy = new Component('#cost-accuracy', {
                 height: '400',                
                     x: {
                         label: `Cost`,
-                        domain: [0, best[0] * 2]
+                        domain: [0, best[0]]
                     },
                     y: {
                         label: "Bits of error",


### PR DESCRIPTION
This PR replaces usage of native racket plot generation with Observable Plot. 
All plots now have both a dot graph and line graph.

Plumbing details:

- For each benchmark, the benchmark name is passed through the `data-benchmark-name` attribute so the js side knows which test data it's looking for in the `results.json`

- There is a new top-level field named cost-accuracy in the `results.json` object where `cost-accuracy[0]` is a pair representing the domain and range, `cost-accuracy[1]` is the first point, and `cost-accuracy[2]` is an array of pareto-optimal points.

Related code has been moved from `make-report.rkt` to `datafile.rkt` but this adds a couple dependencies to `datafile.rkt`.