### PR TITLE
Fix OOM due to large proofs when flattening

### DIFF
--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn egraph_get_proof(
 
         let mut proof = runner.explain_equivalence(&expr_rec, &goal_rec);
         ctx.runner = Some(runner);
-        let string = CString::new(proof.get_flat_string()).unwrap();
+        let string = CString::new(proof.get_string_with_let().replace("\n", "")).unwrap();
         let string_pointer = string.as_ptr();
         std::mem::forget(string);
         string_pointer

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -86,6 +86,7 @@
 
 ;; The maximum size of an egraph
 (define *node-limit* (make-parameter 8000))
+(define *proof-max-length* (make-parameter 100))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -86,7 +86,7 @@
 
 ;; The maximum size of an egraph
 (define *node-limit* (make-parameter 8000))
-(define *proof-max-length* (make-parameter 100))
+(define *proof-max-length* (make-parameter 200))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -29,6 +29,7 @@
   (define proof-programs
     (for/list ([step (in-list proof)])
       `(λ ,program-vars ,(remove-rewrites step))))
+  (println proof-programs)
   (define proof-errors (batch-errors proof-programs pcontext ctx))
   (define proof-diffs
     (cons (list 0 0)

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -5,16 +5,6 @@
 
 (provide add-soundiness)
 
-(define (remove-rewrites proof)
-  (match proof
-    [`(Rewrite=> ,rule ,something)
-     (remove-rewrites something)]
-    [`(Rewrite<= ,rule ,something)
-     (remove-rewrites something)]
-    [(list _ ...)
-     (map remove-rewrites proof)]
-    [else proof]))
-
 (define (canonicalize-rewrite proof)
   (match proof
     [`(Rewrite=> ,rule ,something)
@@ -29,7 +19,6 @@
   (define proof-programs
     (for/list ([step (in-list proof)])
       `(λ ,program-vars ,(remove-rewrites step))))
-  (println proof-programs)
   (define proof-errors (batch-errors proof-programs pcontext ctx))
   (define proof-diffs
     (cons (list 0 0)
@@ -55,16 +44,20 @@
      (define proof (get-proof input
                               (location-get loc (alt-program prev))
                               (location-get loc prog)))
-     ;; Proofs are actually on subexpressions,
-     ;; we need to construct the proof for the full expression
-     (define proof*
-       (for/list ([step proof])
-         (let ([step* (canonicalize-rewrite step)])
-           (program-body (location-do loc prog (λ _ step*))))))
-     (define errors
-       (let ([vars (program-variables prog)])
-         (get-proof-errors proof* pcontext ctx vars)))
-     (alt prog `(simplify ,loc ,input ,proof* ,errors) `(,prev))]
+     (cond
+       [proof
+        ;; Proofs are actually on subexpressions,
+        ;; we need to construct the proof for the full expression
+        (define proof*
+          (for/list ([step proof])
+            (let ([step* (canonicalize-rewrite step)])
+              (program-body (location-do loc prog (λ _ step*))))))
+        (define errors
+          (let ([vars (program-variables prog)])
+            (get-proof-errors proof* pcontext ctx vars)))
+        (alt prog `(simplify ,loc ,input ,proof* ,errors) `(,prev))]
+       [else
+        (alt prog `(simplify ,loc ,input #f #f) `(,prev))])]
     [else
      altn]))
 


### PR DESCRIPTION
This PR moves proof flattening to the Racket side and limits the number of steps it flattens.