### PR TITLE
Don't calculate sound options

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -22,8 +22,6 @@
 ;; pidx = Point index: The index of the point to the left of which we should split.
 (struct si (cidx pidx) #:prefab)
 
-(define check-pick-unsound #t)
-
 ;; `infer-splitpoints` and `combine-alts` are split so the mainloop
 ;; can insert a timeline break between them.
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -22,6 +22,8 @@
 ;; pidx = Point index: The index of the point to the left of which we should split.
 (struct si (cidx pidx) #:prefab)
 
+(define check-pick-unsound #t)
+
 ;; `infer-splitpoints` and `combine-alts` are split so the mainloop
 ;; can insert a timeline break between them.
 
@@ -33,18 +35,7 @@
         (exprs-to-branch-on alts ctx)
         (program-variables (alt-program (first alts)))))
   (define err-lsts (batch-errors (map alt-program alts) (*pcontext*) ctx))
-  (define options
-    ;; We can only combine alts for which the branch expression is
-    ;; critical, to enable binary search.
-    (reap [sow]
-      (for ([bexpr branch-exprs])
-        (define unsound-option (option-on-expr alts err-lsts bexpr ctx))
-        (sow unsound-option)
-        (define sound-alts (filter (λ (alt) (critical-subexpression? (program-body (alt-program alt)) bexpr)) alts))
-        (when (and (> (length sound-alts) 1)
-                   (for/or ([si (option-split-indices unsound-option)])
-                     (not (set-member? sound-alts (list-ref alts (si-cidx si))))))
-          (sow (option-on-expr sound-alts err-lsts bexpr ctx))))))
+  (define options (for/list ([bexpr branch-exprs]) (option-on-expr alts err-lsts bexpr ctx)))
   (define best (argmin (compose errors-score option-errors) options))
   (timeline-push! 'count (length alts) (length (option-split-indices best)))
   (timeline-push! 'outputs

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -387,7 +387,6 @@
      [else
       (define opt (infer-splitpoints alts ctx))
       (define branched-alt (combine-alts opt ctx))
-      ;c finds highest index of alts
       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
       (cons branched-alt (loop (take alts high)))])))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -380,15 +380,16 @@
   (extract!))
 
 (define (pareto-regimes sorted ctx)
-  (let loop ([alts sorted] [idx 0])
+  (let loop ([alts sorted])
     (cond
      [(null? alts) '()]
      [(= (length alts) 1) (list (car alts))]
      [else
       (define opt (infer-splitpoints alts ctx))
       (define branched-alt (combine-alts opt ctx))
+      ;c finds highest index of alts
       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
-      (cons branched-alt (loop (take alts high) (+ idx (- (length alts) high))))])))
+      (cons branched-alt (loop (take alts high)))])))
 
 (define (extract!)
   (define ctx (*context*))


### PR DESCRIPTION
This PR removes calculating sound options; we are always choosing `unsound-option` over `sound-option` in `infer-splitpoints` so there is no need to recalculate sound options.

Also removes an unused parameter in `mainloop.rkt` `pareto-regimes`' inner loop.