### PR TITLE
Added FPCore for Rust's `{f32,f64}::a{sin,cos,tan}h`

### DIFF
--- a/bench/libraries/rust.fpcore
+++ b/bench/libraries/rust.fpcore
@@ -1,0 +1,54 @@
+(FPCore (x)
+  :name "Rust f64::asinh"
+  :spec (asinh x)
+
+  :herbie-target
+  (let* ([ax (fabs x)] [ix (/ 1 ax)])
+    (copysign (log1p (+ ax (/ ax (+ (hypot 1 ix) ix)))) x))
+
+  (copysign (log (+ (fabs x) (sqrt (+ (* x x) 1)))) x))
+
+(FPCore (x)
+  :name "Rust f32::asinh"
+  :spec (asinh x)
+  :precision binary32
+
+  :herbie-target
+  (let* ([ax (fabs x)] [ix (/ 1 ax)])
+    (copysign (log1p (+ ax (/ ax (+ (hypot 1 ix) ix)))) x))
+
+  (copysign (log (+ (fabs x) (sqrt (+ (* x x) 1)))) x))
+
+(FPCore (x)
+  :name "Rust f64::acosh"
+  :spec (acosh x)
+  :pre (>= x 1)
+
+  :herbie-target
+  (log (+ x (* (sqrt (- x 1)) (sqrt (+ x 1)))))
+
+  (log (+ x (sqrt (- (* x x) 1)))))
+
+(FPCore (x)
+  :name "Rust f32::acosh"
+  :spec (acosh x)
+  :precision binary32
+  :pre (>= x 1)
+
+  :herbie-target
+  (log (+ x (* (sqrt (- x 1)) (sqrt (+ x 1)))))
+
+  (log (+ x (sqrt (- (* x x) 1)))))
+
+(FPCore (x)
+  :name "Rust f64::atanh"
+  :spec (atanh x)
+
+  (* 0.5 (log1p (/ (* 2 x) (- 1 x)))))
+
+(FPCore (x)
+  :name "Rust f32::atanh"
+  :spec (atanh x)
+  :precision binary32
+
+  (* 0.5 (log1p (/ (* 2 x) (- 1 x)))))


### PR DESCRIPTION
Rust's math library [reimplements][rust-libm] `asinh`, `acosh`, and `atanh`. I'm not sure why it doesn't use `libm`'s implementation; I assume it's about supported platforms.

In any case, @finnbear discovered that their implementations are woefully inaccurate (see https://github.com/FPBench/FPBench/pull/118).

This PR adds these implementations as a benchmark in `libraries/rust.fpcore`. The benchmarks are available in 32-bit and 64-bit mode, are annotated with the relevant precondition, and also have a `:herbie-target` which is my hand-written improved version.

[rust-libm]: https://github.com/rust-lang/rust/blob/1ea4efd0656599f824e2567a5b7a95454f701c03/library/std/src/f64.rs#L883