### PR TITLE
Added Links to Alternative expressions

### DIFF
--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -199,7 +199,9 @@
                            [i (in-naturals 1)])
                 `(div ([class "entry"])
                   (table
-                    (tr (th ([style "font-weight:bold"]) ,(format "Alternative ~a" i)))
+                    (tr (th ([style "font-weight:bold"]
+                             [id ,(format "alternative~a" i)])
+                             ,(format "Alternative ~a" i)))
                     (tr (th "Accuracy") (td ,(format-accuracy (errors-score errs) repr-bits #:unit "%")))
                     (tr (th "Cost") (td ,(format-cost cost repr))))
                   (div ([class "math"])

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -139,7 +139,7 @@
          "These can be toggled with buttons below the plot. "
          "The line is an average while dots represent individual samples."))
 
-      ,(if (> (length end-alts) 1)
+      ,(if (>= (length end-alts) 1)
            `(div ([class "figure-row"] [id "cost-accuracy"]
                   [data-benchmark-name ,(~a (test-name test))])
              (figure
@@ -190,12 +190,12 @@
        (ol ([class "history"])
         ,@(render-history end-alt train-pctx test-pctx ctx)))
 
-      ,(if (> (length end-alts) 1)
+      ,(if (>= (length end-alts) 1)
            `(section ([id "alternatives"])
               (h1 "Alternatives")
-              ,@(for/list ([alt (cdr end-alts)]
-                           [errs (cdr end-errors)]
-                           [cost (cdr end-costs)]
+              ,@(for/list ([alt  end-alts]
+                           [errs end-errors]
+                           [cost end-costs]
                            [i (in-naturals 1)])
                 `(div ([class "entry"])
                   (table

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -408,7 +408,9 @@ const CostAccuracy = new Component('#cost-accuracy', {
                 let accuracy = 100*(1 - d[1]/bits);
                 let speedup = initial_pt[0]/d[0];
                 return Element("tr", [
-                    Element("th", "Alternative " + (i + 1)),
+                    Element("th",
+                        Element("a", { href: "#alternative" + (i + 1)},
+                                "Alternative " + (i + 1))),
                     Element("td", { className: accuracy >= initial_accuracy ? "better" : "" },
                             accuracy.toFixed(1) + "%"),
                     Element("td", { className: speedup >= 1 ? "better" : "" },

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -423,8 +423,12 @@ const CostAccuracy = new Component('#cost-accuracy', {
                 let speedup = initial_pt[0]/d[0];
                 return Element("tr", [
                     Element("th",
-                        Element("a", { href: "#alternative" + (i + 1)},
-                                "Alternative " + (i + 1))),
+                        rest_pts.length > 1 ?
+                            Element("a", { href: "#alternative" + (i + 1)},
+                                "Alternative " + (i + 1)) 
+                            // else
+                            : "Alternative " + (i + 1)
+                    ),
                     Element("td", { className: accuracy >= initial_accuracy ? "better" : "" },
                             accuracy.toFixed(1) + "%"),
                     Element("td", { className: speedup >= 1 ? "better" : "" },

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -395,9 +395,7 @@ const CostAccuracy = new Component('#cost-accuracy', {
         const [initial_pt, best_pt, rest_pts] = benchmark["cost-accuracy"];
         const bits = benchmark["bits"];
         const initial_accuracy = 100*(1 - initial_pt[1]/bits);
-        rest_pts.push(best_pt);
         rest_pts.sort((a, b) => b[0]-a[0]);
-
         return Element("tbody", [
             Element("tr", [
                 Element("th", "Initial program"),

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -412,6 +412,7 @@ const CostAccuracy = new Component('#cost-accuracy', {
         const bits = benchmark["bits"];
         const initial_accuracy = 100*(1 - initial_pt[1]/bits);
         rest_pts.sort((a, b) => b[0]-a[0]);
+
         return Element("tbody", [
             Element("tr", [
                 Element("th", "Initial program"),


### PR DESCRIPTION
Added hyper links to Alternative expressions to make it a little easier to jump and view the alternative expressions.

Also fixed a bug where the number of Alternatives match between `report.js` and `make-graph.rkt`
