### PR TITLE
 Add message about adding binary to path and warning against Snap in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Installing from source requires Racket 8.0 or later,
   Rust 1.60.0 or later, and supports Windows, macOS, and Linux
   for various architectures.
 
-Install Racket from [here](https://download.racket-lang.org/).
+Install Racket from [here](https://download.racket-lang.org/). We recommend 
+the official Racket installer over Snap. If your configuration depends on Racket 
+being installed via Snap, you will need to ensure that Herbie and all packages are 
+located in your home directory or another allow-listed directory.
 Install Rust from [here](https://www.rust-lang.org/tools/install).
 In this directory, build Herbie with:
 
@@ -26,7 +29,9 @@ In this directory, build Herbie with:
 
 This will install a `herbie` binary somewhere under `~/.racket` (Linux)
   although this path is dependent on OS and Racket version
-  (check installation messages for a possible location).
+  (check installation messages for a possible location). Depending on
+  your configuration, you may need to add the binary to your path 
+  manually.
 You can also run `src/herbie.rkt` directly.
 
 ### Installing from the Racket package index


### PR DESCRIPTION
Updates the README to remind users that: 
a) Herbie is not necessarily automatically installed in their path, and they may need to add it manually. 
b) They should prefer apt or the official installer over Snap. 