### PR TITLE
Point initial and alternative options help links to report.html#alternatives.

### DIFF
--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -180,7 +180,7 @@
                              (data ,(format-accuracy (errors-score start-error) repr-bits #:unit "%")) " accurate, "
                              (data "1.0×") " speedup")
                        ,dropdown
-                       ,(render-help "report.html#initial"))
+                       ,(render-help "report.html#alternatives"))
                    ,body))
 
       ,@(for/list ([i (in-naturals 1)] [alt end-alts] [errs end-errors] [cost end-costs])
@@ -193,7 +193,7 @@
                   (data ,(format-accuracy (errors-score errs) repr-bits #:unit "%")) " accurate, "
                   (data ,(~r (/ (alt-cost start-alt repr) cost) #:precision '(= 1)) "×") " speedup")
                 ,dropdown
-                ,(render-help "report.html#alternative"))
+                ,(render-help "report.html#alternatives"))
             ,body
             (details
              (summary "Derivation")

--- a/www/doc/2.0/report.html
+++ b/www/doc/2.0/report.html
@@ -134,7 +134,7 @@
   are better than the initial program, and black otherwise. Each
   alternative is linked to its description lower on the page.</p>
 
-  <h2 id="initial">Initial program and Alternatives</h2>
+  <h2 id="alternatives">Initial program and Alternatives</h2>
 
   <p>Below the table come a series of boxes detailing the initial
     program and each of Herbie's alternatives, along with their


### PR DESCRIPTION
The help links for alternatives on the current reports page are broken right now, so I changed the link location for both initial and alternative expressions to "#alternatives" and set the ID of the appropriate paragraph of `www/docs/report.html` ("Initial program and Alternatives") to `alternatives`. I confirmed that this fix works on my system.