### PR TITLE
Adds a link to jump to the Metrics/ Timeline page from the reports page

### DIFF
--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -436,6 +436,10 @@ function tableRow(test) {
             Element("a", {
                 href: `${test.link}/graph.html`
             }, ["»"])]),
+        Element("td", {}, [
+            Element("a", {
+                href: `${test.link}/timeline.html`
+            }, ["📊"])]),
     ])
     tr.addEventListener("click", () => tr.querySelector("a").click())
     return tr
@@ -566,6 +570,10 @@ function tableRowDiff(test) {
             Element("a", {
                 href: `${test.link}/graph.html`
             }, ["»"])]),
+        Element("td", {}, [
+            Element("a", {
+                href: `${test.link}/timeline.html`
+            }, ["📊"])]),
     ])
     tr.addEventListener("click", () => tr.querySelector("a").click())
     return { tr: tr, equal: hideRow }


### PR DESCRIPTION
Adds a simple link to the reports page so you can skip to the timeline without needing to route through graph.html

Wasn't sure on which symbol to use so went with Unicode.