### PR TITLE
Make nightly Slack link to the main report page

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -38,4 +38,3 @@ RECURSE=1 LOG=1 \
 
 # upload
 bash $INFRA_DIR/publish.sh upload "$OUT_DIR"
-bash $INFRA_DIR/publish.sh index


### PR DESCRIPTION
I believe this is because `nightly-results publish` takes the last-uploaded URL and we were re-indexing for no reason.