### PR TITLE
Make it possible to disable proofs

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -32,6 +32,7 @@ RECURSE=1 LOG=1 \
   bash "$INFRA_DIR"/run.sh \
     "$BENCH_DIR" "$OUT_DIR" \
     --profile \
+    --disable generate:proofs \
     --seed "$SEED" \
     --threads "$CORES" \
     $FLAGS

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -7,14 +7,14 @@
 (define all-flags
   #hash([precision . (double fallback)]
         [setup . (simplify search)]
-        [generate . (rr taylor simplify better-rr)]
+        [generate . (rr taylor simplify better-rr proofs)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 
 (define default-flags
   #hash([precision . ()]
         [setup . (simplify search)]
-        [generate . (rr taylor simplify)]
+        [generate . (rr taylor simplify proofs)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -460,10 +460,13 @@
          [(< new-score score) (values altn new-score (cons best rest))] ; kick out current best
          [else (values best score (cons altn rest))]))))
 
-  (timeline-event! 'soundness)
-
   (match-define (cons best-annotated rest-annotated)
-    (add-soundiness (cons best rest) (*pcontext*) (*context*)))
+    (cond
+     [(flag-set? 'generate 'proofs)
+      (timeline-event! 'soundness)
+      (add-soundiness (cons best rest) (*pcontext*) (*context*))]
+     [else
+      (cons best rest)]))
 
   (timeline-event! 'end)
   


### PR DESCRIPTION
This PR adds `generate:proofs` as a default-on flag that users can turn off if they don't want proofs. Moreover, I **turn this flag off for the nightly** since at the moment proofs are broken. @oflatt will turn it on when he fixes proofs.