### PR TITLE
Redesign cost-accuracy plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ plugin
 rival
 regraph
 egg-herbie/pkg
+odyssey
 
 # Racket
 *.zo

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ minimal-distribution:
 nightly: install
 	bash infra/nightly.sh reports
 
-start-server: install
+upgrade:
+	git pull
+	$(MAKE) install
+
+start-server:
 	racket src/herbie.rkt web --seed 1 --timeout 150 --num-iters 2 \
 		--demo --public --prefix /demo/ --port 4053 --save-session www/demo/ \
 		--log infra/server.log --quiet 2>&1

--- a/infra/herbie-demo.service
+++ b/infra/herbie-demo.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=The Herbie web demo
+Documentation=https://herbie.uwplse.org/demo/
+After=network.target
+
+[Service]
+ExecStart=make start-server
+WorkingDirectory=/var/www/herbie
+User=pavpan
+
+[Install]
+WantedBy=multi-user.target

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -208,7 +208,7 @@
            [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
             (semaphore-post sema)]
            [else
-            (eprintf "Job ~a started on ~a..." hash formula)
+            (eprintf "Job ~a started:\n  improve ~a...\n" hash (syntax->datum formula))
 
             (define result (run-herbie 'improve (parse-test formula) #:seed seed))
 
@@ -225,7 +225,7 @@
                              (build-path (*demo-output*) "results.json")
                              (build-path (*demo-output*) "index.html")))
 
-            (eprintf " complete\n")
+            (eprintf "Job ~a complete\n" hash)
             (hash-remove! *jobs* hash)
             (semaphore-post sema)])])
        (loop seed)))))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -141,6 +141,20 @@
          "These can be toggled with buttons below the plot. "
          "The line is an average while dots represent individual samples."))
 
+      ,(if (> (length end-alts) 1)
+           `(div ([id "figure-row"])
+             (div)
+             (figure ([id "cost-accuracy"] [data-benchmark-name ,(~a (test-name test))])
+               (h2 "Accuracy vs Speed")
+               (svg)
+               (figcaption
+                "A speed-accuracy pareto curve. Accuracy is on the vertical axis, "
+                "while speedup is on the horizontal axis. Up and to the right is "
+                "better. Each circle represents an alternative program; the red "
+                "square represents the initial program. The line is only there to "
+                "aid redability.")))
+           "")
+
       ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))
            (render-interactive vars (car points))
            "")
@@ -181,12 +195,6 @@
                     "\\[" ,(parameterize ([*expr-cse-able?* at-least-two-ops?])
                             (alt->tex alt ctx))
                     "\\]"))))
-            "")
-                                      
-      ,(if (> (length end-alts) 1)
-          `(section ([id "cost-accuracy"])
-            (h1 "Error")
-            (div ([id "pareto-content"] [data-benchmark-name ,(~a (test-name test))])))
             "")
 
       ,(render-reproduction test)))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -142,17 +142,23 @@
          "The line is an average while dots represent individual samples."))
 
       ,(if (> (length end-alts) 1)
-           `(div ([id "figure-row"])
-             (div)
-             (figure ([id "cost-accuracy"] [data-benchmark-name ,(~a (test-name test))])
-               (h2 "Accuracy vs Speed")
-               (svg)
-               (figcaption
-                "A speed-accuracy pareto curve. Accuracy is on the vertical axis, "
-                "while speedup is on the horizontal axis. Up and to the right is "
-                "better. Each circle represents an alternative program; the red "
-                "square represents the initial program. The line is only there to "
-                "aid redability.")))
+           `(div ([class "figure-row"] [id "cost-accuracy"]
+                  [data-benchmark-name ,(~a (test-name test))])
+             (figure
+              (p "Herbie found "  ,(~a (length end-alts)) " alternatives:")
+              (table
+               (thead (tr (th "Alternative") 
+                          (th ([class "numeric"]) "Accuracy")
+                          (th ([class "numeric"]) "Speedup")))
+               (tbody)))
+             (figure
+              (h2 "Accuracy vs Speed")
+              (svg)
+              (figcaption
+               "The accuracy (vertical axis) and speed (horizontal axis) of each "
+               "of Herbie's proposed alternatives. Up and to the right is better. "
+               "Each dot represents an alternative program; the red square represents "
+               "the initial program.")))
            "")
 
       ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -127,7 +127,7 @@
                       "×"
                       #:title "Aggregate speedup of fastest alternative that improves accuracy."))
 
-      (div ([id "figure-row"])
+      (div ([class "figure-row"])
        (figure ([id "xy"])
         (h2 "Output vs Input Accuracy")
         (svg)

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -121,7 +121,10 @@
        ,(render-large "Bad Runs" (~a (+ total-crashes total-timeouts)) "/" (~a total-tests)
                       #:title "Crashes and timeouts are considered bad runs.")
        ,(render-large "Speedup" 
-                      (~r speedup-at-initial-accuracy #:precision 1) "×"
+                      (if speedup-at-initial-accuracy
+                          (~r speedup-at-initial-accuracy #:precision 1)
+                          "N/A")
+                      "×"
                       #:title "Aggregate speedup of fastest alternative that improves accuracy."))
 
       (div ([id "figure-row"])

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -66,14 +66,17 @@
       (representation-total-bits
        (get-representation
         (table-row-precision t)))))
-  (match-define (list (list _ initial-accuracy) frontier) merged-cost-accuracy)
   (define speedup-at-initial-accuracy
     ;; The `frontier`'s accuracies are descending, so here we're searching from
     ;; the end backwards to get the cost of the first point with an accuracy
     ;; higher than that of the initial point's
-    (for/first ([point (reverse frontier)]
-                #:when (> (second point) initial-accuracy))
-      (first point)))
+    (cond
+     [(null? merged-cost-accuracy) #f]
+     [else
+      (match-define (list (list _ initial-accuracy) frontier) merged-cost-accuracy)
+      (for/first ([point (reverse frontier)]
+                  #:when (> (second point) initial-accuracy))
+        (first point))]))
 
   (define (round* x)
     (inexact->exact (round x)))

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -33,7 +33,7 @@ header li:first-child::before { content: none; }
 
 /* Plots at the top */
 
-#figure-row { display: flex; flex-direction: row; gap: 1em; margin: 2em 0; }
+.figure-row { display: flex; flex-direction: row; gap: 1em; margin: 1em 0; }
 figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 0; }
 figure h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
 figure .domain, figure .tick { color: #888; }
@@ -201,6 +201,14 @@ section h1 {
 #functions #function_end.selected { background: #00a2; }
 #functions #function_target { border: 3px solid #050; }
 #functions #function_target.selected { background: #0502; }
+
+#cost-accuracy p { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
+#cost-accuracy table { width: 374px; padding: 1ex 0; }
+#cost-accuracy thead th { color: #888; border-bottom: 1px solid #888; }
+#cost-accuracy thead th.numeric { text-align: right; }
+#cost-accuracy tbody th { font-weight: normal; }
+#cost-accuracy tbody td { font-family: 'Ruda', serif; text-align: right; font-weight: 400; }
+#cost-accuracy tbody td.better { font-weight: 800; color: #050; }
 
 /* Try it out section */
 

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -231,9 +231,9 @@ const ClientGraph = new Component('#graphs', {
     render: async function(selected_var_name, selected_functions) {
         const all_fns = ['start', 'end', 'target'].filter(name => this.points_json.error[name] != false)
         const fn_description = {
-            start: "Original expression",
-            end: "Herbie's result",
-            target: "Target expression"
+            start: "Initial program",
+            end: "Most accurate alternative",
+            target: "Target program"
         }
         this.$variables.replaceChildren.apply(
             this.$variables,
@@ -338,92 +338,83 @@ const MergedCostAccuracy = new Component('#pareto', {
 const CostAccuracy = new Component('#cost-accuracy', {
     setup: async function() {
         const $svg = this.elt.querySelector("svg");
+        const $tbody = this.elt.querySelector("tbody");
+
+        let response = await fetch("../results.json", {
+            headers: {"content-type": "text/plain"},
+            method: "GET",
+            mode: "cors",
+        });
+        let results_json = await response.json();
         
-        const results_json = await (async () => {
-            const get_results_store = {}
-            
-            const get_results_memo = async () => {
-                if (get_results_store.value) { return get_results_store.value }
-                const ps = await get_json('../results.json');
-                get_results_store.value = ps;
-                return get_results_store.value;
+        // find right test by iterating through results_json
+        for (let test of results_json.tests) {
+            if (test.name == this.elt.dataset.benchmarkName) {
+                $svg.replaceWith(await this.plot(test));
+                $tbody.replaceWith(await this.tbody(test));
+                break;
             }
-            const get_json = url => fetch(url, {
-                // body: `_body_`,
-                headers: {"content-type": "text/plain"},
-                method: "GET",
-                mode: 'cors'
-                }).then(async response => {
-                //await new Promise(r => setTimeout(() => r(), 200) )  // model network delay
-                return await response.json()
-            })
-            return get_results_memo()
-        })()
-
-        const plot = async () => {
-            // NOTE ticks and splitpoints include all vars, so we must index
-            const tests = results_json.tests;
-            
-            let benchmark;
-
-            // find right test by iterating through results_json
-            for (let test of tests) {
-                if (test.name == this.elt.dataset.benchmarkName) {
-                    benchmark = test;
-                    break;
-                }
-            }
-
-            console.log(benchmark);
-
-            const costAccuracy = benchmark["cost-accuracy"];
-            
-            // find maximum x and y values
-            let xmax = costAccuracy[0][0];
-            let ymax = costAccuracy[0][1];
-
-            if (costAccuracy[1][0] > xmax) xmax = costAccuracy[1][0];
-            if (costAccuracy[1][1] > ymax) ymax = costAccuracy[1][1];
-            
-            for (let point of costAccuracy[2]) {
-                if (point[0] > xmax) xmax = point[0];
-                if (point[1] > ymax) ymax = point[1];
-            }
-
-            // ceiling ymax to nearest multiple of 16
-            const range = Math.ceil(ymax/16) * 16;
-
-            // composite array for both best and other points so the line graph
-            // contains the best point as well.
-            const allpoints = [costAccuracy[1], ...costAccuracy[2]];
-            allpoints.sort((a, b) => {return a[0]-b[0]});
-            console.log(allpoints);
-
-            const out = Plot.plot({
-                marks: [
-                    Plot.dot(costAccuracy[0], {x: costAccuracy[0][0], y: costAccuracy[0][1], fill: "black"}),
-                    Plot.dot(costAccuracy[1], {x: costAccuracy[1][0], y: costAccuracy[1][1], fill: "red", stroke: "blue", title: d => `x: ${costAccuracy[1][0]} y: ${costAccuracy[1][1]} best`}),
-                    Plot.dot(costAccuracy[2], {x: d => d[0], y: d => d[1], fill: "red", stroke: "black", title: d => `x: ${d[0]} y: ${d[1]} exp: ${d[2]}`}),
-                    Plot.line(allpoints, {x: d => d[0], y: d => d[1], stroke: "red"})
-                ],
-                grid: true,
-                width: '800',
-                height: '400',                
-                    x: {
-                        label: `Cost`,
-                        domain: [0, 2 * xmax]
-                    },
-                    y: {
-                        label: "Bits of error",
-                        domain: [0, range],
-                        ticks: new Array(range / 4 + 1).fill(0).map((_, i) => i * 4),
-                        tickFormat: d => d % 8 != 0 ? '' : d
-                    },
-            })
-            out.setAttribute('viewBox', '0 0 800 430')
-            return out
         }
-        $svg.replaceWith(await plot());
+    },
+
+    plot: async function(benchmark) {
+        const [initial_pt, best_pt, rest_pts] = benchmark["cost-accuracy"];
+        const bits = benchmark["bits"];
+        rest_pts.push(best_pt);
+        rest_pts.sort((a, b) => a[0]-b[0]);
+
+        const out = Plot.plot({
+            marks: [
+                Plot.dot([initial_pt], {
+                    x: d => initial_pt[0]/d[0],
+                    y: d => 1 - d[1]/bits,
+                    stroke: "#d00", symbol: "square", strokeWidth: 2 }),
+                Plot.dot(rest_pts, {
+                    x: d => initial_pt[0]/d[0],
+                    y: d => 1 - d[1]/bits,
+                    fill: "#00a", r: 3,
+                }),
+                Plot.line(rest_pts, {
+                    x: d => initial_pt[0]/d[0],
+                    y: d => 1 - d[1]/bits,
+                    stroke: "#00a", strokeWidth: 1, strokeOpacity: .2,
+                }),
+            ],
+            marginBottom: 0,
+            marginRight: 0,
+            width: '400',
+            height: '200',
+            x: { line: true, nice: true, tickFormat: c => c + "×" },
+            y: { nice: true, line: true, domain: [0, 1], tickFormat: "%" },
+        })
+        out.setAttribute('viewBox', '0 0 420 220')
+        return out
+    },
+
+    tbody: async function(benchmark) {
+        const [initial_pt, best_pt, rest_pts] = benchmark["cost-accuracy"];
+        const bits = benchmark["bits"];
+        const initial_accuracy = 100*(1 - initial_pt[1]/bits);
+        rest_pts.push(best_pt);
+        rest_pts.sort((a, b) => b[0]-a[0]);
+
+        return Element("tbody", [
+            Element("tr", [
+                Element("th", "Initial program"),
+                Element("td", initial_accuracy.toFixed(1) + "%"),
+                Element("td", "1×")
+            ]),
+            rest_pts.map((d, i) => {
+                let accuracy = 100*(1 - d[1]/bits);
+                let speedup = initial_pt[0]/d[0];
+                return Element("tr", [
+                    Element("th", "Alternative " + (i + 1)),
+                    Element("td", { className: accuracy >= initial_accuracy ? "better" : "" },
+                            accuracy.toFixed(1) + "%"),
+                    Element("td", { className: speedup >= 1 ? "better" : "" },
+                            speedup.toFixed(1) + "×")
+            ])}),
+        ]);
     }
 });
 

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -237,7 +237,7 @@ const ClientGraph = new Component('#graphs', {
         }
         this.$variables.replaceChildren.apply(
             this.$variables,
-            [" vs. "].concat(this.all_vars.map(v =>
+            [" vs "].concat(this.all_vars.map(v =>
                 Element("span", {
                     className: "variable " + (selected_var_name == v ? "selected" : ""),
                     onclick: () => this.render(v, selected_functions),
@@ -336,8 +336,8 @@ const MergedCostAccuracy = new Component('#pareto', {
 })
 
 const CostAccuracy = new Component('#cost-accuracy', {
-    setup: async () => {
-        const content = document.querySelector('#pareto-content');
+    setup: async function() {
+        const $svg = this.elt.querySelector("svg");
         
         const results_json = await (async () => {
             const get_results_store = {}
@@ -368,8 +368,7 @@ const CostAccuracy = new Component('#cost-accuracy', {
 
             // find right test by iterating through results_json
             for (let test of tests) {
-                console.log(test);
-                if (test.name == content.dataset.benchmarkName) {
+                if (test.name == this.elt.dataset.benchmarkName) {
                     benchmark = test;
                     break;
                 }
@@ -424,15 +423,10 @@ const CostAccuracy = new Component('#cost-accuracy', {
             out.setAttribute('viewBox', '0 0 800 430')
             return out
         }
-        async function render() {
-            const options_view = Element("figcaption", "");
-            const toggle = (option, options) => options.includes(option) ? options.filter(o => o != option) : [...options, option]
-
-            content.replaceChildren(await plot(), options_view)
-        }
-        render()
+        $svg.replaceWith(await plot());
     }
-})
+});
+
 var RenderMath = new Component(".math", {
     depends: function() {
         if (typeof window.renderMathInElement === "undefined") throw "KaTeX unavailable";

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -365,20 +365,20 @@ const CostAccuracy = new Component('#cost-accuracy', {
 
         const out = Plot.plot({
             marks: [
-                Plot.dot([initial_pt], {
-                    x: d => initial_pt[0]/d[0],
-                    y: d => 1 - d[1]/bits,
-                    stroke: "#d00", symbol: "square", strokeWidth: 2 }),
-                Plot.dot(rest_pts, {
-                    x: d => initial_pt[0]/d[0],
-                    y: d => 1 - d[1]/bits,
-                    fill: "#00a", r: 3,
-                }),
                 Plot.line(rest_pts, {
                     x: d => initial_pt[0]/d[0],
                     y: d => 1 - d[1]/bits,
                     stroke: "#00a", strokeWidth: 1, strokeOpacity: .2,
                 }),
+                Plot.dot(rest_pts, {
+                    x: d => initial_pt[0]/d[0],
+                    y: d => 1 - d[1]/bits,
+                    fill: "#00a", r: 3,
+                }),
+                Plot.dot([initial_pt], {
+                    x: d => initial_pt[0]/d[0],
+                    y: d => 1 - d[1]/bits,
+                    stroke: "#d00", symbol: "square", strokeWidth: 2 }),
             ],
             marginBottom: 0,
             marginRight: 0,


### PR DESCRIPTION
This PR does a pass over the per-benchmark pareto plot, and also adds a handy table of alternatives:

![image (1)](https://github.com/herbie-fp/herbie/assets/30707/9d7e13da-c39a-4deb-847b-decea6b33369)

The end result is, I hope, easier to use and also highlights Herbie's new Pareto capabilities. Plus, the plot now matches all of our new metrics (speedup and percentage accurate) and also matches the overall style.