### PR TITLE
Redesign the details page

### DIFF
--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -11,7 +11,7 @@
          "../syntax/types.rkt" "../syntax/sugar.rkt")
 
 (provide render-menu render-warnings render-large render-comparison render-program
-         render-bogosity
+         render-bogosity render-help
          format-percent
          program->fpcore program->tex render-reproduction js-tex-include)
 
@@ -254,6 +254,11 @@
               (a ((href "https://github.com/herbie-fp/herbie/issues")) "bug report")
               " with this information.")
           ""))))
+
+(define (render-help url #:float [float? #t])
+  `(a ([class ,(if float? "help-button float" "help-button")] 
+       [href ,(format "/doc/latest/~a" url)] 
+       [target "_blank"]) "?"))
 
 (define js-tex-include
   '((link ([rel "stylesheet"] [href "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css"]

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -238,21 +238,22 @@
 (define/contract (render-reproduction test #:bug? [bug? #f])
   (->* (test?) (#:bug? boolean?) xexpr?)
 
-  `(figure ([id "reproduce"])
-    (h2 "Reproduce" (a (
-          [class "help-button"] 
+  `(section ([id "reproduce"])
+    (details ,(if bug? '([open "open"]) "")
+     (summary
+      (h2 "Reproduce")
+      (a ([class "help-button float"] 
           [href "/doc/latest/report.html#reproduction"] 
-          [target "_blank"] 
-          ) "?"))
-    (pre ((class "shell"))
-         (code
-          ,(render-command-line) "\n"
-          ,(render-fpcore test) "\n"))
-    ,(if bug?
-         `(p "Please file a "
-             (a ((href "https://github.com/herbie-fp/herbie/issues")) "bug report")
-             " with this information.")
-         "")))
+          [target "_blank"]) "?"))
+     (pre ((class "shell"))
+          (code
+           ,(render-command-line) "\n"
+           ,(render-fpcore test) "\n"))
+     ,(if bug?
+          `(p "Please file a "
+              (a ((href "https://github.com/herbie-fp/herbie/issues")) "bug report")
+              " with this information.")
+          ""))))
 
 (define js-tex-include
   '((link ([rel "stylesheet"] [href "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css"]

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -141,7 +141,7 @@
               `(li ,(let ([dir (match dir ['Rewrite<= "right to left"] ['Rewrite=> "left to right"])]
                           [tag (string-append (format " ↑ ~a" (first sound))
                                               (format " ↓ ~a" (second sound)))])
-                      `(p ,(format "~a (~a)" rule dir)
+                      `(p (code ([title ,dir]) ,(~a rule))
                           (span ([class "error"] [title ,tag]) ,err)))
                    (div ([class "math"])
                         "\\[\\leadsto "

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -101,10 +101,10 @@
 
     [(alt prog `(simplify ,loc ,input ,proof ,soundiness) `(,prev))
      `(,@(render-history prev pcontext pcontext2 ctx)
+       (li ,(if proof (render-proof proof soundiness pcontext ctx) ""))
        (li (p "Simplified" (span ([class "error"] [title ,err2]) ,err))
            (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) 
-                "\\]")
-           ,(if proof (render-proof proof soundiness pcontext ctx) "")))]
+                "\\]")))]
 
     [(alt prog `initial-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 ctx)
@@ -118,17 +118,17 @@
 
     [(alt prog `(rr ,loc ,input ,proof ,soundiness) `(,prev))
      `(,@(render-history prev pcontext pcontext2 ctx)
+       (li ,(if proof (render-proof proof soundiness pcontext ctx) ""))
        (li (p "Applied " (span ([class "rule"]) , (if (rule? input) "rewrite-once" "egg-rr"))
               (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")
-           ,(if proof (render-proof proof soundiness pcontext ctx) "")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]
     ))
 
 (define (render-proof proof soundiness pcontext ctx)
   `(div ([class "proof"])
     (details
      (summary "Step-by-step derivation")
-     (table
+     (ol
       ,@(for/list ([step proof] [sound soundiness])
           (define-values (dir rule loc expr) (splice-proof-step step))
           (define step-prog (program->fpcore expr ctx))
@@ -136,18 +136,14 @@
             (format-accuracy (errors-score (errors expr pcontext ctx))
                              (representation-total-bits (context-repr ctx))
                              #:unit "%"))
-          `(tr (th ,(if (equal? dir 'Goal)
-                        `(p "[Start]"
-                            (span ([class "info"]) ,err))
-                        (let ([dir (match dir ['Rewrite<= "<="] ['Rewrite=> "=>"])]
-                              [tag (string-append (format " ↑ ~a" (first sound))
-                                                  (format " ↓ ~a" (second sound)))])
-                          `(p ,(format "~a [~a]" rule dir)
-                              (span ([class "info"] [title ,tag]) ,err)))
-                        ))
-               (td (div ([class "math"])
-                        "\\[ "
-                        ,(if (equal? dir 'Goal)
-                             (core->tex step-prog)
-                             (core->tex step-prog #:loc (cons 2 loc) #:color "blue"))
+          (if (equal? dir 'Goal)
+              ""
+              `(li ,(let ([dir (match dir ['Rewrite<= "right to left"] ['Rewrite=> "left to right"])]
+                          [tag (string-append (format " ↑ ~a" (first sound))
+                                              (format " ↓ ~a" (second sound)))])
+                      `(p ,(format "~a (~a)" rule dir)
+                          (span ([class "error"] [title ,tag]) ,err)))
+                   (div ([class "math"])
+                        "\\[\\leadsto "
+                        ,(core->tex step-prog #:loc (cons 2 loc) #:color "blue")
                         "\\]"))))))))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -71,7 +71,7 @@
   (define speedup
     (let ([better
            (for/list ([alt end-alts] [err end-errors] [cost end-costs]
-                      #:when (>= (errors-score err) (errors-score start-error)))
+                      #:when (<= (errors-score err) (errors-score start-error)))
              (/ start-cost cost))])
       (and (not (null? better)) (apply max better))))
 

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -102,9 +102,9 @@
                  (format-accuracy (apply max (map ulps->bits start-error)) repr-bits #:unit "%")
                  (format-accuracy (apply max (map ulps->bits end-error)) repr-bits #:unit "%")))
        ,(render-large "Time" (format-time time))
-       ,(render-large "Precision" `(kbd ,(~a (representation-name repr))))
+       ,(render-large "Alternatives" (~a (length end-alts)))
        ,(if (*pareto-mode*)
-            (render-large "Cost" `(kbd ,(format-cost (car end-costs) repr)))
+            (render-large "Speedup" "TODO×")
             ""))
 
       ,(render-warnings warnings)
@@ -172,7 +172,7 @@
 
       ,@(for/list ([alt end-alts] [i (in-naturals 1)])
           `(section ([id ,(format "alternative~a" i)])
-            (h2 "Alternative " ,(~a i))
+            (h2 "Alternative " ,(~a i) ,(render-help "report.html#alternative"))
             (div ([class "math"])
                  "\\[" ,(parameterize ([*expr-cse-able?* at-least-two-ops?])
                           (alt->tex alt ctx))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -92,14 +92,7 @@
          '("Report" . "../index.html")
          '("Metrics" . "timeline.html")))
 
-      (section ([id "large"])
-       (h1 
-        (a (
-          [class "help-button"] 
-          [href "/doc/latest/report.html#summary"] 
-          [target "_blank"] 
-          ;[style "rotate: 270deg"]
-          ) "?"))
+      (div ([id "large"])
        ,(render-comparison
          "Percentage Accurate"
          (format-accuracy (errors-score start-error) repr-bits #:unit "%")
@@ -116,19 +109,23 @@
 
       ,(render-warnings warnings)
 
-      (figure ([id "specification"] [class "collapsible"])
-        (h2 "Specification")
-        (div ([class "math"]) "\\[" ,(alt->tex start-alt ctx) "\\]")
-        ,(render-bogosity bogosity)
+      (section
+        (details ([id "specification"] [class "section"])
+          (summary (h2 "Specification")
+                   (a ([class "help-button float"] 
+                       [href "/doc/latest/report.html#spec"] 
+                       [target "_blank"]) "?"))
+          (div ([class "math"]) "\\[" ,(alt->tex start-alt ctx) "\\]")
+          ,(render-bogosity bogosity)
 
-        ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))
-             (render-interactive vars (car points))
-             ""))
+          ,(if (and fpcore? (for/and ([p points]) (andmap number? p)))
+               (render-interactive vars (car points))
+               "")))
       
       (figure ([id "graphs"])
         (h2 "Local Percentage Accuracy vs "
             (span ([id "variables"]))
-            (a ([class "help-button"] 
+            (a ([class "help-button float"] 
                 [href "/doc/latest/report.html#graph"] 
                 [target "_blank"]) "?"))
         (svg)
@@ -141,9 +138,11 @@
          "These can be toggled with buttons below the plot. "
          "The line is an average while dots represent individual samples."))
 
-      (figure ([id "cost-accuracy"] [data-benchmark-name ,(~a (test-name test))])
+
+      (section ([id "cost-accuracy"] [class "section"]
+                [data-benchmark-name ,(~a (test-name test))])
         (h2 "Accuracy vs Speed"
-            (a ([class "help-button"] 
+            (a ([class "help-button float"] 
                 [href "/doc/latest/report.html#cost-accuracy"] 
                 [target "_blank"]) "?"))
         (div ([class "figure-row"])
@@ -172,7 +171,7 @@
            "")
 
       ,@(for/list ([alt end-alts] [i (in-naturals 1)])
-          `(figure ([id ,(format "alternative~a" i)])
+          `(section ([id ,(format "alternative~a" i)])
             (h2 "Alternative " ,(~a i))
             (div ([class "math"])
                  "\\[" ,(parameterize ([*expr-cse-able?* at-least-two-ops?])

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -122,7 +122,7 @@
                       #:title "Crashes and timeouts are considered bad runs.")
        ,(render-large "Speedup" 
                       (if speedup-at-initial-accuracy
-                          (~r speedup-at-initial-accuracy #:precision 1)
+                          (~r speedup-at-initial-accuracy #:precision '(= 1))
                           "N/A")
                       "×"
                       #:title "Aggregate speedup of fastest alternative that improves accuracy."))

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -155,18 +155,9 @@ section { display: flow-root; }
 
 /* Big block for program input output */
 
-#program {
-    background: #f8f8f8; border: 1px solid #ddd;
-    text-align: center; font-size: 24px;
-    position: relative; padding: 1em;
-}
-@media print { #program { padding: 0; background: transparent; margin: 2em 0; } }
-#program .program { display: inline-block; text-align: left; }
-#program .arrow { color: transparent; font-size: 0; }
-#program .arrow:after { content: "↓"; color: black; font-size: 24px; }
-#program.horizontal .arrow { display: inline-block; }
-#program.horizontal .arrow:after { margin: 0 1em; content: "→"; font-size: 40px; }
-#language { position: absolute; right: 1em; }
+.programs { position: relative; }
+.programs select { position: absolute; right: 3em; }
+.program { display: inline-block; text-align: left; }
 #precondition { padding: 0 1em 1em; margin: 0 -1em 1em; border-bottom: 2px solid white; }
 #precondition:before { content: "Precondition"; float: left; color: #444; }
 /* Allow line breaks in display equations (see https://katex.org/docs/issues.html) */

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -30,14 +30,16 @@ summary h1, summary h2 { display: inline-block; }
     font-size: 2em; display: block; font-family: 'Ruda', serif; color: black;
     margin-top: -.2em;
 }
-#large .unit { font-family: 'IBM Plex Seirf', serif; color: #aaa; }
+#large .unit { font-family: 'IBM Plex Serif', serif; color: #aaa; }
 @media print { #large { margin-top: 0; }}
 
 /* Plots at the top */
 
-.figure-row { display: flex; flex-direction: row; gap: 1em; margin: 1em 0; }
+.figure-row { display: flex; flex-direction: row; gap: 1em; align-items: start; }
 figure, section { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 1em 0; align-self: start; }
 h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
+data { font-family: 'Ruda'; }
+h2 .subhead { font-weight: normal; }
 svg .domain, svg .tick { color: #888; }
 svg text { font-family: 'IBM Plex Serif', serif; }
 figcaption { font-size: 80%; color: #666; padding-top: 1ex; }

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -20,6 +20,8 @@ header li { display: inline-block; margin: 0 .5em; }
 header li::before { content: "•"; margin-right: 1em; }
 header li:first-child::before { content: none; }
 
+summary h1, summary h2 { display: inline-block; }
+
 #large {
     margin: 2em 0; display: flex; gap: 3em; justify-content: center;
     font-family: 'IBM Plex Serif', serif; color: #888;
@@ -34,10 +36,10 @@ header li:first-child::before { content: none; }
 /* Plots at the top */
 
 .figure-row { display: flex; flex-direction: row; gap: 1em; margin: 1em 0; }
-figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 1em 0; align-self: start; }
-figure h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
-figure .domain, figure .tick { color: #888; }
-figure text { font-family: 'IBM Plex Serif', serif; }
+figure, section { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 1em 0; align-self: start; }
+h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
+svg .domain, svg .tick { color: #888; }
+svg text { font-family: 'IBM Plex Serif', serif; }
 figcaption { font-size: 80%; color: #666; padding-top: 1ex; }
 svg.clickable circle:hover { stroke: #00a; stroke-width: 10; cursor: pointer; }
 
@@ -101,8 +103,7 @@ tr.timeout    td:nth-child(3) {background-color:#8e8e93;color:#f7f7f7;}
  position: relative; bottom: .125em;
 }
 .help-button:hover { background: #444; color: #eee; text-decoration: none; cursor: pointer; }
-h1 > .help-button { rotate: 270deg; }
-figure h2 .help-button { float: right; font-size: 120%; font-weight: normal; }
+.help-button.float { float: right; font-size: 120%; font-weight: normal; }
 
 /* Subreports */
 
@@ -135,13 +136,7 @@ figure h2 .help-button { float: right; font-size: 120%; font-weight: normal; }
 
 /* Detail page layout */
 
-section { margin: 5em 0; position: relative; }
-@media print { section { margin: 3em 0; } }
-section h1 {
-    position: absolute; width: 300px; text-align: left; right: -340px; top: -15px;
-    transform: rotate(90deg); transform-origin: top left;
-    font-size: 24px; font-weight: normal; color: #aaa;
-}
+section { display: flow-root; }
 
 /* Warnings */
 
@@ -233,9 +228,9 @@ section h1 {
 
 .history, .history ol { list-style: none inside; width: 800px; margin: 0 0 2em; padding: 0; }
 
-.history li p { width: 150px; display: inline-block; margin: 0 25px 0 0; }
+.history li p { width: 250px; display: inline-block; margin: 0 25px 0 0; }
 .history li .error { display: block; color: #666; }
-.history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: middle; }
+.history li > div { display: inline-block; margin: 0; width: 500px; vertical-align: middle; }
 .history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
 
 .history h2 { margin: 1.333em 0 .333em; }
@@ -325,7 +320,6 @@ table pre { padding: 0; margin: 0; text-align: left; font-size: 110%; }
 
 /* Code sample to reproduce */
 
-#reproduce pre { padding: 1em; margin: 0; font-family: monospace; overflow-x: auto; }
 pre.shell code:before { content: "$ "; font-weight: bold; }
 
 /* Target / expected code block */
@@ -334,14 +328,6 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 #comparison table th { text-align: left; }
 #comparison table td { text-align: right; }
 #comparison div { display: inline-block; width: 500px; }
-
-/* Alternatives */
-
-#alternatives table { width: 275px; display: inline-table; vertical-align: top; }
-#alternatives table th { text-align: left; font-weight: normal; }
-#alternatives table td { text-align: left; width: 75px; }
-#alternatives .entry { padding: 5px 0px; }
-#alternatives .entry .math { display: inline-block; width: 500px; }
 
 /* Formatting backtraces */
 

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -34,7 +34,7 @@ header li:first-child::before { content: none; }
 /* Plots at the top */
 
 .figure-row { display: flex; flex-direction: row; gap: 1em; margin: 1em 0; }
-figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 0; align-self: start; }
+figure { flex: 1; border: 1px solid #ddd; padding: 1ex; margin: 1em 0; align-self: start; }
 figure h2 { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
 figure .domain, figure .tick { color: #888; }
 figure text { font-family: 'IBM Plex Serif', serif; }

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -178,21 +178,6 @@ section { display: flow-root; }
 
 #functions { display: flex; flex-direction: row; gap: 1em; margin-top: 1ex; }
 #functions:before { content: "Show: "; }
-#functions .function {
-    width: 1em;
-    height: 1em;
-    border-radius: 50%;
-    box-sizing: border-box; /* Include padding and border in element's width and height */
-    display: inline-block;
-    margin-right: 1ex;
-}
-
-#functions #function_start { border: 3px solid #d00; }
-#functions #function_start.selected { background: #d002; }
-#functions #function_end { border: 3px solid #00a; }
-#functions #function_end.selected { background: #00a2; }
-#functions #function_target { border: 3px solid #050; }
-#functions #function_target.selected { background: #0502; }
 
 #cost-accuracy p { font-size: 1em; font-family: 'IBM Plex Serif', serif; margin: 0; }
 #cost-accuracy table { width: 374px; padding: 1ex 0; }

--- a/src/web/resources/report.css
+++ b/src/web/resources/report.css
@@ -164,6 +164,7 @@ section { display: flow-root; }
 .katex-display > .katex { white-space: normal }
 .katex-display .base { margin: 0.25em 0 }
 .katex-display { margin: 0.5em 0; }
+.katex-display .arraycolsep { width: 0 !important; }
 #preprocess { padding: 0 1em 1em; margin: 0 -1em 1em; border-bottom: 2px solid white; }
 #preprocess:before { content: "Preprocess"; float: left; color: #444; }
 

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -360,10 +360,9 @@ const CostAccuracy = new Component('#cost-accuracy', {
         // find right test by iterating through results_json
         for (let test of results_json.tests) {
             if (test.name == this.elt.dataset.benchmarkName) {
-                const [initial_pt, best_pt, rest_pts] = test["cost-accuracy"];
-                rest_pts.push(best_pt);
-                rest_pts.sort((a, b) => b[0]-a[0]);
-                const target_pt = test["target"] && [this.elt.dataset.targetCost, test["target"]]
+                let [initial_pt, best_pt, rest_pts] = test["cost-accuracy"];
+                let target_pt = test["target"] && [this.elt.dataset.targetCost, test["target"]]
+                rest_pts = [best_pt].concat(rest_pts)
                 $svg.replaceWith(await this.plot(test, initial_pt, target_pt, rest_pts));
                 $tbody.replaceWith(await this.tbody(test, initial_pt, target_pt, rest_pts));
                 break;
@@ -409,7 +408,7 @@ const CostAccuracy = new Component('#cost-accuracy', {
                     y: d => 1 - d[1]/bits,
                     stroke: "#080", symbol: "circle", strokeWidth: 2
                 }),
-            ],
+            ].filter(x=>x),
             marginBottom: 0,
             marginRight: 0,
             width: '400',
@@ -496,7 +495,7 @@ var ClickableRows = new Component("#results", {
     }
 })
 
-var Implementations = new Component("#program", {
+var Implementations = new Component(".programs", {
     setup: function() {
         this.dropdown = this.elt.querySelector("select");
         this.programs = this.elt.querySelectorAll(".implementation");
@@ -509,19 +508,8 @@ var Implementations = new Component("#program", {
             var $prog = this.programs[i];
             if ($prog.dataset["language"] == lang) {
                 $prog.style.display = "block";
-                this.arrow($prog);
             } else {
                 $prog.style.display =  "none";
-            }
-        }
-    },
-    arrow: function($prog) {
-        var progs = $prog.querySelectorAll(".program");
-        $prog.classList.add("horizontal");
-        for (var i = 0; i < progs.length; i++) {
-            var progBot = progs[i].offsetTop + progs[i].offsetHeight;
-            if (progs[i].offsetTop >= progBot) {
-                return $prog.classList.remove("horizontal");
             }
         }
     },

--- a/src/web/resources/report.js
+++ b/src/web/resources/report.js
@@ -212,7 +212,7 @@ const ClientGraph = new Component('#graphs', {
         }
         const out = Plot.plot({
             width: '800',
-            height: '400',                
+            height: '300',
             marks: splitpoints.concat(marks),
             x: {
                 tickFormat: d => tick_strings[tick_ordinals.indexOf(d)],
@@ -224,7 +224,7 @@ const ClientGraph = new Component('#graphs', {
             marginBottom: 0,
             marginRight: 0,
         });
-        out.setAttribute('viewBox', '0 0 820 420')
+        out.setAttribute('viewBox', '0 0 820 320')
         return out
     },
 

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -1,7 +1,7 @@
 #lang racket
 (require json (only-in xml write-xexpr xexpr?) racket/date)
 (require "../common.rkt" "../datafile.rkt" "common.rkt" "../syntax/types.rkt" "../float.rkt")
-(provide make-timeline render-phase-bogosity)
+(provide make-timeline)
 
 (define timeline-phase? (hash/c symbol? any/c))
 (define timeline? (listof timeline-phase?))


### PR DESCRIPTION
This WIP PR is working on redoing the details page completely. Goals include:
 - Treat all alternatives equally. Don't highlight the "most accurate alternative" specially
 - Make the styling uniform
 - Show derivations for each alternative
 - Make proofs look good
 - Simplify the code to the extent possible 

TODO:

- [ ] Make the help links go somewhere real
- [x] Show accuracy and cost for each alternative
- [x] Show speedup at the top
- [x] Integrate bogosity somehow
- [x] Show preprocessing
- [x] Integrate dropdowns for changing language
- [x] Should we have the "Try it" section at all?