### PR TITLE
Fix calculate speedup

### DIFF
--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -38,9 +38,8 @@ function displayCrashTimeoutRatio(errors, total) {
 
 function calculateSpeedup(mergedCostAccuracy) {
     const initial_accuracy = mergedCostAccuracy[0][1]
-    // Deep copy
-    const copy = JSON.parse(JSON.stringify(mergedCostAccuracy[1]))
-    for (const point of copy.reverse()) {
+    const list = mergedCostAccuracy[1].reverse()
+    for (const point of list) {
         if (point[1] > initial_accuracy) {
             return point[0].toFixed(1) + "×"
         }

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -38,8 +38,9 @@ function displayCrashTimeoutRatio(errors, total) {
 
 function calculateSpeedup(mergedCostAccuracy) {
     const initial_accuracy = mergedCostAccuracy[0][1]
-    const list = mergedCostAccuracy[1].reverse()
-    for (const point of list) {
+    // Deep copy
+    const copy = JSON.parse(JSON.stringify(mergedCostAccuracy[1]))
+    for (const point of copy.reverse()) {
         if (point[1] > initial_accuracy) {
             return point[0].toFixed(1) + "×"
         }

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -38,9 +38,8 @@ function displayCrashTimeoutRatio(errors, total) {
 
 function calculateSpeedup(mergedCostAccuracy) {
     const initial_accuracy = mergedCostAccuracy[0][1]
-    // Deep copy
-    const copy = JSON.parse(JSON.stringify(mergedCostAccuracy[1]))
-    for (const point of copy.reverse()) {
+    const deepCopy = JSON.parse(JSON.stringify(mergedCostAccuracy[1]))
+    for (const point of deepCopy.reverse()) {
         if (point[1] > initial_accuracy) {
             return point[0].toFixed(1) + "×"
         }


### PR DESCRIPTION
Adds a deep copy to prevent `calculateSpeedup` from modifying the underlying data.

This feels wrong but this was the first solution I could find.