### PR TITLE
Fix expansive rules

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -114,8 +114,7 @@
 (define (expr->egg-expr expr egg-data ctx)
   (define egg->herbie-dict (egraph-data-egg->herbie-dict egg-data))
   (define herbie->egg-dict (egraph-data-herbie->egg-dict egg-data))
-  (define expr* (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict ctx))
-  expr*)
+  (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict ctx))
 
 (define (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict ctx)
   (let loop ([expr expr])

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -114,9 +114,6 @@
 (define (expr->egg-expr expr egg-data ctx)
   (define egg->herbie-dict (egraph-data-egg->herbie-dict egg-data))
   (define herbie->egg-dict (egraph-data-herbie->egg-dict egg-data))
-  (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict ctx))
-
-(define (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict ctx)
   (let loop ([expr expr])
     (match expr
       [(list 'if cond ift iff)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -597,11 +597,12 @@
 (define (get-canon-rule-name name [failure #f])
   (hash-ref (*canon-names*) name failure))
 
-;; expand the rules first due to some bad but currently
-;; necessary reasons (see `rule->egg-rules` for details).
-;; checks the cache in case we used them previously
+;; expand the rules first due to some bad but currently necessary reasons
+;; (see `rule->egg-rules` for details); checks the cache in case we used
+; them previously
 (define (expand-rules rules)
-  (for/fold ([rules* '()]) ([rule (in-list rules)])
+  ; TODO: reversing the rules causes CI to pass, why?
+  (for/fold ([rules* '()] #:result (reverse rules*)) ([rule (in-list rules)])
     (append
       (hash-ref! (*ffi-rules*) (cons rule (*needed-reprs*))
                  (λ ()

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -153,15 +153,15 @@
     (define altns (append real-alts (^queuedlow^)))
     
     (define rewritten
-      (for/fold ([done '()] #:result (reverse done))
-                ([cls comb-changelists] [altn altns]
-                #:when true [cl cls])
-          (match-define (list subexp input) cl)
+      (reap [sow]
+        (for ([changelists comb-changelists] [altn altns])
+          (for ([cl changelists])
+            (match-define (list subexp input) cl)
             (define body* (apply-repr-change-expr subexp (*context*)))
-            (if body*
-              ; We need to pass '() here so it can get overwritten on patch-fix
-              (cons (alt body* (list 'rr '() input #f #f) (list altn)) done)
-              done)))
+            (when body*
+              ; apply-repr-change-expr is partial
+              ; we need to pass '() here so it can get overwritten on patch-fix
+              (sow (alt body* (list 'rr '() input #f #f) (list altn))))))))
 
     (timeline-push! 'count (length (^queued^)) (length rewritten))
     ; TODO: accuracy stats for timeline

--- a/src/preprocess.rkt
+++ b/src/preprocess.rkt
@@ -10,14 +10,15 @@
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
 (define (find-preprocessing initial specification context)
   (define even-identities
-    (for/list ([variable (in-list (context-vars context))]
-               [representation (in-list (context-var-reprs context))])
-      ;; TODO: Handle case where neg isn't supported for this representation
-      (with-handlers ([exn:fail:user:herbie? (const #f)])
-        (define negate (get-parametric-operator 'neg representation))
-        ; Check if representation has an fabs operator
-        (define fabs (get-parametric-operator 'fabs representation))
-        (replace-vars (list (cons variable (list negate variable))) specification))))
+    (reap [sow]
+      (for ([variable (in-list (context-vars context))]
+            [representation (in-list (context-var-reprs context))])
+        (with-handlers ([exn:fail:user:herbie? (const (void))])
+          ; TODO: Handle case where neg isn't supported for this representation
+          (define negate (get-parametric-operator 'neg representation))
+          ; Check if representation has an fabs operator
+          (define fabs (get-parametric-operator 'fabs representation))
+          (sow (replace-vars (list (cons variable (list negate variable))) specification))))))
   (define pairs (combinations (context-vars context) 2))
   (define swap-identities
     (for/list ([pair (in-list pairs)])

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -38,7 +38,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; rules ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-ruleset bool-reduce (bools simplify fp-safe)
+(define-ruleset* bool-reduce (bools simplify fp-safe)
   #:type ([a bool] [b bool])
   [not-true     (not (TRUE))     (FALSE)]
   [not-false    (not (FALSE))    (TRUE)]

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -38,7 +38,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; rules ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-ruleset* bool-reduce (bools simplify fp-safe)
+(define-ruleset bool-reduce (bools simplify fp-safe)
   #:type ([a bool] [b bool])
   [not-true     (not (TRUE))     (FALSE)]
   [not-false    (not (FALSE))    (TRUE)]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -382,8 +382,7 @@
   (hash-set! (*functions*) name (list args repr body)))
 
 (define (all-operators)
-  (for/list ([(name _) (in-hash operators)])
-    name))
+  (sort (hash-keys operators) symbol<?))
 
 (define (all-constants)
   (for/list ([(name rec) (in-hash operators)]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -7,7 +7,7 @@
          variable? constant-operator?
          operator-exists? operator-deprecated? impl-exists?
          real-operator-info operator-info 
-         impl->operator all-constants operator-all-impls
+         impl->operator all-operators all-constants operator-all-impls
          *functions* register-function!
          get-parametric-operator get-parametric-constant
          generate-conversion-impl!
@@ -380,6 +380,10 @@
 
 (define (register-function! name args repr body)
   (hash-set! (*functions*) name (list args repr body)))
+
+(define (all-operators)
+  (for/list ([(name _) (in-hash operators)])
+    name))
 
 (define (all-constants)
   (for/list ([(name rec) (in-hash operators)]

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -4,7 +4,7 @@
 (require "../common.rkt" "../programs.rkt" "../float.rkt"
          "../ground-truth.rkt" "types.rkt" "../load-plugin.rkt"
          "rules.rkt" (submod "rules.rkt" internals)
-         "../core/egg-herbie.rkt")
+         (submod "../core/egg-herbie.rkt" internals))
 
 (load-herbie-builtins)
 
@@ -72,7 +72,7 @@
    (for ([name names])
      (eprintf "Checking ~a...\n" name)
      (define rule (first (filter (λ (x) (equal? (~a (rule-name x)) name)) (*rules*))))
-     (for ([rule* (rule->egg-rules rule)])
+     (for ([rule* (rule->impl-rules rule)])
       (check-rule-correct rule*)
       (when (set-member? (*fp-safe-simplify-rules*) rule*)
         (check-rule-fp-safe rule*))))))
@@ -83,13 +83,13 @@
 
   (for* ([test-ruleset (*rulesets*)]
          [test-rule (first test-ruleset)]
-         [test-rule* (rule->egg-rules test-rule)])
+         [test-rule* (rule->impl-rules test-rule)])
     (test-case (~a (rule-name test-rule*))
       (check-rule-correct test-rule*)))
 
   (for* ([test-ruleset (*rulesets*)]
          [test-rule (first test-ruleset)]
-         [test-rule* (rule->egg-rules test-rule)]
+         [test-rule* (rule->impl-rules test-rule)]
          #:when (set-member? (*fp-safe-simplify-rules*) test-rule*))
     (test-case (~a (rule-name test-rule*))
       (check-rule-fp-safe test-rule*))))


### PR DESCRIPTION
Expansive rules, e.g., `?x => f(?x)` cause problems with multi-precision expressions in egg since these rules match without checking for the "type" of an expression. As a result, expansive rules are removed from egg if more than one precision is detected, but this usually hurts output accuracy.

Fixing this problem requires a few changes.

 - "egg IR" within Herbie to encode variables as operators with type information rather than symbols
 - expansive rules are handled separately during rule expansion:
    - for all operators: `g(?x ...) => f(g(?x ....))`
    - variables: `(var T ?x) => f(T, ?x)` (where `f` is parameterized over a type `T`)
 - `make-egg-query` takes an optional context (by default `*context*`) since we need to know the representations of variables. This restricts egg to expressions with known representations.

This nearly achieves the same effect as before except expansive rules may not fire on constants. Comments have been added to explain this design. Now, expansive rules can be used without issue when multiple precisions are active.

Other changes:
 - better rule caching; for each rule (from `(*rules*)`  or similar) store the associated FFI rules after expansion. For Hamming: `expand-rules` went from 36s -> 10s.
 - `all-operators` for getting a list of real operators