### PR TITLE
Serve `results.json` when running in unsaved web shell

### DIFF
--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -134,7 +134,9 @@
           (tests . ,(map simplify-test tests))
           (merged-cost-accuracy . ,merged-cost-accuracy)))]))
 
-  (call-with-atomic-output-file file (λ (p name) (write-json data p))))
+  (if (port? file)
+      (write-json data file)
+      (call-with-atomic-output-file file (λ (p name) (write-json data p)))))
 
 (define (flags->list flags)
   (for*/list ([rec (hash->list flags)] [fl (cdr rec)])

--- a/src/web/resources/404.html
+++ b/src/web/resources/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Herbie Page Not Found</title>
-  <link rel='stylesheet' type='text/css' href='/main.css'>
+  <link rel='stylesheet' type='text/css' href='/report.css'>
 </head>
 <body>
   <header>


### PR DESCRIPTION
The code is kind of ugly, but this PR replaces #616 without writing anything to the file system.