### PR TITLE
Fix OOM due to getting sexp of proofs

### DIFF
--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2018"
 
 [dependencies]
-egg = "0.9.2"
+egg = "0.9.3"
 
 log = "0.4"
 indexmap = "1"


### PR DESCRIPTION
This PR bumps the egg version so it includes the performance bug fix