### PR TITLE
study-server bug on demo

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -244,7 +244,7 @@
   (call-with-output-file html-file #:exists 'replace (curryr make-report-page info #f)))
 
 (define (run-improve hash formula)
-  (hash-set! *jobs* hash *timeline*)
+  (hash-set! *jobs* hash (*timeline*))
   (define sema (make-semaphore))
   (thread-send *worker-thread* (list 'improve hash formula sema))
   sema)


### PR DESCRIPTION
Fixed a small bug on the study server branch. When using the demo on localhost. 

Received the following output.
```
Exception
The application raised an exception with the message:
match: no matching clause for #<procedure:parameter-procedure>
Stack trace:
check-status at:
  line 315, column 0, in file /Users/zane/Developer/herbie/src/web/demo.rkt
```