### PR TITLE
Multiple `next-alt`s at once

### DIFF
--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -279,17 +279,17 @@
   (when (^next-alts^)
     (raise-user-error 'run-iter! "An iteration is already in progress\n~a"
                       "Run (finish-iter!) to finish it, or (rollback-iter!) to abandon it.\n"))
-  (^patched^
-    (for/fold ([full '()]) ([picked (choose-alts)] [i (in-naturals 1)])
+
+  (^next-alts^ (choose-alts))
+  (^table^
+    (for/fold ([table (^table^)]) ([picked (choose-alts)] [i (in-naturals 1)])
       (define (picking-func x)
         (for/first ([v x] #:when (alt-equal? v picked)) v))
       (define-values (_ table*)
-        (atab-pick-alt (^table^) #:picking-func picking-func #:only-fresh #t))
-      (^next-alts^ (list picked))
-      (^table^ table*)
-      (localize!)
-      (reconstruct! (patch-table-run (^locs^) (^lowlocs^)))
-      (append full (^patched^))))
+        (atab-pick-alt table #:picking-func picking-func #:only-fresh #t))
+      table*))
+  (localize!)
+  (reconstruct! (patch-table-run (^locs^) (^lowlocs^)))
   (finalize-iter!))
   
 (define (setup-context! vars specification precondition repr)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -16,7 +16,7 @@
 ;; extending, make sure this never gets too complicated to fit in your
 ;; head at once, because then global state is going to mess you up.
 
-(struct shellstate (table next-alt locs lowlocs patched) #:mutable)
+(struct shellstate (table next-alts locs lowlocs patched) #:mutable)
 
 (define (empty-shellstate)
   (shellstate #f #f #f #f #f))
@@ -34,9 +34,9 @@
 (define (^table^ [newval 'none])
   (when (not (equal? newval 'none))  (set-shellstate-table! (^shell-state^) newval))
   (shellstate-table (^shell-state^)))
-(define (^next-alt^ [newval 'none])
-  (when (not (equal? newval 'none)) (set-shellstate-next-alt! (^shell-state^) newval))
-  (shellstate-next-alt (^shell-state^)))
+(define (^next-alts^ [newval 'none])
+  (when (not (equal? newval 'none)) (set-shellstate-next-alts! (^shell-state^) newval))
+  (shellstate-next-alts (^shell-state^)))
 (define (^patched^ [newval 'none])
   (when (not (equal? newval 'none)) (set-shellstate-patched! (^shell-state^) newval))
   (shellstate-patched (^shell-state^)))
@@ -58,7 +58,7 @@
     (for ([alt (atab-active-alts (^table^))]
 	  [n (in-naturals)])
       (printf "~a ~a ~a\n"
-       (cond [(equal? alt (^next-alt^)) ">"]
+       (cond [(set-member? (^next-alts^) alt) ">"]
              [(set-member? ndone-alts alt) " "]
              [else "."])
        (~r #:min-width 4 n)
@@ -72,7 +72,7 @@
                       n (length (atab-active-alts (^table^)))))
   (define-values (picked table*)
     (atab-pick-alt (^table^) #:picking-func (curryr list-ref n) #:only-fresh #f))
-  (^next-alt^ picked)
+  (^next-alts^ (list picked))
   (^table^ table*)
   (void))
 
@@ -115,23 +115,27 @@
 (define (choose-best-alt!)
   (define-values (picked table*)
     (atab-pick-alt (^table^) #:picking-func (curry argmin score-alt) #:only-fresh #t))
-  (^next-alt^ picked)
+  (^next-alts^ (list picked))
   (^table^ table*)
   (void))
 
 ;; Invoke the subsystems individually
 (define (localize!)
-  (unless (^next-alt^)
+  (unless (^next-alts^)
     (raise-user-error 'localize! "No alt chosen. Run (choose-best-alt!) or (choose-alt! n) to choose one"))
   (timeline-event! 'localize)
 
   (define vars (context-vars (*context*)))
-  (define loc-errs (localize-error (alt-expr (^next-alt^)) (*context*)))
+  (define loc-errss
+    (for/list ([alt (^next-alts^)])
+      (localize-error (alt-expr alt) (*context*))))
   (define repr (context-repr (*context*)))
 
   ; high-error locations
   (^locs^
-    (for/list ([(err expr) (in-dict loc-errs)]
+    (for/list ([loc-errs (in-list loc-errss)]
+               #:when true
+               [(err expr) (in-dict loc-errs)]
                [i (in-range (*localize-expressions-limit*))])
       (timeline-push! 'locations (~a expr) (errors-score err)
                       (not (patch-table-has-expr? expr)) (format "~a" (representation-name repr)))
@@ -140,7 +144,9 @@
   ; low-error locations (Pherbie-only with multi-precision)
   (^lowlocs^
     (if (and (*pareto-mode*) (not (hash-empty? (*conversions*))))
-        (for/list ([(err expr) (in-dict (reverse loc-errs))]
+        (for/list ([loc-errs (in-list loc-errss)]
+                   #:when true
+                   [(err expr) (in-dict (reverse loc-errs))]
                    [i (in-range (*localize-expressions-limit*))])
           (timeline-push! 'locations (~a expr) (errors-score err) #f (~a (representation-name repr)))
           (cons vars expr)) 
@@ -199,8 +205,9 @@
               ([altn (in-list alts)])
       (define expr0 (get-starting-expr altn))
       (if expr0     ; if expr0 is #f, altn is a full alt (probably iter 0 simplify)
-          (let ([locs (get-locations (alt-expr (^next-alt^)) expr0)])
-            (append (map (λ (l) (reconstruct-alt altn l (^next-alt^))) locs) patched))
+          (for/fold ([patched patched]) ([alt0 (in-list (^next-alts^))])
+            (let ([locs (get-locations (alt-expr alt0) expr0)])
+              (append (map (λ (l) (reconstruct-alt altn l alt0)) locs) patched)))
           (cons altn patched))))
       
   (void))
@@ -229,11 +236,11 @@
                      (length (set-intersect new-alts final-fresh-alts)))
           'fresh (list (length orig-fresh-alts)
                        (length (set-intersect orig-fresh-alts final-fresh-alts)))
-          'done (list (- (length orig-done-alts) (if (^next-alt^) 1 0))
+          'done (list (- (length orig-done-alts) (length (or (^next-alts^) empty)))
                       (- (length (set-intersect orig-done-alts final-done-alts))
-                         (if (set-member? final-done-alts (^next-alt^)) 1 0)))
-          'picked (list (if (^next-alt^) 1 0)
-                        (if (and (^next-alt^) (set-member? final-done-alts (^next-alt^))) 1 0))))
+                         (length (set-intersect final-done-alts (or (^next-alts^) empty)))))
+          'picked (list (length (or (^next-alts^) empty))
+                        (length (set-intersect final-done-alts (or (^next-alts^) empty))))))
   (timeline-push! 'kept data)
 
   (define repr (context-repr (*context*)))
@@ -248,10 +255,8 @@
   (void))
 
 (define (finish-iter!)
-  (when (not (^next-alt^))
-    (choose-best-alt!))
-  (when (not (^locs^))
-    (localize!))
+  (unless (^next-alts^) (choose-best-alt!))
+  (unless (^locs^) (localize!))
   (reconstruct! (patch-table-run (^locs^) (^lowlocs^)))
   (finalize-iter!)
   (void))
@@ -259,7 +264,7 @@
 (define (rollback-iter!)
   (^locs^ #f)
   (^lowlocs^ #f)
-  (^next-alt^ #f)
+  (^next-alts^ #f)
   (^patched^ #f)
   (void))
 
@@ -271,7 +276,7 @@
 
 ;; Run a complete iteration
 (define (run-iter!)
-  (when (^next-alt^)
+  (when (^next-alts^)
     (raise-user-error 'run-iter! "An iteration is already in progress\n~a"
                       "Run (finish-iter!) to finish it, or (rollback-iter!) to abandon it.\n"))
   (^patched^
@@ -280,7 +285,7 @@
         (for/first ([v x] #:when (alt-equal? v picked)) v))
       (define-values (_ table*)
         (atab-pick-alt (^table^) #:picking-func picking-func #:only-fresh #t))
-      (^next-alt^ picked)
+      (^next-alts^ (list picked))
       (^table^ table*)
       (localize!)
       (reconstruct! (patch-table-run (^locs^) (^lowlocs^)))
@@ -314,7 +319,7 @@
   (when (flag-set? 'setup 'simplify)
       (reconstruct! (patch-table-run-simplify (atab-active-alts (^table^))))
       (finalize-iter!)
-      (^next-alt^ #f)))
+      (^next-alts^ #f)))
 
 ;; This is only here for interactive use; normal runs use run-improve!
 (define (run-improve vars prog iters


### PR DESCRIPTION
This PR rejiggers the main loop a bit, with the aim of making control flow a little clearer and also potentially making it faster.

Basically, right now, Herbie runs for ~4 iterations. In each iteration, it picks ~5 alts (evenly spaced from most accurate to cheapest). Each alt produces ~100 new alts, which are combined and pruned before going on to the next iteration. The iterations run in series. The 5 alts run in parallel. However, that 5-way parallelism isn't batched at the moment, which leads to confusing timelines where certain portions are repeated five times over. It also means less sharing / deduplication than there could be, which in turn likely means somewhat slower runtime.