### PR TITLE
fix errors being added in reverse

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -53,7 +53,13 @@
     (make-hash
      (for*/list ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
        (cons (car subexpr) '()))))
-  (for ([(pt ex) (in-pcontext (*pcontext*))])
+
+  (define rev-points (reverse (
+    for/list ([(pt _) (in-pcontext (*pcontext*))])
+    pt
+  )))
+
+  (for ([(pt) rev-points])
     (define exacts (apply subexprs-fn pt))
     (define exacts-hash
       (make-immutable-hash (map cons (apply append subexprss) exacts)))


### PR DESCRIPTION
Fixes a small bug where, sampled points and local errors don't match up. The local error list was being built in reverse, so I just made it so that `compute-local-errors` iterates through the sampled points in reverse.