### PR TITLE
Remove all of the `root-loc` code in `matcher.rkt`

### DIFF
--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -5,7 +5,7 @@
          "common.rkt" "syntax/types.rkt" "errors.rkt"
          "syntax/syntax.rkt")
 
-(provide generate-conversions generate-prec-rewrites *conversions* apply-repr-change)
+(provide generate-conversions generate-prec-rewrites *conversions* apply-repr-change-expr)
 
 (define *conversions* (make-parameter (hash)))
 
@@ -203,8 +203,3 @@
         (and cast (list cast expr))])]
      [_ expr])))
 
-(define (apply-repr-change prog ctx)
-  (match prog
-   [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(apply-repr-change-expr body ctx))]
-   [(list (or 'λ 'lambda) (list vars ...) body) `(λ ,vars ,(apply-repr-change-expr body ctx))]
-   [_ (apply-repr-change-expr prog ctx)]))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -58,7 +58,7 @@
 ;;  Non-recursive rewriter
 ;;
 
-(define (rewrite-once expr ctx #:rules rules #:root [root-loc '()])
+(define (rewrite-once expr ctx #:rules rules)
   ;; we want rules over representations
   (match-define (list rules* _ canon-names) (expand-rules rules))
   (define rule-apps (make-hash))
@@ -71,7 +71,7 @@
           (when result
             (define canon-name (hash-ref canon-names (rule-name rule)))
             (hash-update! rule-apps canon-name (curry + 1) 1)
-            (sow  (list (car result) root-loc)))))))
+            (sow (car result)))))))
   ;; rule statistics
   (for ([(name count) (in-hash rule-apps)])
     (when (> count 0) (timeline-push! 'rules (~a name) count)))
@@ -90,12 +90,11 @@
 (define (batch-egg-rewrite exprs
                            ctx
                            #:rules rules
-                           #:roots [root-locs (make-list (length exprs) '())]
                            #:depths [depths (make-list (length exprs) 1)])
   (define reprs (map (λ (e) (repr-of e ctx)) exprs))
   ; If unsoundness was detected, try running one epxression at a time.
   ; Can optionally set iter limit (will give up if unsoundness detected).
-  (let loop ([exprs exprs] [root-locs root-locs] [iter-limit #f])
+  (let loop ([exprs exprs] [iter-limit #f])
     ; Returns a procedure rather than the variants directly:
     ; if we need to fallback, we exit the `with-egraph` closure first
     ; so the existing egraph gets cleaned up
@@ -109,29 +108,27 @@
        (match* (exprs iter-limit)
          [((list (? list?) (? list?) (? list?) ...) #f)     ; run expressions individually
           (set! egg-graph #f)                               ; allow old egraph to be GC'd
-          (for/list ([expr exprs] [root-loc root-locs])
+          (for/list ([expr exprs])
             (timeline-push! 'method "egg-rewrite")
-            (car (loop (list expr) (list root-loc) #f)))]
+            (car (loop (list expr) #f)))]
          [((list (? list?)) #f)                             ; run expressions with iter limit
           (set! egg-graph #f)                               ; allow old egraph to be GC'd
           (define limit (- (length iter-data) 2))
           (timeline-push! 'method "egg-rewrite-iter-limit")
-          (loop exprs root-locs limit)]
+          (loop exprs limit)]
          [(_ (? number?))                                   ; give up
           (timeline-push! 'method "egg-rewrite-fail")
           '(())])]
       [else
-       (for/list ([id node-ids] [expr exprs] [root-loc root-locs] [expr-repr reprs])
+       (for/list ([id node-ids] [expr exprs] [expr-repr reprs])
          (define egg-rule (rule "egg-rr" 'x 'x (list expr-repr) expr-repr))
          (define output (egraph-get-variants egg-graph id expr))
-         (for/list ([variant (remove-duplicates output)])
-           (list variant root-loc)))])))
+         (remove-duplicates output))])))
     
 ;;  Recursive rewrite chooser
 (define (rewrite-expressions exprs
                              ctx
                              #:rules rules
-                             #:roots [root-locs (make-list (length exprs) '())]
                              #:depths [depths (make-list (length exprs) 1)]
                              #:once? [once? #f])
   ; choose correct rr driver
@@ -139,13 +136,13 @@
    [(or (null? exprs) (null? rules)) (make-list (length exprs) '())]
    [(or once? (not (flag-set? 'generate 'rr)))
     (timeline-push! 'method "rewrite-once")
-    (for/list ([expr exprs] [root-loc root-locs] [n (in-naturals 1)])
+    (for/list ([expr exprs] [n (in-naturals 1)])
       (define timeline-stop! (timeline-start! 'times (~a expr)))
-      (begin0 (rewrite-once expr ctx #:rules rules #:root root-loc)
+      (begin0 (rewrite-once expr ctx #:rules rules)
         (timeline-stop!)))]
    [else
     (timeline-push! 'method "batch-egg-rewrite")
     (timeline-push! 'inputs (map ~a exprs))
-    (define out (batch-egg-rewrite exprs ctx #:rules rules #:roots root-locs #:depths depths))
+    (define out (batch-egg-rewrite exprs ctx #:rules rules #:depths depths))
     (timeline-push! 'outputs (map ~a out))
     out]))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -44,8 +44,8 @@
               #:unless (equal? k (context-repr ctx))
               #:when (set-member? v (context-repr ctx)))
       (define rewrite (get-rewrite-operator k))
-      (define prog* `(λ ,(program-variables prog) (,rewrite ,(program-body prog))))
-      (alt (apply-repr-change prog* ctx) 'start '()))))
+      (define body* (apply-repr-change-expr (list rewrite (program-body prog)) ctx))
+      (alt `(λ ,(program-variables prog) ,body*) 'start '()))))
 
 ;; Information
 (define (list-alts)

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -153,8 +153,6 @@
   ;; get subexprs and locations
   (define exprs (map (compose program-body alt-program) (^queued^)))
   (define lowexprs (map (compose program-body alt-program) (^queuedlow^)))
-  (define locs (make-list (length (^queued^)) '(2)))          ;; always at the root
-  (define lowlocs (make-list (length (^queuedlow^)) '(2)))    ;; always at the root
 
   ;; HACK:
   ;; - check loaded representations
@@ -166,32 +164,29 @@
   (define changelists
     (if one-real-repr?
         (merge-changelists
-          (rewrite-expressions exprs (*context*) #:rules (append expansive-rules normal-rules) #:roots locs)
-          (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:roots locs #:once? #t))
+          (rewrite-expressions exprs (*context*) #:rules (append expansive-rules normal-rules))
+          (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:once? #t))
         (merge-changelists
-          (rewrite-expressions exprs (*context*) #:rules normal-rules #:roots locs)
-          (rewrite-expressions exprs (*context*) #:rules expansive-rules #:roots locs #:once? #t)
-          (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:roots locs #:once? #t))))
+          (rewrite-expressions exprs (*context*) #:rules normal-rules)
+          (rewrite-expressions exprs (*context*) #:rules expansive-rules #:once? #t)
+          (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:once? #t))))
 
   ;; rewrite low-error locations (only precision changes allowed)
   (define changelists-low-locs
-    (rewrite-expressions lowexprs (*context*)
-                         #:rules reprchange-rules
-                         #:roots lowlocs
-                         #:once? #t))
+    (rewrite-expressions lowexprs (*context*) #:rules reprchange-rules #:once? #t))
 
   (define comb-changelists (append changelists changelists-low-locs))
   (define altns (append (^queued^) (^queuedlow^)))
   
+  (define variables (program-variables (alt-program (first altns))))
   (define rewritten
     (for/fold ([done '()] #:result (reverse done))
               ([cls comb-changelists] [altn altns]
-              #:when true [cl cls])
-        (match-define (list subexp loc) cl)
-        (define change-app (location-do loc (alt-program altn) (const subexp)))
-        (define prog* (apply-repr-change change-app (*context*)))
-        (if (program-body prog*)
-            (cons (alt prog* (list 'change loc) (list altn)) done)
+               #:when true [subexp cls])
+        (define body* (apply-repr-change-expr subexp (*context*)))
+        (if body*
+            ; We need to pass '(2) here so it can get overwritten on patch-fix
+            (cons (alt `(λ ,variables ,body*) (list 'change '(2)) (list altn)) done)
             done)))
 
   (timeline-push! 'count (length (^queued^)) (length rewritten))


### PR DESCRIPTION
This PR follows up on #559 to remove the last remnants of `root-loc` handling in `rewrite-once`.

*Short story*: After a series of refactors, there was a lot of code in `patch.rkt` and `matcher.rkt` dedicated to passing around and carefully accounting for a constant value. We can just rip all of that out!

*Long story*: When the recursive rewriter was originally written, it was intended to produce a "proof" of its output by recording each rewrite it applied and the location where it applied it. The recursive rewriter was passed a "root" location, but it would rewrite at various locations below that root. In this case it made sense that the root was passed in and then different locations would come back.

However, when we switched from `rr` to `egg-rr`, we stopped getting back detailed derivations, so the locations thing didn't make any sense. And additionally, when we split the patch loop, we also stopped passing _in_ any location besides `'(2)`. So at this point the whole thing became a farce: we were passing in a constant location and getting that constant location spat back to us! So this PR finally removes that left-over oddity.