### PR TITLE
Migrate egg-herbie to Rust 2021

### DIFF
--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egg-herbie"
 version = "0.3.0"
 authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 egg = "0.9.5"


### PR DESCRIPTION
I followed [this page](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html). The diff was empty and `cargo build`, `cargo test`, and the Hamming benchmark all work. From what I've read about editions, it seems it's crate local, so everything should just work even though `egg` uses the 2018 edition. I basically just want to be able to use `TryInto` from the 2021 standard library in the memory leak fix.