### PR TITLE
Supporting let expressions on the web demo

### DIFF
--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -281,7 +281,7 @@ function get_unused_var_warnings(tree) {
             // Assume each assignment is of the form:
             //  <assign> ::= <name> = <val>; <body>.
             // Then
-            //  (i)  <name> is used if <name> is not in Used(<body>),
+            //  (i)  <name> is unused if <name> is not in Used(<body>),
             //  (ii) Used(<expr>) = Used(<val>) U (Used(<body>) \ { <name> })
             // Clearly, the assumption is slightly wrong, but this
             // tells us we just walk backwards checking condition (i)

--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -78,6 +78,11 @@ function tree_errors(tree, expected) /* tree -> list */ {
             }
             return node.trueExpr.res;
         case "BlockNode":
+            for (var i = 0; i < tree.blocks.length - 1; i++) {
+                stmt = tree.blocks[i].node;
+                if (stmt.type != "AssignmentNode")
+                    messages.push("Expected an assignment statement before a semicolon: " + stmt);
+            }
             return node.blocks[node.blocks.length - 1].node.res;
         default:
             messages.push("Unsupported syntax; found unexpected <code>" + node.type + "</code>.")
@@ -103,7 +108,7 @@ function bottom_up(tree, cb) {
         for (var i = 0; i < tree.blocks.length - 1; i++) {
             stmt = tree.blocks[i].node;
             if (stmt.type != "AssignmentNode")
-                throw SyntaxError("Only assignment statements are supported! " + stmt);
+                throw SyntaxError("Expected an assignment statement before a semicolon: " + stmt);
             stmt.expr = bottom_up(stmt.expr, cb);
         }
 
@@ -217,7 +222,7 @@ function dump_tree(tree, names) {
             for (var i = 0; i < node.blocks.length - 1; i++) {
                 stmt = node.blocks[i].node;
                 if (stmt.type != "AssignmentNode")
-                    throw SyntaxError("Only assignment statements are supported! " + stmt);
+                    throw SyntaxError("Expected an assignment statement before a semicolon: " + stmt);
 
                 rec(stmt.expr, bound);
                 str += ("(let ((" + stmt.name + " " + stmt.expr.res + ")) ");
@@ -267,7 +272,7 @@ function get_unused_var_warnings(tree) {
             for (var i = 0; i < node.blocks.length - 1; i++) {
                 stmt = node.blocks[i].node;
                 if (stmt.type != "AssignmentNode")
-                    throw SyntaxError("Only assignment statements are supported! " + stmt);
+                    throw SyntaxError("Expected an assignment statement before a semicolon: " + stmt);
 
                 bound.push(stmt.name);
                 usedInAssigns.push(stmt.expr.res);

--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -212,15 +212,17 @@ function dump_tree(tree, names) {
 
                 // TODO: handle name
                 let name = stmt.name;
-                let val = rec(stmt.expr, bound);
-                str += ("(let ((" + name + " " + val + ")) ");
+                let val = stmt.expr;
+                rec(val, bound);
+                str += ("(let ((" + name + " " + val.res + ")) ");
 
                 if (bound.indexOf(name) == -1)
                     bound.push(name);
             }
 
-            let body = rec(node.blocks[node.blocks.length - 1].node, bound);
-            node.res = str + body + ")".repeat(node.blocks.length - 1);
+            let body = node.blocks[node.blocks.length - 1].node
+            rec(body, bound);
+            node.res = str + body.res + ")".repeat(node.blocks.length - 1);
             return node;
         default:
             throw SyntaxError("Invalid tree!");

--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -247,12 +247,15 @@ function get_unused_var_warnings(tree) {
         case "FunctionNode":
         case "OperatorNode":
             used = new Set();
-            for (s in extract(node.args)) {
+            extract(node.args).forEach(function(s) {
                 s.forEach(function(n) { used.add(n); });
-            };
+            })
             return used;
         case "SymbolNode":
-            return new Set(node.name);
+            if (!CONSTANTS[node.name])
+                return new Set([node.name]);
+            else
+                return new Set();
         case "ConditionalNode":
             usedCond = node.condition.res;
             usedTrue  = node.trueExpr.res;
@@ -282,7 +285,6 @@ function get_unused_var_warnings(tree) {
             for (var i = node.blocks.length - 2; i >= 0; i--) {
                 if (!used.has(bound[i]))
                     unused.push("UnboundVariable: " + bound[i]);
-                
                 used.delete(bound[i]);
                 used = new Set([...used, ...usedInAssigns[i]]);
             }
@@ -316,10 +318,14 @@ function get_errors() {
 }
 
 function get_warnings() {
-    const input = document.querySelector("[name=formula-math]")
-    rangeWarnings = get_varnames_mathjs(input.value).map(varname => get_input_range_warnings(KNOWN_INPUT_RANGES[varname]).map(s => "RangeWarning: " + varname + ": " + s)).flat();
-    unusedWarnings = get_unused_var_warnings(math.parse(input.value))
-    return rangeWarnings.concat(unusedWarnings);
+    try {
+        const input = document.querySelector("[name=formula-math]")
+        rangeWarnings = get_varnames_mathjs(input.value).map(varname => get_input_range_warnings(KNOWN_INPUT_RANGES[varname]).map(s => "RangeWarning: " + varname + ": " + s)).flat();
+        unusedWarnings = get_unused_var_warnings(math.parse(input.value))
+        return rangeWarnings.concat(unusedWarnings);
+    } catch (e) {
+        return []
+    }
 }
 
 function check_errors() {

--- a/src/web/resources/demo.js
+++ b/src/web/resources/demo.js
@@ -276,7 +276,7 @@ function get_unused_var_warnings(tree) {
             // Assume each assignment is of the form:
             //  <assign> ::= <name> = <val>; <body>.
             // Then
-            //  (i)  <name> is used if n is not in Used(<body>),
+            //  (i)  <name> is used if <name> is not in Used(<body>),
             //  (ii) Used(<expr>) = Used(<val>) U (Used(<body>) \ { <name> })
             // Clearly, the assumption is slightly wrong, but this
             // tells us we just walk backwards checking condition (i)


### PR DESCRIPTION
This PR adds support for let expressions in the MathJS input box on the web demo. Users can now write `<var> = <val>; <var> = <val>; ... ; <expr>`. Hopefully, makes for a better experience.

Example shown below:

![image](https://user-images.githubusercontent.com/16217412/216229546-c0d34f93-62bd-4821-860d-c1e99e2d33c0.png)