### PR TITLE
More verbose command line --help flag

### DIFF
--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -5,7 +5,8 @@ authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2018"
 
 [dependencies]
-egg = "0.9.4"
+# egg = "0.9.4"
+egg = { git="https://github.com/egraphs-good/egg", rev="f7e9fd6cb87136d48f5275c8f60d98173ffc170a" }
 
 log = "0.4"
 indexmap = "1"

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -35,7 +35,7 @@
     [('generate 'better-rr)
      (eprintf "The generate:better-rr option has been removed.\n")
      (eprintf "  The current recursive rewriter does not support the it.\n")
-     (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
+     (eprintf "See <https://herbie.uwplse.org/doc/~a/options.html> for more.\n" *herbie-version*)]
     [(_ _)
      (void)]))
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -28,10 +28,6 @@
      (eprintf "The precision:fallback option has been removed.\n")
      (eprintf "  The fallback representation is specified with :precision racket.\n")
      (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
-    [('precision 'fallback)
-     (eprintf "The precision:fallback option has been removed.\n")
-     (eprintf "  Please use :precision racket instead.\n")
-     (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
     [('generate 'better-rr)
      (eprintf "The generate:better-rr option has been removed.\n")
      (eprintf "  The current recursive rewriter does not support the it.\n")
@@ -51,6 +47,13 @@
 
 (define (flag-set? class flag)
   (set-member? (dict-ref (*flags*) class) flag))
+
+(define (flag-deprecated? category flag)
+  (match* (category flag)
+    [('precision 'double) #t]
+    [('precision 'fallback) #t]
+    [('generate 'better-rr) #t]
+    [(_ _) #f]))
 
 ; `hash-copy` returns a mutable hash, which makes `dict-update` invalid
 (define *flags* (make-parameter (make-immutable-hash (hash->list default-flags))))

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -31,7 +31,7 @@
                            (~a "default?" #:min-width 10))
     (~a "" #:min-width 44 #:pad-string "=")
     (for*/list ([(category flags) (in-hash all-flags)]
-                [flag (in-list flags)])
+                [flag (in-list flags)] #:unless (flag-deprecated? category flag))
       (format "~a | ~a | ~a" (~a category #:min-width 10)
                              (~a flag #:min-width 20)
                              (if (flag-set? category flag) "\u2714" "")))))
@@ -117,7 +117,7 @@
     (
      "Enable a flag (formatted category:name)"
      (format "See https://herbie.uwplse.org/doc/~a/options.html for more" *herbie-version*)
-     (apply string-append "\n"
+     (apply string-append "\n"  ;; 5 spaces is the padding inserted by `command-line`
             (map (curry format "     ~a\n") (default-flags->table)))
     )
     (define tf (string->flag flag))

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -59,21 +59,49 @@
   (multi-command-line
    #:program "herbie"
    #:once-each
-   [("--timeout") s "Timeout for each test (in seconds)"
+   [("--timeout") s
+    (
+     "Timeout for each test (in seconds)"
+     (format "[Default: ~a seconds]" (/ (*timeout*) 1000))
+    )
     (set! timeout-set? #t)
     (*timeout* (* 1000 (string->number s)))]
-   [("--seed") int "The random seed to use in point generation"
+   [("--seed") int
+    (
+     "The random seed to use in point generation"
+     "[Default: random]"
+    )
     (define given-seed (read (open-input-string int)))
     (when given-seed (set-seed! given-seed))]
-   [("--num-iters") num "The number of iterations to use for the main loop"
+   [("--num-iters") num
+    (
+     "The number of iterations to use for the main loop"
+     (format "[Default: ~a iterations]" (*num-iterations*))
+    )
     (*num-iterations* (string->number num))]
-   [("--num-points") num "The number of points to use during sampling"
+   [("--num-points") num
+    (
+     "The number of points to use during sampling"
+     (format "[Default: ~a points]" (*num-points*))
+    )
     (*num-points* (string->number num))]
-   [("--num-enodes") num "The number of enodes to use during simplification"
+   [("--num-enodes") num
+    (
+     "The number of enodes to use during simplification"
+     (format "[Default: ~a enodes]" (*node-limit*))
+    )
     (*node-limit* (string->number num))]
-   [("--num-analysis") num "The number of input analysis iterations to use"
+   [("--num-analysis") num
+    (
+     "The number of input analysis iterations to use"
+     (format "[Default: ~a iterations]" (*max-find-range-depth*))
+    )
     (*max-find-range-depth* (string->number num))]
-   [("--no-pareto") "Disables Pareto-Herbie (Pherbie)"
+   [("--no-pareto")
+    (
+     "Disables Pareto-Herbie (Pherbie)"
+     "[Default: Pareto-Herbie enabled]"
+    )
     (*pareto-mode* #f)]
    #:multi
    [("-o" "--disable") flag

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -13,7 +13,11 @@
  ["improve.rkt" (run-improve)])
 
 (define (string->thread-count th)
-  (match th ["no" #f] ["yes" (max (- (processor-count) 1) 1)] [_ (string->number th)]))
+  (match th
+    ["no" #f]
+    ["yes" (max (- (processor-count) 1) 1)]
+    [(? positive-integer?) (string->number th)]
+    [_ (error 'string->thread-count "Invalid thread count ~a" th)]))
 
 (define (string->flag s)
   (match (string-split s ":")

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -16,8 +16,10 @@
   (match th
     ["no" #f]
     ["yes" (max (- (processor-count) 1) 1)]
-    [(? positive-integer?) (string->number th)]
-    [_ (error 'string->thread-count "Invalid thread count ~a" th)]))
+    [else
+     (match (string->number th)
+       [(? positive-integer? x) x]
+       [else (error 'string->thread-count "invalid thread count ~a" th)])]))
 
 (define (string->flag s)
   (match (string-split s ":")

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -73,8 +73,6 @@
     (*node-limit* (string->number num))]
    [("--num-analysis") num "The number of input analysis iterations to use"
     (*max-find-range-depth* (string->number num))]
-   [("--pareto") "Enables Pareto-Herbie (Pherbie)"
-    (*pareto-mode* #t)]
    [("--no-pareto") "Disables Pareto-Herbie (Pherbie)"
     (*pareto-mode* #f)]
    #:multi

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -61,53 +61,59 @@
    #:once-each
    [("--timeout") s
     (
-     "Timeout for each test (in seconds)"
+     "Timeout for each test (in seconds)."
      (format "[Default: ~a seconds]" (/ (*timeout*) 1000))
     )
     (set! timeout-set? #t)
     (*timeout* (* 1000 (string->number s)))]
    [("--seed") int
     (
-     "The random seed to use in point generation"
+     "The random seed to use in point generation."
      "[Default: random]"
     )
     (define given-seed (read (open-input-string int)))
     (when given-seed (set-seed! given-seed))]
    [("--num-iters") num
     (
-     "The number of iterations to use for the main loop"
+     "The number of iterations to use for the main loop. Herbie may find additional improvements
+     with more iterations. Herbie slows down with more iterations."
      (format "[Default: ~a iterations]" (*num-iterations*))
     )
     (*num-iterations* (string->number num))]
    [("--num-points") num
     (
-     "The number of points to use during sampling"
+     "The number of points to use during sampling. Increasing the number of points may make results
+     more consistent, but may slow down Herbie."
      (format "[Default: ~a points]" (*num-points*))
     )
     (*num-points* (string->number num))]
    [("--num-enodes") num
     (
-     "The number of enodes to use during simplification"
+     "The maximum number of enodes to use during egraph-based rewriting. Herbie may find additional
+     improvements with a higher limit, but run time increases exponentially."
      (format "[Default: ~a enodes]" (*node-limit*))
     )
     (*node-limit* (string->number num))]
    [("--num-analysis") num
     (
-     "The number of input analysis iterations to use"
+     "The number of input analysis iterations used when searching for valid input points
+     during sampling. May fix \"Cannot sample enough valid points\" but will slow."
      (format "[Default: ~a iterations]" (*max-find-range-depth*))
     )
     (*max-find-range-depth* (string->number num))]
    [("--no-pareto")
     (
-     "Disables Pareto-Herbie (Pherbie)"
+     "Disables Pareto-Herbie (Pherbie). Pareto-mode performs accuracy and expression cost
+     optimization and extracts multiple output expressions that are Pareto-optimal. Disabling
+     this feature forces Herbie to extract a single, most-accurate output expression."
      "[Default: Pareto-Herbie enabled]"
     )
     (*pareto-mode* #f)]
    #:multi
    [("-o" "--disable") flag
     (
-     "Disable a flag (formatted category:name)"
-     "See `+o/--enable` for the full list of flags"
+     "Disable a search flag (formatted category:name)."
+     "See `+o/--enable` for the full list of search flags."
     )
     (define tf (string->flag flag))
     (when (not tf)
@@ -115,8 +121,9 @@
     (apply disable-flag! tf)]
    [("+o" "--enable") flag
     (
-     "Enable a flag (formatted category:name)"
-     (format "See https://herbie.uwplse.org/doc/~a/options.html for more" *herbie-version*)
+     "Enable a search flag (formatted category:name)."
+     (format "Description of each search flag: https://herbie.uwplse.org/doc/~a/options.html."
+             *herbie-version*)
      (apply string-append "\n"  ;; 5 spaces is the padding inserted by `command-line`
             (map (curry format "     ~a\n") (default-flags->table)))
     )

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -24,6 +24,18 @@
       (list category flag))]
     [_ #f]))
 
+(define (default-flags->table)
+  (list*
+    (format "~a | ~a | ~a" (~a "category" #:min-width 10)
+                           (~a "flag" #:min-width 20)
+                           (~a "default?" #:min-width 10))
+    (~a "" #:min-width 44 #:pad-string "=")
+    (for*/list ([(category flags) (in-hash all-flags)]
+                [flag (in-list flags)])
+      (format "~a | ~a | ~a" (~a category #:min-width 10)
+                             (~a flag #:min-width 20)
+                             (if (flag-set? category flag) "\u2714" "")))))
+
 (module+ main
   (define quiet? #f)
   (define demo-output #f)
@@ -66,12 +78,22 @@
    [("--no-pareto") "Disables Pareto-Herbie (Pherbie)"
     (*pareto-mode* #f)]
    #:multi
-   [("-o" "--disable") flag "Disable a flag (formatted category:name)"
+   [("-o" "--disable") flag
+    (
+     "Disable a flag (formatted category:name)"
+     "See `+o/--enable` for the full list of flags"
+    )
     (define tf (string->flag flag))
     (when (not tf)
       (raise-herbie-error "Invalid flag ~a" flag #:url "options.html"))
     (apply disable-flag! tf)]
-   [("+o" "--enable") flag "Enable a flag (formatted category:name)"
+   [("+o" "--enable") flag
+    (
+     "Enable a flag (formatted category:name)"
+     (format "See https://herbie.uwplse.org/doc/~a/options.html for more" *herbie-version*)
+     (apply string-append "\n"
+            (map (curry format "     ~a\n") (default-flags->table)))
+    )
     (define tf (string->flag flag))
     (when (not tf)
       (raise-herbie-error "Invalid flag ~a" flag #:url "options.html"))


### PR DESCRIPTION
This PR addresses issues raised in #541. When `--help` is supplied via the command line, Herbie now prints more details about each of the command line flags.

- [x] Remove `--pareto`
- [x] Show all search flags that can be enabled/disabled
- [x] Show defaults for each command-line flag
- [x] Short description of what changing the default may do
- [x] Missing command-line options in web documentation