### PR TITLE
Fix errors from function discontinuities by converting infinities to valid JSON values.

### DIFF
--- a/src/float.rkt
+++ b/src/float.rkt
@@ -8,7 +8,7 @@
  ulp-difference ulps->bits
  midpoint random-generate
  </total <=/total
- value->string value->json
+ value->string value->json json->value
  real->repr repr->real)
 
 (define (ulp-difference x y repr)
@@ -61,6 +61,20 @@
        [(or +nan.0 +nan.f) (hash 'type "real" 'value "NaN")])]
     [_ (hash 'type (~a (representation-name repr))
              'ordinal (~a ((representation-repr->ordinal repr) x)))]))
+
+(define (json->value x repr)
+  (match x
+    [(? real?) x]
+    [(? hash?) 
+      (match (hash-ref x 'type) 
+        ["real"
+          (match (hash-ref x 'value)
+            ["-inf" -inf.0]
+            ["+inf" +inf.0]
+            ["NaN" +nan.0]
+            [_ +nan.0])]
+        [_ ((representation-ordinal->repr repr)
+              (string->number (hash-ref x 'ordinal)))])]))
 
 (define (value->string n repr)
   ;; Prints a number with relatively few digits

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -94,6 +94,6 @@
       (values (map real->repr pt var-reprs) (real->repr ex output-repr))))
   (mk-pcontext pts exs))
 
-(define (pcontext->json pcontext)
+(define (pcontext->json pcontext repr)
   (for/list ([(pt ex) (in-pcontext pcontext)])
-    (list pt ex)))
+    (list (map (curryr value->json repr) pt) (value->json ex repr))))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -91,7 +91,7 @@
   (define-values (pts exs)
     (for/lists (pts exs) ([entry (in-list json)])
       (match-define (list pt ex) entry)
-      (values (map real->repr pt var-reprs) (real->repr ex output-repr))))
+      (values (map real->repr pt var-reprs) (real->repr (json->value ex output-repr) output-repr))))
   (mk-pcontext pts exs))
 
 (define (pcontext->json pcontext repr)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -358,7 +358,7 @@
       (define pctx (job-result-backend result))
 
       (eprintf " complete\n")
-      (hasheq 'points (pcontext->json pctx)))))
+      (hasheq 'points (pcontext->json pctx (context-repr (test-context test)))))))
 
 (define analyze-endpoint
   (post-with-json-response


### PR DESCRIPTION
Bug originally reported [in this slack thread](https://davidtamaspar-r2y7532.slack.com/archives/C0G44MH4P/p1686595272352829)

Functions with discontinuities (e.g. 1/x from -1 to 1) were causing errors in Herbie (and consequently Oddysey) by creating infinite values that were not properly converted to JSON values. This PR fixes this by 

1. converting them to valid JSON values in pcontext->json, 
2. writing a new json->value function, and:
3. using the json->value function to convert points back into values in json->pcontext.

These changes have been verified using Odyssey to fix the discontinuity errors for: 
- 1/x from -1 to 1.
- 1/(sin(x)) from -1 to 1.
- 1/(exp(x) -1) from -1e308 to 1e308.