### PR TITLE
Render proofs

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -10,7 +10,7 @@
 (provide with-egraph egraph-add-expr egraph-run-rules
          egraph-get-simplest egraph-get-variants
          egraph-get-proof egraph-is-unsound-detected
-         rule->egg-rules expand-rules)
+         rule->egg-rules expand-rules get-canon-rule-name)
 
 ;; Converts a string expression from egg into a Racket S-expr
 (define (egg-expr->expr expr eg-data)
@@ -363,6 +363,16 @@
 
 ;; (rules, reprs) -> (egg-rules, ffi-rules, name-map)
 (define ffi-rules-cache #f)
+
+;; Tries to look up the canonical name of a rule using the cache.
+;; Obviously dangerous if the cache is invalid.
+(define (get-canon-rule-name name [failure #f])
+  (cond
+    [ffi-rules-cache
+     (match-define (list _ _ canon-names) (cdr ffi-rules-cache))
+     (hash-ref canon-names name failure)]
+    [else
+     failure]))
 
 ;; expand the rules first due to some bad but currently
 ;; necessary reasons (see `rule->egg-rules` for details).

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -52,8 +52,8 @@
   (match altn
     [(alt prog `(simplify ,loc ,input #f #f) `(,prev))
      (define proof (get-proof input
-                              (location-get loc prog)
-                              (location-get loc (alt-program prev))))
+                              (location-get loc (alt-program prev))
+                              (location-get loc prog)))
      ;; Proofs are actually on subexpressions,
      ;; we need to construct the proof for the full expression
      (define proof*

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -55,24 +55,14 @@
         [_ (void)]))
     (k 'Goal #f #f step)))
 
-;; If consecutive proof steps are step(N-1) to stepN
-;; then the rewrite information is actually attached to step(N-1).
-;; Take the rewrite information and associate it with stepN.
+;; Extracts render information from the proof
 (define (compute-proof proof soundiness)
-  (define spliced
-    (for/list ([step (in-list proof)])
-      (define-values (dir rule loc expr) (splice-proof-step step))
-      (list dir rule loc expr)))
-  (for/list ([stepn   (reverse spliced)]
-             [stepn-1 (cons #f (reverse (cdr spliced)))]
-             [sound   (reverse soundiness)])
-    (match-define (list _ _ _ expr) stepn)
-    (cond
-      [stepn-1
-       (match-define (list dir rule loc _) stepn-1)
-       (list dir rule loc expr sound)]
-      [else
-       (list #f #f #f expr #f)])))
+  (for/list ([step (in-list proof)] [sound soundiness])
+     (define-values (dir rule loc expr) (splice-proof-step step))
+     (if (eq? dir 'Goal)
+         (list #f #f #f expr #f)
+         (list dir rule loc expr sound))))
+
 
 (define/contract (render-history altn pcontext pcontext2 ctx)
   (-> alt? pcontext? pcontext? context? (listof xexpr?))

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -136,7 +136,7 @@
                (table
                 ,@(for/list ([step proof*])
                     (match-define (list dir rule loc expr sound) step)
-                    (define prog* (program->fpcore (list 'λ '() (resugar-program expr repr))))
+                    (define step-prog (program->fpcore (list 'λ '() (resugar-program expr repr))))
                     (define err
                       (let ([prog (list 'λ (program-variables prog) expr)])
                         (format-bits (errors-score (errors prog pcontext ctx)))))
@@ -154,8 +154,8 @@
                         (td (div ([class "math"])
                               "\\[ "
                              ,(if dir
-                                  (core->tex prog* #:loc (cons 2 loc) #:color "blue")
-                                  (core->tex prog*))
+                                  (core->tex step-prog #:loc (cons 2 loc) #:color "blue")
+                                  (core->tex step-prog))
                               "\\]")))))))))]
 
     [(alt prog `initial-simplify `(,prev))

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -141,16 +141,13 @@
                       (let ([prog (list 'λ (program-variables prog) expr)])
                         (format-bits (errors-score (errors prog pcontext ctx)))))
                    `(tr (th ,(if dir 
-                                (let ([tag (string-append "Dir "
-                                                          (match dir
-                                                            ['Rewrite<= "<="]
-                                                            ['Rewrite=> "=>"])
-                                                          (format " ↑ ~a" (first sound))
+                                (let ([dir (match dir ['Rewrite<= "<="] ['Rewrite=> "=>"])]
+                                      [tag (string-append (format " ↑ ~a" (first sound))
                                                           (format " ↓ ~a" (second sound)))])
-                                 `(p ,(~a rule)
+                                 `(p ,(format "~a [~a]" rule dir)
                                       (span ([class "info"] [title ,tag]) ,err)))
-                                `(p "[Start]"
-                                    (span ([class "info"]) ,err))))
+                               `(p "[Start]"
+                                   (span ([class "info"]) ,err))))
                         (td (div ([class "math"])
                               "\\[ "
                              ,(if dir

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -280,6 +280,7 @@ section h1 {
 .history .event { display: block; margin: .5em 0; }
 
 .history .proof { width: 100%; overflow: auto; }
+.history .proof table { padding: 0 .5em; }
 .history .proof table th { text-align: left; font-weight: normal; }
 .history .proof table th .info { display: block; color: #666; }
 .history .proof table td { text-align: left; }

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -279,7 +279,10 @@ section h1 {
 .history .rule { text-decoration: underline; }
 .history .event { display: block; margin: .5em 0; }
 
-.history .proof { overflow: auto;  }
+.history .proof { width: 100%; overflow: auto; }
+.history .proof table th { text-align: left; font-weight: normal; }
+.history .proof table th .info { display: block; color: #666; }
+.history .proof table td { text-align: left; }
 
 /* Process / debug info */
 

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -279,6 +279,8 @@ section h1 {
 .history .rule { text-decoration: underline; }
 .history .event { display: block; margin: .5em 0; }
 
+.history .proof { overflow: auto;  }
+
 /* Process / debug info */
 
 #process-info { background: #ddd; }


### PR DESCRIPTION
Renders the egg proofs for simplify (added in #485). Proofs are collapsible and show average error. Additional information visually displayed upon hovering over error including direction, points better/worse.