### PR TITLE
Fix demo timeline

### DIFF
--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -12,7 +12,9 @@
 ;; Important: Use 'eq?' based hash tables, process may freeze otherwise
 (define-resetter *timeline*
   (λ () (box '()))
-  (λ () (box '())))
+  (λ ()
+    (set-box! (*timeline*) '())
+    (*timeline*)))
 
 (define *timeline-disabled* (make-parameter true))
 (define *timeline-timers* (mutable-set))


### PR DESCRIPTION
This PR restores timeline info to the demo server. In `src/timeline.rkt`, `*timeline*` contains a box which should be reset to the empty list rather than be _replaced_ by a new box.