### PR TITLE
Rename results.html to index.html

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -75,7 +75,7 @@ jobs:
       - run: racket src/herbie.rkt report bench/tutorial.fpcore /tmp/out/
       - run: test -d /tmp/out/
         name: "Test that report created a directory"
-      - run: test -f /tmp/out/results.html
-        name: "Test that report created a results.html"
+      - run: test -f /tmp/out/index.html
+        name: "Test that report created a index.html"
       - run: test -f /tmp/out/results.json
         name: "Test that report created a results.json"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 
 # Standard directories
+reports
 previous
 graphs
 www/demo

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -124,7 +124,7 @@
            (td ,(if (> (field 'tests-available) 0) (format "~a/~a" (field 'tests-passed) (field 'tests-available)) ""))
            (td ,(if (field 'bits-improved) (format "~a/~a" (round* (field 'bits-improved)) (round* (field 'bits-available))) ""))
            (td ([title ,(format "At ~a\nOn ~a\nFlags ~a" (field 'date-full) (field 'hostname) (string-join (field 'options) " "))])
-               (a ([href ,(format "./~a/results.html" (field 'folder))]) "»")))))))
+               (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
 
 (define (make-index-page folders out)
   (define branch-infos

--- a/infra/merge.rkt
+++ b/infra/merge.rkt
@@ -47,7 +47,7 @@
   (define dfs (map car rss))
   (define joint-rs (merge-datafiles dfs #:dirs dirs #:name name))
   (write-datafile (build-path outdir "results.json") joint-rs)
-  (call-with-output-file (build-path outdir "results.html")
+  (call-with-output-file (build-path outdir "index.html")
     #:exists 'replace
     (curryr make-report-page joint-rs outdir #:merge-data rss)))
 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -166,9 +166,9 @@
             '("formulas submitted here are not logged.")]
            [(*demo?*)
             `("all formulas submitted here are logged and made public."
-              (a ([href "./results.html"])" See what formulas other users submitted."))]
+              (a ([href "./index.html"])" See what formulas other users submitted."))]
            [else
-            `("all formulas submitted here are " (a ([href "./results.html"]) "logged") ".")])))))
+            `("all formulas submitted here are " (a ([href "./index.html"]) "logged") ".")])))))
 
 (define *completed-jobs* (make-hash))
 (define *jobs* (make-hash))
@@ -211,7 +211,7 @@
                     (λ (out) (make-page page out result #f)))))
               (update-report result path seed
                              (build-path (*demo-output*) "results.json")
-                             (build-path (*demo-output*) "results.html")))
+                             (build-path (*demo-output*) "index.html")))
 
             (eprintf " complete\n")
             (hash-remove! *jobs* hash)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -93,7 +93,7 @@
          '("Derivation" . "#history")
          '("Reproduce" . "#reproduce"))
         (list
-         '("Report" . "../results.html")
+         '("Report" . "../index.html")
          '("Metrics" . "timeline.html")))
 
       (section ([id "large"])

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -20,7 +20,7 @@
     (table
       (tr (th "Subreport") (th "Time") (th "Passed") (th "Tests") (th "Bits"))
       ,@(for/list ([report reports] [path paths])
-          (let ([index (path->string (build-path path "results.html"))]
+          (let ([index (path->string (build-path path "index.html"))]
                 [time (apply + (map table-row-time (report-info-tests report)))]
                 [passed (for/sum ([row (report-info-tests report)])
                           (if (member (table-row-status row)

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -64,7 +64,7 @@
   (write-datafile (build-path dir "results.json") info)
   (copy-file (web-resource "report.js") (build-path dir "report.js") #t)
   (copy-file (web-resource "report.css") (build-path dir "report.css") #t)
-  (call-with-output-file (build-path dir "results.html")
+  (call-with-output-file (build-path dir "index.html")
     (curryr make-report-page info dir) #:exists 'replace)
   (define timeline (merge-timeline-jsons (read-json-files info dir "timeline.json")))
   (call-with-output-file (build-path dir "timeline.json") (curry write-json timeline) #:exists 'replace)
@@ -96,6 +96,6 @@
 (define (diff-report old new)
   (define df (diff-datafiles (read-datafile (build-path old "results.json"))
                              (read-datafile (build-path new "results.json"))))
-  (call-with-output-file (build-path new "results.html")
+  (call-with-output-file (build-path new "index.html")
     #:exists 'replace
     (curryr make-report-page df #f)))

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -24,7 +24,7 @@
           '("Timeline" . "#process-info")
           '("Profile" . "#profile"))
          (if info 
-             `(("Report" . "results.html"))
+             `(("Report" . "index.html"))
              `(("Details" . "graph.html"))))
        ,(if info (render-about info) "")
        ,(render-timeline timeline)

--- a/src/web/traceback.rkt
+++ b/src/web/traceback.rkt
@@ -23,7 +23,7 @@
       ,(render-menu
         (list)
         (list
-         '("Report" . "../results.html")
+         '("Report" . "../index.html")
          '("Metrics" . "timeline.html")))
 
       ,(render-warnings warnings)


### PR DESCRIPTION
Rename `results.html` to `index.html` in reports so that the results page shows up by default. 