### PR TITLE
FFI memory management

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -7,7 +7,7 @@
 
 (module+ test (require rackunit))
 
-(provide with-egraph egraph-add-expr egraph-run-rules
+(provide make-egraph with-egraph egraph-add-expr egraph-run-rules
          egraph-get-simplest egraph-get-variants
          egraph-get-proof egraph-is-unsound-detected
          rule->egg-rules expand-rules get-canon-rule-name
@@ -328,6 +328,10 @@
     (free (FFIRule-right rule))
     (free rule)))
 
+
+; Makes a new egraph that is managed by Racket's GC
+(define (make-egraph)
+  (egraph-data (egraph_create) (make-hash) (make-hash)))
 
 ;; calls the function on a new egraph, and cleans up
 (define (with-egraph egraph-function)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -54,16 +54,15 @@
   
   (timeline-push! 'method "egg-herbie")
 
-  (with-egraph
-   (lambda (egg-graph)
-     (define node-ids (map (curry egraph-add-expr egg-graph) exprs))
-     (define iter-data (egraph-run-rules egg-graph (*node-limit*) rules node-ids (and precompute? true)))
+  (define egg-graph (make-egraph))
+  (define node-ids (map (curry egraph-add-expr egg-graph) exprs))
+  (define iter-data (egraph-run-rules egg-graph (*node-limit*) rules node-ids (and precompute? true)))
         
-     (when (egraph-is-unsound-detected egg-graph)
-       (warn 'unsound-rules #:url "faq.html#unsound-rules"
-             "Unsound rule application detected in e-graph. Results from simplify may not be sound."))
+  (when (egraph-is-unsound-detected egg-graph)
+    (warn 'unsound-rules #:url "faq.html#unsound-rules"
+          "Unsound rule application detected in e-graph. Results from simplify may not be sound."))
 
-     (egraph-func egg-graph node-ids iter-data))))
+  (egraph-func egg-graph node-ids iter-data))
 
 (define (get-proof input start end)
   (run-simplify-input

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -9,7 +9,7 @@
    ;; Constants are zero-ary functions
    [(? constant-operator?) (list expr)]
    ;; unfold let
-   [(list let* (list (list var val) rest ...) body)
+   [(list 'let* (list (list var val) rest ...) body)
     (replace-vars (list (cons var (expand val))) (expand `(let* ,rest ,body)))]
    [(list 'let (list (list vars vals) ...) body)
     (replace-vars (map cons vars (map expand vals)) (expand body))]


### PR DESCRIPTION
This PR makes the Racket garbage collector manage e-graphs allocated in Rust, and it fixes a double-free bug for the FFI rule cache. Some additional cleanup since `with-egraph` is no longer needed. As a side note, I attempted to have FFI rule structs be automatically reclaimed, but weird bugs started popping up on the Rust-side, presumably use-after-free.