### PR TITLE
Regimes fix on no-pareto

### DIFF
--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -419,7 +419,7 @@
        [(*pareto-mode*)
         (map (curryr combine-alts ctx) (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) ctx))]
        [else
-        (define option (infer-splitpoints all-alts ctx))
+        (define-values (option _) (infer-splitpoints all-alts ctx))
         (list (combine-alts option ctx))])]
      [else
       (list (argmin score-alt all-alts))]))


### PR DESCRIPTION
This PR fixes regime inference changes from #591 that break on the flag ``--no-pareto``.
Makes the parameter ``errs`` an optional keyword parameter. 
``errs`` defaults to an empty hash table; using default values when ``hash-ref`` does not find the key removes the need to externally calculate branch-expressions.