### PR TITLE
Preprocess initial simplify attempt 4

### DIFF
--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -304,7 +304,7 @@
   (match-define (cons initial simplified) alternatives)
   (*start-prog* (alt-expr initial))
   (define table (make-alt-table pcontext initial context))
-  (define simplified* (append-map (curryr starting-alts context) simplified))
+  (define simplified* (append (append-map (curryr starting-alts context) simplified) simplified))
   (define-values (errss costs) (atab-eval-altns table simplified* context))
   (^table^ (atab-add-altns table simplified* errss costs)))
 


### PR DESCRIPTION
This PR is actually attempt 2, without my reproducibility fixes, but with the bug fix. The bug is that, in trying to get `starting-alts` to work, we accidentally disabled initial simplify, which is essential for, like, the CI passing and stuff.