### PR TITLE
Don't rewrite boolean expressions

### DIFF
--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -154,6 +154,7 @@
     ;; get subexprs and locations
     (define exprs (map alt-expr (^queued^)))
     (define lowexprs (map alt-expr (^queuedlow^)))
+    (define real-exprs (filter (λ (e) (equal? (type-of e (*context*)) 'real)) exprs))
 
     ;; HACK:
     ;; - check loaded representations
@@ -165,10 +166,10 @@
     (define changelists
       (if one-real-repr?
           (merge-changelists
-            (rewrite-expressions exprs (*context*) #:rules (append expansive-rules normal-rules))
+            (rewrite-expressions real-exprs (*context*) #:rules (append expansive-rules normal-rules))
             (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:once? #t))
           (merge-changelists
-            (rewrite-expressions exprs (*context*) #:rules normal-rules)
+            (rewrite-expressions real-exprs (*context*) #:rules normal-rules)
             (rewrite-expressions exprs (*context*) #:rules expansive-rules #:once? #t)
             (rewrite-expressions exprs (*context*) #:rules reprchange-rules #:once? #t))))
 

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -57,9 +57,17 @@
 (define (errors expr pcontext ctx)
   (map first (batch-errors (list expr) pcontext ctx)))
 
+(define ((batch-errors-handler exprs point) e)
+  (raise e)
+  (eprintf "Error during batch-errors with exprs:\n")
+  (for ([expr (in-list exprs)])
+    (eprintf "  ~a\n" expr))
+  (eprintf "on point ~a\n" point)
+  (raise e))
+
 (define (batch-errors exprs pcontext ctx)
   (define fn (batch-eval-progs exprs 'fl ctx))
   (for/list ([(point exact) (in-pcontext pcontext)])
-    (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" exprs point) (raise e))])
+    (with-handlers ([exn:fail? (batch-errors-handler exprs point)])
       (for/list ([out (in-list (apply fn point))])
         (point-error out exact (context-repr ctx))))))


### PR DESCRIPTION
This PR fixes an issue discovered in #578, whereby Herbie would sometimes attempt to rewrite a boolean expression and thereby produce expressions like `(*.f64 1.0 (>= b 0))`, which are nonsense and would cause Herbie to crash.

The fix is to just not rewrite expressions whose type isn't `'real` with expansive rules.