### PR TITLE
Fix Accuracy vs Speed missing data in web mode w/o --save-session

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -201,6 +201,11 @@
           (*reeval-pts* reeval)
           (*demo?* demo?)]
          [(list 'improve hash formula sema)
+          (eprintf "~a\n" (*demo-output*))
+          (when (not (*demo-output*))
+            (*demo-output* "./web-cache")
+            (eprintf "~a\n" (*demo-output*))
+              (make-directory (build-path (*demo-output*))))
           (define path (format "~a.~a" hash *herbie-commit*))
           (cond
            [(hash-has-key? *completed-jobs* hash)


### PR DESCRIPTION
Currently results.json isn't generated in web mode when --save-session isn't passed in. But with the recent improvements to Herbie 2.0 this leaves the graph.html page generated after Herbie has finished the job with missing data.

![Screenshot 2023-06-22 at 3 38 12 PM](https://github.com/herbie-fp/herbie/assets/39070793/bb8d2b50-4fc4-4059-b622-6358bf5a36aa)
![Screenshot 2023-06-22 at 3 37 45 PM](https://github.com/herbie-fp/herbie/assets/39070793/25e9eed2-ef89-4def-8778-5d81ee2fe676)
