### PR TITLE
Report redesign part 3

### DIFF
--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -86,7 +86,7 @@
                   input output spec target-prog
                   start-bits end-bits target-bits start-est end-est
                   time link cost-accuracy)
-       (define bits 128)  ; Deprecated JSON field
+       (define bits (representation-total-bits (get-representation prec)))
        (define cost-accuracy*
         (match cost-accuracy
           [(list) (list)]
@@ -101,6 +101,7 @@
           (pre . ,(~s pre))
           (preprocess . ,(~s preprocess))
           (prec . ,(~s prec))
+          (bits . ,(representation-total-bits (get-representation prec)))
           (conversions . ,(map (curry map ~s) conversions))
           (status . ,status)
           (start . ,start-bits)
@@ -114,7 +115,6 @@
           (spec . ,(~s spec))
           (target-prog . ,(~s target-prog))
           (time . ,time)
-          (bits . ,bits)
           (link . ,(~a link))
           (cost-accuracy . ,cost-accuracy*)))]))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -185,8 +185,8 @@
           ;; differentiated between "programs" with a λ term and
           ;; "expressions" without
           (match event
-           [(list 'taylor name var '())
-            (list 'taylor name var loc0)]
+           [(list 'taylor '() name var)
+            (list 'taylor loc0 name var)]
            [(list 'rr '() input proof soundiness)
             (list 'rr loc0 input proof soundiness)]
            [(list 'simplify '() input proof soundiness)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -185,12 +185,12 @@
           ;; differentiated between "programs" with a λ term and
           ;; "expressions" without
           (match event
-           [(list 'taylor name var (list 2 loc ...))
-            (list 'taylor name var (append '(2) loc0 loc))]
-           [(list 'rr (list 2 loc ...) input proof soundiness)
-            (list 'rr (append '(2) loc0 loc) input proof soundiness)]
-           [(list 'simplify (list 2 loc ...) input proof soundiness)
-            (list 'simplify (append '(2) loc0 loc) input proof soundiness)]))
+           [(list 'taylor name var '())
+            (list 'taylor name var loc0)]
+           [(list 'rr '() input proof soundiness)
+            (list 'rr loc0 input proof soundiness)]
+           [(list 'simplify '() input proof soundiness)
+            (list 'simplify loc0 input proof soundiness)]))
         (define expr* (location-do loc0 (alt-expr orig) (const (alt-expr altn))))
         (alt expr* event* (list (loop (first prevs))))])))
   

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -94,7 +94,7 @@
       (for ([i (in-range 4)])
         (define replace (genexpr))
         (when replace
-          (sow (alt replace `(taylor ,name ,var ()) (list altn)))))
+          (sow (alt replace `(taylor () ,name ,var) (list altn)))))
       (timeline-stop!))))
 
 (define (gen-series!)

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -94,7 +94,7 @@
       (for ([i (in-range 4)])
         (define replace (genexpr))
         (when replace
-          (sow (alt replace `(taylor ,name ,var (2)) (list altn)))))
+          (sow (alt replace `(taylor ,name ,var ()) (list altn)))))
       (timeline-stop!))))
 
 (define (gen-series!)
@@ -176,7 +176,6 @@
     (define comb-changelists (append changelists changelists-low-locs))
     (define altns (append (^queued^) (^queuedlow^)))
     
-    (define variables (context-vars (*context*)))
     (define rewritten
       (for/fold ([done '()] #:result (reverse done))
                 ([cls comb-changelists] [altn altns]
@@ -184,8 +183,8 @@
           (match-define (list subexp input) cl)
             (define body* (apply-repr-change-expr subexp (*context*)))
             (if body*
-              ; We need to pass '(2) here so it can get overwritten on patch-fix
-              (cons (alt body* (list 'rr '(2) input #f #f) (list altn)) done)
+              ; We need to pass '() here so it can get overwritten on patch-fix
+              (cons (alt body* (list 'rr '() input #f #f) (list altn)) done)
               done)))
 
     (timeline-push! 'count (length (^queued^)) (length rewritten))
@@ -209,7 +208,6 @@
   (when (flag-set? 'generate 'simplify)
     (timeline-event! 'simplify)
     (define children (^final^))
-    (define variables (context-vars (*context*)))
 
     (define to-simplify (map alt-expr children))
 
@@ -224,7 +222,7 @@
                   [output outputs])
          (if (equal? input output)
              child
-             (alt output `(simplify (2) ,egg-query #f #f) (list child))))
+             (alt output `(simplify () ,egg-query #f #f) (list child))))
        alt-equal?))
 
     ; dedup for cache

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -49,14 +49,14 @@
 (define (add-soundiness-to pcontext ctx cache altn)
   (match altn
 
-    [(alt expr `(rr (2 ,@loc) ,(? egraph-query? e-input) #f #f) `(,prev))
+    [(alt expr `(rr (,@loc) ,(? egraph-query? e-input) #f #f) `(,prev))
      (define p-input (cons (location-get loc (alt-expr prev)) (location-get loc (alt-expr altn))))
      (match-define (cons proof errs)
        (hash-ref! cache (cons p-input e-input)
                   (λ () (canonicalize-proof (alt-expr altn) loc pcontext ctx #t e-input p-input))))
-     (alt expr `(rr (2 ,@loc) ,e-input ,proof ,errs) `(,prev))]
+     (alt expr `(rr (,@loc) ,e-input ,proof ,errs) `(,prev))]
 
-    [(alt expr `(rr (2 ,@loc) ,(? rule? input) #f #f) `(,prev))
+    [(alt expr `(rr (,@loc) ,(? rule? input) #f #f) `(,prev))
      (match-define (cons proof errs)
        (hash-ref! cache (cons input expr)
                   (λ ()
@@ -66,15 +66,15 @@
                     (define errs
                       (get-proof-errors proof pcontext ctx))
                     (cons proof errs))))
-     (alt expr `(rr (2 ,@loc) ,input ,proof ,errs) `(,prev))]
+     (alt expr `(rr (,@loc) ,input ,proof ,errs) `(,prev))]
 
     ;; This is alt coming from simplify
-    [(alt expr `(simplify (2 ,@loc) ,(? egraph-query? e-input) #f #f) `(,prev))
+    [(alt expr `(simplify (,@loc) ,(? egraph-query? e-input) #f #f) `(,prev))
      (define p-input (cons (location-get loc (alt-expr prev)) (location-get loc (alt-expr altn))))
      (match-define (cons proof errs)
        (hash-ref! cache (cons p-input e-input)
                   (λ () (canonicalize-proof (alt-expr altn) loc pcontext ctx #f e-input p-input))))
-     (alt expr `(simplify (2 ,@loc) ,e-input ,proof ,errs) `(,prev))]
+     (alt expr `(simplify (,@loc) ,e-input ,proof ,errs) `(,prev))]
 
     [else altn]))
 

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -101,7 +101,7 @@
 (define (program->tex prog ctx #:loc [loc #f])
   (define prog* (program->fpcore prog ctx))
   (if (supported-by-lang? prog* "tex")
-      (core->tex prog* #:loc loc #:color "blue")
+      (core->tex prog* #:loc (and loc (cons 2 loc)) #:color "blue")
       "ERROR"))
 
 (define (render-program #:to [result #f] preprocess test)

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -93,7 +93,7 @@
                (ol ,@(render-history entry new-pcontext new-pcontext2 ctx))))))
        (li ([class "event"]) "Recombined " ,(~a (length prevs)) " regimes into one program."))]
 
-    [(alt prog `(taylor ,pt ,var ,loc) `(,prev))
+    [(alt prog `(taylor ,loc ,pt ,var) `(,prev))
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li (p "Taylor expanded in " ,(~a var)
               " around " ,(~a pt) " " (span ([class "error"] [title ,err2]) ,err))

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -55,14 +55,6 @@
         [_ (void)]))
     (k 'Goal #f #f step)))
 
-;; Extracts render information from the proof
-(define (compute-proof proof soundiness)
-  (for/list ([step (in-list proof)] [sound soundiness])
-     (define-values (dir rule loc expr) (splice-proof-step step))
-     (if (eq? dir 'Goal)
-         (list #f #f #f expr #f)
-         (list dir rule loc expr sound))))
-
 ;; HTML renderer for derivations
 (define/contract (render-history altn pcontext pcontext2 ctx)
   (-> alt? pcontext? pcontext? context? (listof xexpr?))
@@ -108,13 +100,11 @@
            (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]
 
     [(alt prog `(simplify ,loc ,input ,proof ,soundiness) `(,prev))
-     (define proof*
-       (if proof (compute-proof proof soundiness) #f))
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li (p "Simplified" (span ([class "error"] [title ,err2]) ,err))
            (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) 
                 "\\]")
-           ,(if proof* (render-proof proof* pcontext ctx) "")))]
+           ,(if proof (render-proof proof soundiness pcontext ctx) "")))]
 
     [(alt prog `initial-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 ctx)
@@ -127,36 +117,37 @@
            (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx) "\\]")))]
 
     [(alt prog `(rr ,loc ,input ,proof ,soundiness) `(,prev))
-     (define proof*
-       (if proof (compute-proof proof soundiness) #f))
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li (p "Applied " (span ([class "rule"]) , (if (rule? input) "rewrite-once" "egg-rr"))
               (span ([class "error"] [title ,err2]) ,err))
            (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")
-           ,(if proof* (render-proof proof* pcontext ctx) "")))]
+           ,(if proof (render-proof proof soundiness pcontext ctx) "")))]
     ))
 
-
-(define (render-proof proof pcontext ctx)
+(define (render-proof proof soundiness pcontext ctx)
   `(div ([class "proof"])
     (details
      (summary "Step-by-step derivation")
      (table
-      ,@(for/list ([step proof])
-          (match-define (list dir rule loc expr sound) step)
+      ,@(for/list ([step proof] [sound soundiness])
+          (define-values (dir rule loc expr) (splice-proof-step step))
           (define step-prog (program->fpcore expr ctx))
-          (define err (format-accuracy (errors-score (errors expr pcontext ctx)) (representation-total-bits (context-repr ctx))))
-          `(tr (th ,(if dir
+          (define err
+            (format-accuracy (errors-score (errors expr pcontext ctx))
+                             (representation-total-bits (context-repr ctx))
+                             #:unit "%"))
+          `(tr (th ,(if (equal? dir 'Goal)
+                        `(p "[Start]"
+                            (span ([class "info"]) ,err))
                         (let ([dir (match dir ['Rewrite<= "<="] ['Rewrite=> "=>"])]
                               [tag (string-append (format " ↑ ~a" (first sound))
                                                   (format " ↓ ~a" (second sound)))])
                           `(p ,(format "~a [~a]" rule dir)
                               (span ([class "info"] [title ,tag]) ,err)))
-                        `(p "[Start]"
-                            (span ([class "info"]) ,err))))
+                        ))
                (td (div ([class "math"])
                         "\\[ "
-                        ,(if dir
-                             (core->tex step-prog #:loc (cons 2 loc) #:color "blue")
-                             (core->tex step-prog))
+                        ,(if (equal? dir 'Goal)
+                             (core->tex step-prog)
+                             (core->tex step-prog #:loc (cons 2 loc) #:color "blue"))
                         "\\]"))))))))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -126,7 +126,7 @@
       ,(render-program preprocess test #:to (alt-expr end-alt))
       
       (figure ([id "graphs"])
-        (h2 "Local Percentage Accuracy"
+        (h2 "Local Percentage Accuracy vs "
             (span ([id "variables"]))
             (a ([class "help-button"] 
                 [href "/doc/latest/report.html#graph"] 
@@ -141,25 +141,23 @@
          "These can be toggled with buttons below the plot. "
          "The line is an average while dots represent individual samples."))
 
-      ,(if (> (length end-alts) 1)
-           `(div ([class "figure-row"] [id "cost-accuracy"]
-                  [data-benchmark-name ,(~a (test-name test))])
-             (figure
-              (p "Herbie found "  ,(~a (length end-alts)) " alternatives:")
-              (table
-               (thead (tr (th "Alternative") 
-                          (th ([class "numeric"]) "Accuracy")
-                          (th ([class "numeric"]) "Speedup")))
-               (tbody)))
-             (figure
-              (h2 "Accuracy vs Speed")
-              (svg)
-              (figcaption
-               "The accuracy (vertical axis) and speed (horizontal axis) of each "
-               "of Herbie's proposed alternatives. Up and to the right is better. "
-               "Each dot represents an alternative program; the red square represents "
-               "the initial program.")))
-           "")
+      (div ([class "figure-row"] [id "cost-accuracy"]
+            [data-benchmark-name ,(~a (test-name test))])
+           (figure
+            (p "Herbie found "  ,(~a (length end-alts)) " alternatives:")
+            (table
+             (thead (tr (th "Alternative") 
+                        (th ([class "numeric"]) "Accuracy")
+                        (th ([class "numeric"]) "Speedup")))
+             (tbody)))
+           (figure
+            (h2 "Accuracy vs Speed")
+            (svg)
+            (figcaption
+             "The accuracy (vertical axis) and speed (horizontal axis) of each "
+             "of Herbie's proposed alternatives. Up and to the right is better. "
+             "Each dot represents an alternative program; the red square represents "
+             "the initial program.")))
 
       ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))
            (render-interactive vars (car points))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -155,9 +155,9 @@
             (svg)
             (figcaption
              "The accuracy (vertical axis) and speed (horizontal axis) of each "
-             "of Herbie's proposed alternatives. Up and to the right is better. "
-             "Each dot represents an alternative program; the red square represents "
-             "the initial program.")))
+             "alternatives. Up and to the right is better. The red square shows "
+             "the initial program, and each blue circle shows an alternative."
+             "The line shows the best available speed-accuracy tradeoffs.")))
 
       ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))
            (render-interactive vars (car points))

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -181,9 +181,6 @@ section h1 {
 
 /* Error graphs */
 
-#variables .variable { padding: 0 .75ex 2px; }
-#variables .selected { background-color: lightgray; }
-
 #functions { display: flex; flex-direction: row; gap: 1em; margin-top: 1ex; }
 #functions:before { content: "Show: "; }
 #functions .function {

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -34,7 +34,7 @@ header li:first-child::before { content: none; }
 /* Plots at the top */
 
 .figure-row { display: flex; flex-direction: row; gap: 1em; margin: 1em 0; }
-figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 0; }
+figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 0; align-self: start; }
 figure h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
 figure .domain, figure .tick { color: #888; }
 figure text { font-family: 'IBM Plex Serif', serif; }

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -366,9 +366,22 @@ const CostAccuracy = new Component('#cost-accuracy', {
         rest_pts.push(best_pt);
         rest_pts.sort((a, b) => a[0]-b[0]);
 
+        // The line differs from rest_pts in two ways:
+        // - We filter to the actual pareto frontier, in case points moved
+        // - We make a broken line to show the real Pareto frontier
+        let line = []
+        let last = null;
+        for (let pt of rest_pts) {
+            if (!last || pt[1] < last[1]) {
+                if (last) line.push([pt[0], last[1]]);
+                line.push([pt[0], pt[1]]);
+                last = pt;
+            }
+        }
+
         const out = Plot.plot({
             marks: [
-                Plot.line(rest_pts, {
+                Plot.line(line, {
                     x: d => initial_pt[0]/d[0],
                     y: d => 1 - d[1]/bits,
                     stroke: "#00a", strokeWidth: 1, strokeOpacity: .2,

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -229,21 +229,24 @@ const ClientGraph = new Component('#graphs', {
     },
 
     render: async function(selected_var_name, selected_functions) {
+        this.$variables.replaceChildren.apply(
+            this.$variables,
+            [Element("select", {
+                oninput: (e) => this.render(e.target.value, selected_functions),
+            }, this.all_vars.map(v =>
+                Element("option", {
+                    value: v,
+                    selected: selected_var_name == v,
+                }, v)
+            ))]
+        );
+
         const all_fns = ['start', 'end', 'target'].filter(name => this.points_json.error[name] != false)
         const fn_description = {
             start: "Initial program",
             end: "Most accurate alternative",
             target: "Target program"
         }
-        this.$variables.replaceChildren.apply(
-            this.$variables,
-            [" vs "].concat(this.all_vars.map(v =>
-                Element("span", {
-                    className: "variable " + (selected_var_name == v ? "selected" : ""),
-                    onclick: () => this.render(v, selected_functions),
-                }, v)
-            )),
-        );
         const toggle = (option, options) => options.includes(option) ? options.filter(o => o != option) : [...options, option]
         this.$functions.replaceChildren.apply(
             this.$functions,

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -465,6 +465,15 @@ var Bogosity = new Component(".bogosity", {
     }
 });
 
+var ClickableRows = new Component("#results", {
+    setup: function() {
+        let $rows = this.elt.querySelectorAll("tbody tr");
+        for (let $row of $rows) {
+            $row.addEventListener("click", () => $row.querySelector("a").click());
+        }
+    }
+})
+
 var Implementations = new Component("#program", {
     setup: function() {
         this.dropdown = this.elt.querySelector("select");

--- a/www/doc/1.7/release-notes.html
+++ b/www/doc/1.7/release-notes.html
@@ -29,11 +29,10 @@
   </header>
 
   <p>The <a href="../..">Herbie</a> developers are excited to announce
-  Herbie 1.6! This release focuses on further integration of <a href="https://github.com/egraphs-good/egg">egg</a>, improved reliability,
-  and a better web interface. Our favorite features are below.</p>
+  Herbie 2.0! This release focuses clarity, transparency, and trade-offs.</p>
 
   <img width="100%" src="team.png" style="display: block; margin: 4em 0; border-radius: 6px;"
-       alt="The Herbie team, working over Zoom to bring you Herbie 1.6" />
+       alt="The Herbie 2.0 team at UW and U of U" />
 
   <p><b>What is Herbie?</b> Herbie automatically improves the accuracy
   of floating point expressions. This avoids the bugs, errors, and
@@ -42,170 +41,94 @@
   <p><b>Join us!</b> Join the Herbie developers on the
   <a href="https://fpbench.org">FPBench</a> Slack, at the monthly
   FPBench community meetings, and at
-  <a href="https://fpbench.org/talks/fptalks22.html">FPTalks 2022</a>.
+  <a href="https://fpbench.org/talks/fptalks22.html">FPTalks 2023</a>.
+
+  <h2>Speed-accuracy trade-offs</h2>
 
   <figure class="showcase">
-    <img src="old-rr-seed-variance.png" style="width: 100%;" />
-    <img src="egg-rr-seed-variance.png" style="width: 100%;" />
+    ???
     <figcaption>
-      Comparison of Herbie's total output error (bits) across 100 seeds with
-        the old recursive rewriter (top) versus the egg-based implementation (bottom).
-      The egg-based implementation has lower variability.
+      ???
     </figcaption>
   </figure>
-
-  <h2>Recursive Rewriting with egg</h2>
-
-  Two releases ago, Herbie 1.4 featured a new simplifier that used the
-    <a href="https://github.com/egraphs-good/egg">egg</a> library
-    for a substantial increase in speed.
-  This release further incorporates the egg library into Herbie by replacing
-    the recursive rewriter with an egg-based implementation.
-  Herbie's output is now more stable across seeds compared
-    to the previous implementation, maintains a similar level
-    of performance, and increases accuracy gains overall.
-  This change also makes it easier to add new rewrite rules, 
-  since the egg-based rewriter's behavior is more predictable 
-  than the old recursive rewriter was.
-  
-  <figure class="showcase">
-    <img src="interactive-preconditions.png" style="width: 100%;" />
-    <figcaption>
-      Preconditions in the new web interface. For each input, 
-      users are asked to provide a range of values for Herbie 
-      to focus on optimizing over. Input ranges vary depending
-      on the user's application and should always be 
-      supplied to maximize accuracy.
-    </figcaption>
-  </figure>
-
-  <h2>Interactive Herbie</h2>
 
   <p>
-  Despite the fact that most users interact with Herbie via 
-  the <a href="https://herbie.uwplse.org/demo/">demo page</a>,
-    the web interface has historically had a minimal design,
-    with important features like preconditions hidden behind 
-    advanced configuration dialogs.
-  As part of an ongoing push to make Herbie more user-friendly, 
-    we have added support for preconditions to the main interface, 
-    and have improved the display of warnings and errors.
-  We expect the demo page to change further in the coming year 
-    to provide users with more support in analyzing Herbie's output
-    and testing their own ideas for rewritings.
-  </p>
+  Two years releases ago, Herbie 1.5 added a new <kbd>--pareto</kbd>
+  mode, which let Herbie suggest some alternatives that were accurate
+  but slow, and others that were faster but less accurate. In this
+  release, we've made this mode the default. In order to do that, we
+  had to make it faster, clearer, and more reliable. We think making
+  speed-accuracy trade-offs are a key part of using Herbie in a
+  practical context, and we're excited to make that easier for users.
+  </p
 
+  <h2>New Metrics and Redesign</h2>
+  
   <figure class="showcase">
-    <table style="border:1px solid black;">
-      <tr>
-        <td><img src="quadp-old-branch.png" style="width: 100%;" /></td>
-        <td><img src="quadp-short-branch.png" style="width: 100%;" /></td>
-      </tr>
-    </table>
+    ???
     <figcaption>
-      Comparison of the midpoint (left) vs. shortest number (right) methods for
-        selecting branch conditions.
+      ???
     </figcaption>
   </figure>
-
-  <h2>Shorter Branch Conditions</h2>
 
   <p>
-    Herbie now synthesizes branch conditions with shorter split values.
-    Before, Herbie's binary search algorithm would narrow down the set of
-      possible split values to a small interval from which Herbie took the midpoint.
-    Often the midpoint had a long string representation which made it seem
-      like it was chosen with high precision.
-    Now Herbie will choose a value on that same interval with a short string representation.
-    This change makes output programs more readable and highlights the
-      low precision in the result of binary search.
-      
+  We've cleaned up the report page significantly. The visual redesign
+  is the most notable---we've' refreshed and standardized the new
+  fonts, colors, and spacing. But more importantly, we've switched
+  to <a href="error.html">a new way</a> of measuring accuracy and
+  speed, which we think will be more intuitive for users and avoid
+  some misconceptions we see users run into.
   </p>
 
+  <h2>Derivations</h2>
+
   <figure class="showcase">
-    <img src="system-1.6-changes.png" style="width: 100%;" />
+    ???
     <figcaption>
-      System diagram for Herbie 1.6, with key changes in red dotted boxes.
-      From top to bottom: double-precision (binary64) and single-precision (binary32) types
-        are loaded through plugins instead of being embedded in Herbie's core;
-        a new patching subsystem bundles together the various
-        rewriting methods behind a simple interface;
-        recursive rewrite uses egg.
-      Compare Herbie 1.5 and 1.6 system diagrams <a href="../1.5/diagrams.html">here</a>
-        and <a href="../1.6/diagrams.html">here</a>.
+      ???
     </figcaption>
   </figure>
 
-  <h2>Patching and Plugins</h2>
-  
-  <p>Herbie has undergone a significant architectural change since the previous release.
-  Although this change may not be visible to users, we hope that it
-    makes future Herbie development more streamlined and provides a clearer
-    answer to the question: what is Herbie?
-  In particular, two major improvements include adding the "patch table"
-    and moving number system specifics out of Herbie's
-    core architecture.
+  <p>
+    Herbie can now explain step by step how it transformed your
+    original input into the final program. This helps you understand
+    how Herbie works, and potentially help us identify bugs or
+    misbehaviors.
   </p>
+
+  <h2>Foundations for a Herbie Workbench</h2>
   
-  <p>The patch table manages most rewriting capabilities, provides a
-    minimal interface to generate variants from a set of expressions,
-    and caches variants in case of duplicate input expressions.
-  Creating this subsystem to handle variant generation more cleanly
-    separates the "generate" and "test" parts within Herbie.
+  <p>
+    We&apos;ve started building a prototype numerics workbench,
+    codenamed "Odyssey". As part of that, this release contains the
+    beginnings of a <a href="api-endpoints.html">REST API</a> for
+    interacting with Herbie. Long-term, the goal is an interactive,
+    task-oriented interface for improving the accuracy of
+    floating-point expressions, leveraging Herbie but also potentially
+    other tools. A prototype is currently available in the VS Code
+    store as the <kbd>herbie-vscode</kbd> plugin.
   </p>
-  
-  <p>Herbie's double-precision and single-precision representations
-    are now implemented as plugins that automatically ship
-    with Herbie.
-  Representation-specific operators and definitions are
-    no longer present in Herbie's core architecure.
-  This change makes Herbie representation-agnostic and loads
-    double- and single-precision representations through the plugin interface.
-  Not only is this design cleaner, but these plugins now
-    serve as examples for plugin developers.
-  In the future, we hope to move additional definitions
-    out of core Herbie and into plugins such as error metrics
-    and cost models (Pherbie).
-  </p>
-  <br>
+
   <h2>Other improvements</h2>
   <ul>
-    <li>Precondition analysis and point sampling are unified under a single function.
-      Sampling multiple functions is now supported.
-    </li>
-    <li>The backup sampler now just computes with MPFR floats
-        at high-precision rather than the old "halfpoints" sampler.
-    </li>
-    <li> Constants are now represented internally as operators.
-      This simplifies the plugin interface as well as Herbie's internals.
-    </li>
-    <li>Support for variary operators has been removed.
-      Relational operators are now expanded when parsed.</li>
-    <li>Constants are always read as exact rational numbers.
-      This enables additional optimizations through constant folding.
-    </li>
-    <li>More output languages are supported in the reports including
-      Fortran, Java, Python, Julia, MatLab, and Wolfram.
-    </li>
-    <li>egg has been updated to 0.8.1 which has led to a performance increase.
-      Make sure to have at least Rust 1.60 when installing from source.
-    </li>
+    <li>Inputs whose real-valued result rounds to floating-point
+      infinity are now considered valid. This changes Herbie&apos;s
+      accuracy estimates, sometimes significantly, but we found that
+      typically this yields better results
+    <li>Most sections of the Herbie reports page now have "help" links
+      directly to the relevant section of the documentation.
+    <li>Many, many algorithms within Herbie have been sped up.
+      Notably, pruning, regimes, and binary search have all seen
+      significant speedups.
+    <li>Graphs are now drawn using JavaScript, on the client side,
+      making them higher resolution, especially on high-DPI displays.
+    <li>Herbie&apos;s localization pass was written to be more
+      accurate on tricky cases, which improves Herbie&apos;s results.
+    <li>Herbie&apos; supports for the <code>tgamma</code>
+      and <code>lgamma</code> functions was rewritten to be more
+      accurate (though it is quite slow).
   </ul>
 
-  <h2>Deprecations and removals</h2>
-  <ul>
-    <li>The Bessel functions <code>j0</code>, <code>j1</code>, <code>y0</code>, and <code>y1</code>
-      have been deprecated and will be removed in the next release.</li>
-    <li>Support for the Racket 7.x has been removed. Please upgrade.</li>
-    <li>Support for complex numbers has been removed.
-    Please <a href="mailto:herbie@cs.washington.edu">let us know</a>
-    if you are using it. We hope to reimplement this eventually,
-    but with a better architecture.</li>
-    <li>The <kbd>precision:fallback</kbd> flag has been deprecated, and no
-    longer does anything. Use the <code>:precision racket</code> flag instead.</li>
-    <li>Support for <a href="https://github.com/herbie-fp/regraph">regraph</a> has been removed.</li>
-  </ul>
-  <br>
   <h2>Try it out!</h2>
 
   <p>

--- a/www/doc/1.7/release-notes.html
+++ b/www/doc/1.7/release-notes.html
@@ -2,22 +2,21 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Herbie 1.6 Release Notes</title>
+  <title>Herbie 2.0 Release Notes</title>
   <link rel='stylesheet' type='text/css' href="../../main.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    .showcase {
-      margin: 4em 0 0em 0;
-    }
-    h2 {
-      margin: 1.5em 0 .5em;
+    .showcase { margin: 1em 0; }
+    #team {
+        display: block; box-sizing: border-box; width: 100%;
+        border-radius: 2em; border: 3px solid black;
     }
   </style>
 </head>
 <body>
   <header>
-    <h1>Herbie 1.6 Release Notes</h1>
+    <h1>Herbie 2.0 Release Notes</h1>
     <a href="../.."><img class="logo" src="../../logo-car.png" /></a>
     <nav>
       <ul>
@@ -31,12 +30,12 @@
   <p>The <a href="../..">Herbie</a> developers are excited to announce
   Herbie 2.0! This release focuses clarity, transparency, and trade-offs.</p>
 
-  <img width="100%" src="team.png" style="display: block; margin: 4em 0; border-radius: 6px;"
-       alt="The Herbie 2.0 team at UW and U of U" />
-
   <p><b>What is Herbie?</b> Herbie automatically improves the accuracy
   of floating point expressions. This avoids the bugs, errors, and
-  surprises that so often occur with floating point arithmetic.</p>
+  surprises that so often occur with floating point arithmetic.
+  Visit <a href="../..">the main page</a> to learn more about Herbie.</p>
+
+  <img src="team.png" id="team" alt="The Herbie 2.0 team at UW and U of U" />
 
   <p><b>Join us!</b> Join the Herbie developers on the
   <a href="https://fpbench.org">FPBench</a> Slack, at the monthly
@@ -60,7 +59,7 @@
   had to make it faster, clearer, and more reliable. We think making
   speed-accuracy trade-offs are a key part of using Herbie in a
   practical context, and we're excited to make that easier for users.
-  </p
+  </p>
 
   <h2>New Metrics and Redesign</h2>
   


### PR DESCRIPTION
This is a grab-bag report redesign PR. It includes:

- Changing the variable selector in the graph to a dropdown (to be more intuitive)
- Drawing the true Pareto curve (see below)
- Refactoring "loc"s and proofs so that that code is a little simpler.

<img width="399" alt="image" src="https://github.com/herbie-fp/herbie/assets/30707/e7a472ab-3b0b-4562-afbe-b2fba9a69141">
