### PR TITLE
More Pareto tweaks

### DIFF
--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -53,7 +53,7 @@
 (define/contract (compute-row folder)
   (-> path? cache-row?)
   (define info (read-datafile (build-path folder "results.json")))
-  (match-define (report-info date commit branch hostname seed flags points iterations note tests) info)
+  (match-define (report-info date commit branch hostname seed flags points iterations note tests merged-cost-accuracy) info)
 
   (define-values (total-start total-end)
     (for/fold ([start 0] [end 0]) ([row (or tests '())])

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -68,13 +68,13 @@
           (link . ,(~a link))
           (cost-accuracy . ,cost-accuracy*)))]))
 
-  ;; Calculate the maximum cost and accuracy, the initial cost and accuracy, and
-  ;; the combined and rescaled Pareto frontier and return these as a list.
+  ;; Calculate the maximum cost and accuracy, initial cost and accuracy, and
+  ;; the rescaled and combined Pareto frontier for the given `tests` and return
+  ;; these as a list.
   ;;
-  ;; Each test's Pareto curve is rescaled to be relative to it's initial cost,
-  ;; then they are combined with `pareto-combine`, and then each Pareto efficient
-  ;; point's cost is divided by the number of tests so that the frontier's cost
-  ;; is relative to the combination of the initial costs.
+  ;; Each test's Pareto curve is rescaled so cost is relative to the initial input. They are combined with `pareto-combine`, and then each point's x-value in the combined curve is divided by the number of tests so that the overall cost is relative to the combination of the initial programs.
+  ;;
+  ;; TODO: speedup at initial accuracy
   (define (merged-cost-accuracy tests)
     (define cost-accuracies (map table-row-cost-accuracy tests))
     (define rescaled
@@ -108,6 +108,7 @@
     (define maximum-accuracy
       (for/sum ([test (in-list tests)])
         (representation-total-bits (get-representation (table-row-precision test)))))
+    (define initial-cost (if (zero? tests-length) 0.0 1.0))
     (define initial-accuracy
       (for/sum ([cost-accuracy (in-list cost-accuracies)]
                 #:unless (null? cost-accuracy))
@@ -115,10 +116,7 @@
           [(list (list _ initial-accuracy) _ _) initial-accuracy])))
     (list
      (list maximum-cost maximum-accuracy)
-     (list
-      ;; All costs relative to this, would be `initial-cost`
-      (if (zero? tests-length) 0.0 1.0)
-      initial-accuracy)
+     (list initial-cost initial-accuracy)
      frontier))
 
   (define data

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -206,8 +206,8 @@
     (set! dirs (map (const #f) dfs)))
   (define tests
     (for/list ([df (in-list dfs)] [dir (in-list dirs)]
-                                  #:when true
-                                  [test (in-list (report-info-tests df))])
+               #:when true
+               [test (in-list (report-info-tests df))])
       (struct-copy table-row test
                    [link (if dir
                              (format "~a/~a" dir (table-row-link test))

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -6,7 +6,7 @@
 (provide
  (struct-out table-row) (struct-out report-info)
  make-report-info read-datafile write-datafile
- merge-datafiles diff-datafiles merged-cost-accuracy)
+ merge-datafiles diff-datafiles)
 
 
 (struct table-row

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -67,7 +67,7 @@
      (match-lambda
        [(list cost accuracy)
         (list
-         ;; TODO: I think this is always the same as (/ tests-length cost)
+         ;; Equivalent to (/ 1 (/ cost tests-length))
          (/ 1 (/ cost tests-length))
          (- 1 (/ accuracy maximum-accuracy)))])
      (pareto-combine rescaled #:convex? #t)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -68,10 +68,12 @@
         (table-row-precision t)))))
   (match-define (list (list _ initial-accuracy) frontier) merged-cost-accuracy)
   (define speedup-at-initial-accuracy
-    ;; The cost of the point that minimizes distance from the initial-accuracy
-    (first (argmin
-            (lambda (point) (abs (- initial-accuracy (second point))))
-            frontier)))
+    ;; The `frontier`'s accuracies are descending, so here we're searching from
+    ;; the end backwards to get the cost of the first point with an accuracy
+    ;; higher than that of the initial point's
+    (for/first ([point (reverse frontier)]
+                #:when (> (second point) initial-accuracy))
+      (first point)))
 
   (define (round* x)
     (inexact->exact (round x)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -68,11 +68,10 @@
      frontier)
     (merged-cost-accuracy tests))
   (define speedup-at-initial-accuracy
-    (match
-        (findf
-         (match-lambda [(list _ accuracy) (> accuracy initial-accuracy)])
-         frontier)
-    [(list cost _) (/ 1 cost)]))
+    (/ 1 (first 
+          (findf
+           (lambda (point) (> (second point) initial-accuracy))
+           frontier))))
 
   (define (round* x)
     (inexact->exact (round x)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -40,7 +40,7 @@
                  (td ,(~a (round* (- start gained))) "/" ,(~a (round* start)))))))))
 
 (define (make-report-page out info dir #:merge-data [merge-data #f])
-  (match-define (report-info date commit branch hostname seed flags points iterations note tests) info)
+  (match-define (report-info date commit branch hostname seed flags points iterations note tests merged-cost-accuracy) info)
 
   ; (define reprs (map (compose get-representation table-row-precision) trs))
 

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -61,11 +61,17 @@
     (for/sum ([t tests]) (or (table-row-start t) 0)))
   (define total-result
     (for/sum ([t tests]) (or (table-row-result t) 0)))
-  (match-define (list _ (list _ initial-accuracy) frontier) merged-cost-accuracy)
+  (define maximum-accuracy
+    (for/sum ([test (in-list tests)])
+      (representation-total-bits
+       (get-representation
+        (table-row-precision test)))))
+  (match-define (list (list _ initial-accuracy) frontier) merged-cost-accuracy)
   (define speedup-at-initial-accuracy
-    (first (findf
-            (lambda (point) (> (second point) initial-accuracy))
-            frontier))))
+    ;; The cost of the point that minimizes distance from the initial-accuracy
+    (first (argmin
+            (lambda (point) (abs (- initial-accuracy (second point))))
+            frontier)))
 
   (define (round* x)
     (inexact->exact (round x)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -61,17 +61,11 @@
     (for/sum ([t tests]) (or (table-row-start t) 0)))
   (define total-result
     (for/sum ([t tests]) (or (table-row-result t) 0)))
-  (match-define
-    (list
-     (list _ maximum-accuracy)
-     (list _ initial-accuracy)
-     frontier)
-    (merged-cost-accuracy tests))
+  (match-define (list _ (list _ initial-accuracy) frontier) merged-cost-accuracy)
   (define speedup-at-initial-accuracy
-    (/ 1 (first 
-          (findf
-           (lambda (point) (> (second point) initial-accuracy))
-           frontier))))
+    (first (findf
+            (lambda (point) (> (second point) initial-accuracy))
+            frontier))))
 
   (define (round* x)
     (inexact->exact (round x)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -67,6 +67,12 @@
      (list _ initial-accuracy)
      frontier)
     (merged-cost-accuracy tests))
+  (define speedup-at-initial-accuracy
+    (match
+        (findf
+         (match-lambda [(list _ accuracy) (> accuracy initial-accuracy)])
+         frontier)
+    [(list cost _) (/ 1 cost)]))
 
   (define (round* x)
     (inexact->exact (round x)))
@@ -108,15 +114,7 @@
                       (format-accuracy total-result maximum-accuracy #:unit "%"))
        ,(render-large "Time" (format-time total-time #:max 'minute))
        ,(render-large "Crashes and Timeouts" (~a (+ total-crashes total-timeouts)) "/" (~a total-tests))
-       ,(render-large "Speedup at Initial Accuracy"
-                      (match-let ([(list cost _)
-                                   (argmin
-                                    (match-lambda [(list _ accuracy)
-                                                   (-
-                                                    (- 1 (/ accuracy maximum-accuracy))
-                                                    (- 1 (/ initial-accuracy maximum-accuracy)))])
-                                    frontier)])
-                        (format "~ax" (~r (/ 1 cost) #:precision 1)))))
+       ,(render-large "Speedup at Initial Accuracy" (format "~a×" (~r speedup-at-initial-accuracy #:precision 1))))
 
       (figure
        (div ([id "xy"])

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -62,10 +62,10 @@
   (define total-result
     (for/sum ([t tests]) (or (table-row-result t) 0)))
   (define maximum-accuracy
-    (for/sum ([test (in-list tests)])
+    (for/sum ([t (in-list tests)])
       (representation-total-bits
        (get-representation
-        (table-row-precision test)))))
+        (table-row-precision t)))))
   (match-define (list (list _ initial-accuracy) frontier) merged-cost-accuracy)
   (define speedup-at-initial-accuracy
     ;; The cost of the point that minimizes distance from the initial-accuracy

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -99,9 +99,7 @@
               (div ([id "subreports"] [style "display: none"]))))))
 
       (div ((id "large"))
-       ;; TODO minutes
        ,(render-large "Average Accuracy"
-                      ;; TODO ulps->bits ?
                       (format-accuracy total-start total-bits #:unit "%")
                       " → "
                       (format-accuracy total-result total-bits #:unit "%"))
@@ -117,12 +115,12 @@
                         "and vertical position shows final accuracy. "
                         "Points above the line are improved by Herbie."))
        (div ([id "pareto"])
-            (h2 "Accuracy vs Cost")
+            (h2 "Accuracy vs Speed")
             (svg)
-            (figcaption "A joint cost-accuracy pareto curve for the "
+            (figcaption "A joint speed-accuracy pareto curve for the "
                         "Herbie runs below. Accuracy is on the vertical "
-                        "axis, and cost is on the horizontal axis. Down "
-                        "and to the left is better. The initial programs "
+                        "axis, and speed is on the horizontal axis. Up "
+                        "and to the right is better. The initial programs "
                         "are shown by the red square.")
             ))
 

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -8,7 +8,7 @@ figure { margin: 0; }
 
 #large { margin: 2em 0; text-align: center; }
 #large div { margin: 0 1em; display: inline-block; vertical-align: top; }
-#large .number { font-size: 3em; display: block; }
+#large .number { font-size: 2em; display: block; }
 @media print { #large { margin-top: 0; }}
 
 /* Plots at the top */

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -334,28 +334,22 @@ const MergedCostAccuracy = new Component('#pareto', {
         });
         let stub = this.elt.querySelector("svg");
         let json = await response.json();
-        this.elt.replaceChild(this.plot(json["cost-accuracy"], json.tests.length), stub)
+        const [initial, frontier] = json["merged-cost-accuracy"];
+        this.elt.replaceChild(this.plot(initial, frontier), stub)
     },
 
-    plot: function(speedAccuracy) {
-        const accuracyMax = speedAccuracy[0][1];
-        const initial = speedAccuracy[1];
-        const frontier = speedAccuracy[2];
+    plot: function(initial, frontier) {
         const out = Plot.plot({
             marks: [
+                Plot.dot([initial], {
+                    stroke: "#d00",
+                    symbol: "square",
+                    strokeWidth: 2,
+                }),
                 Plot.line(frontier, {
-                    x: p => 1 / p[0],
-                    y: p => 1 - (p[1] / accuracyMax),
                     stroke: "#00a",
                     strokeWidth: 2,
                 }),
-                Plot.dot([initial], {
-                    x: p => 1 / p[0],
-                    y: p => 1 - (p[1] / accuracyMax),
-                    stroke: "#d00",
-                    symbol: "square",
-                    strokeWidth: 2
-                })
             ],
             width: '400',
             height: '400',

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -337,7 +337,7 @@ const MergedCostAccuracy = new Component('#pareto', {
         this.elt.replaceChild(this.plot(json["cost-accuracy"], json.tests.length), stub)
     },
 
-    plot: function(speedAccuracy, testsLength) {
+    plot: function(speedAccuracy) {
         const accuracyMax = speedAccuracy[0][1];
         const initial = speedAccuracy[1];
         const frontier = speedAccuracy[2];

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -337,23 +337,32 @@ const MergedCostAccuracy = new Component('#pareto', {
         this.elt.replaceChild(this.plot(json["cost-accuracy"], json.tests.length), stub)
     },
 
-    plot: function(json, n) {
-        const sortLine = [...json[2]];
-        sortLine.sort((a, b) => {return a[0]-b[0]});
-        const ymax = 64 * n;
+    plot: function(speedAccuracy, testsLength) {
+	const accuracyMax = speedAccuracy[0][1];
+	const initial = speedAccuracy[1];
+	const frontier = speedAccuracy[2];
         const out = Plot.plot({
             marks: [
-                Plot.line(sortLine, {x: d => d[0], y: d => 1 - d[1] / ymax,
-                                     stroke: "#00a", strokeWidth: 2}),
-                Plot.dot(json[1], {x: json[1][0], y: 1 - json[1][1] / ymax,
-                                   stroke: "#d00", symbol: "square", strokeWidth: 2})
+		Plot.line(frontier, {
+		    x: p => 1 / p[0],
+		    y: p => 1 - (p[1] / accuracyMax),
+                    stroke: "#00a",
+		    strokeWidth: 2,
+		}),
+		Plot.dot([initial], {
+		    x: p => 1 / p[0],
+		    y: p => 1 - (p[1] / accuracyMax),
+                    stroke: "#d00",
+		    symbol: "square",
+		    strokeWidth: 2
+		})
             ],
             width: '400',
             height: '400',                
-            x: { line: true, },
+            x: { line: true, nice: true, tickFormat: x => `${x}x` },
             y: { line: true, nice: true, domain: [0, 1], tickFormat: "%", },
-            marginBottom: 0,
-            marginRight: 0,
+	    marginBottom: 0,
+	    marginRight: 0
         })
         out.setAttribute('viewBox', '0 0 420 420')
         return out;

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -338,31 +338,31 @@ const MergedCostAccuracy = new Component('#pareto', {
     },
 
     plot: function(speedAccuracy, testsLength) {
-	const accuracyMax = speedAccuracy[0][1];
-	const initial = speedAccuracy[1];
-	const frontier = speedAccuracy[2];
+        const accuracyMax = speedAccuracy[0][1];
+        const initial = speedAccuracy[1];
+        const frontier = speedAccuracy[2];
         const out = Plot.plot({
             marks: [
-		Plot.line(frontier, {
-		    x: p => 1 / p[0],
-		    y: p => 1 - (p[1] / accuracyMax),
+                Plot.line(frontier, {
+                    x: p => 1 / p[0],
+                    y: p => 1 - (p[1] / accuracyMax),
                     stroke: "#00a",
-		    strokeWidth: 2,
-		}),
-		Plot.dot([initial], {
-		    x: p => 1 / p[0],
-		    y: p => 1 - (p[1] / accuracyMax),
+                    strokeWidth: 2,
+                }),
+                Plot.dot([initial], {
+                    x: p => 1 / p[0],
+                    y: p => 1 - (p[1] / accuracyMax),
                     stroke: "#d00",
-		    symbol: "square",
-		    strokeWidth: 2
-		})
+                    symbol: "square",
+                    strokeWidth: 2
+                })
             ],
             width: '400',
-            height: '400',                
-            x: { line: true, nice: true, tickFormat: x => `${x}x` },
+            height: '400',
+            x: { line: true, nice: true, tickFormat: c => c + "×" },
             y: { line: true, nice: true, domain: [0, 1], tickFormat: "%", },
-	    marginBottom: 0,
-	    marginRight: 0
+            marginBottom: 0,
+            marginRight: 0,
         })
         out.setAttribute('viewBox', '0 0 420 420')
         return out;

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -360,7 +360,7 @@
 ;; This next part handles summarizing several timelines into one details section for the report page.
 
 (define (render-about info)
-  (match-define (report-info date commit branch hostname seed flags points iterations note tests) info)
+  (match-define (report-info date commit branch hostname seed flags points iterations note tests merged-cost-accuracy) info)
 
   `(table ((id "about"))
      (tr (th "Date:") (td ,(date->string date)))


### PR DESCRIPTION
This adds a few more tweaks to the Pareto curve in the reports generated by Herbie.

- [x] Add "x" on the x-axis to clarify that values are relative
- [x] Speedup instead of slowdown
- [x] Speedup at initial accuracy