### PR TITLE
Share code between `compile-specs` and `compile-progs`

### DIFF
--- a/bench/hamming/machine-decide.fpcore
+++ b/bench/hamming/machine-decide.fpcore
@@ -3,9 +3,10 @@
 (FPCore (a x)
  :name "expax (section 3.5)"
  ;:herbie-expected 14
+ :pre (> 710 (* a x))
+ ; Hamming suggests using Taylor expansion for ax small
+ ; We use expm1 as it specifically avoids cancellation for ax small
  :herbie-target
- (if (< (fabs (* a x)) 1/10)
-   (* (* a x) (+ 1 (+ (/ (* a x) 2) (/ (pow (* a x) 2) 6))))
-   (- (exp (* a x)) 1))
+ (expm1 (* a x))
 
  (- (exp (* a x)) 1))

--- a/bench/hamming/overflow-underflow.fpcore
+++ b/bench/hamming/overflow-underflow.fpcore
@@ -2,7 +2,10 @@
 
 (FPCore (x)
  :name "expq2 (section 3.11)"
+ :pre (> 715 x)
  :herbie-target
- (/ 1 (- 1 (exp (- x))))
+ ; Hamming version was not accurated. Dealt with overflow/underflow but not cancellation.
+ ; Used expm1 to deal with cancellation.
+ (/ (- 1) (expm1 (- x)))
 
  (/ (exp x) (- (exp x) 1)))

--- a/bench/hamming/rearrangement.fpcore
+++ b/bench/hamming/rearrangement.fpcore
@@ -3,15 +3,17 @@
 (FPCore (x)
  :name "2sqrt (example 3.1)"
  :herbie-target
- (/ 1 (+ (sqrt (+ x 1)) (sqrt x)))
+ (if (<= x 66000000.0)
+    (- (sqrt (+ 1.0 x)) (sqrt x))
+    (/ 1 (+ (sqrt (+ x 1.0)) (sqrt x))))
 
  (- (sqrt (+ x 1)) (sqrt x)))
 
 (FPCore (x eps)
  :name "2sin (example 3.3)"
  :herbie-target
- (* 2 (* (cos (+ x (/ eps 2))) (sin (/ eps 2))))
-
+ (fma (sin x) (- (cos eps) 1) (* (sin eps) (cos x)))
+ 
  (- (sin (+ x eps)) (sin x)))
 
 (FPCore (x)

--- a/bench/hamming/series.fpcore
+++ b/bench/hamming/series.fpcore
@@ -40,9 +40,11 @@
 
 (FPCore (a b eps)
  :name "expq3 (problem 3.4.2)"
- :pre (and (< -1 eps) (< eps 1))
+ :pre (and (< (fabs eps) (fabs (/ (+ a b) 1e5))) (<  (fabs a) 710) (< (fabs b) 710))
+ ; We want epsilon small compared to a and b according to Hamming. Bound by 710 to avoid sampling infinite values.
  :herbie-target
- (/ (+ a b) (* a b))
+ ; Hammings' rewrite
+ (+ (/ 1 a) (/ 1 b))
 
  (/
   (* eps (- (exp (* (+ a b) eps)) 1))

--- a/bench/hamming/temp-rearrangement.fpcore
+++ b/bench/hamming/temp-rearrangement.fpcore
@@ -1,0 +1,23 @@
+; -*- mode: scheme -*-
+
+(FPCore (x)
+ :name "2sqrt (example 3.1)"
+ :herbie-target
+ (/ 1 (+ (sqrt (+ x 1.0)) (sqrt x)))
+
+ (- (sqrt (+ x 1)) (sqrt x)))
+
+(FPCore (x eps)
+ :name "2sin (example 3.3)"
+ :herbie-target
+ (fma (cos x) (sin eps) (* (sin x) (- (cos eps) 1))) ; Goes from 76.6 to 99.2 (fma (sin x) (- (cos eps) 1) (* (sin eps) (cos x)))
+ 
+ (- (sin (+ x eps)) (sin x)))
+
+ (FPCore (x)
+  :name "tanhf (example 3.4)"
+  ;:herbie-expected 2
+  :herbie-target
+  (tan (/ x 2)) ; As good as it gets by Odyssey, Herbie graohs
+ 
+  (/ (- 1 (cos x)) (sin x)))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -139,6 +139,46 @@
     (for/list ([root (in-list roots)])
       (vector-ref vregs root))))
 
+(define (make-compiler arg->precision operator-handler operator-type-handler
+                       if-handler if-type interpreter-name)
+  (lambda (exprs vars type)
+    ;; Instruction cache
+    (define icache '())
+    (define exprhash
+      (make-hash
+       (for/list ([var vars] [i (in-naturals)])
+         (cons var i))))
+
+    ; Counts
+    (define size 0)
+    (define exprc 0)
+    (define varc (length vars))
+
+    ; Translates programs into an instruction sequence
+    (define (munge prog type)
+      (set! size (+ 1 size))
+      (define expr
+        (match prog
+          [(? number?) (list (const (arg->precision prog type)))]
+          [(? variable?) prog]
+          [`(if ,c ,t ,f)
+           (list if-handler (munge c if-type) (munge t type) (munge f type))]
+          [(list op args ...)
+           (cons (operator-handler op) (map munge args (operator-type-handler op)))]
+          ;; (cons (operator-info op 'ival) (map munge args))]
+          [_ (raise-argument-error 'compile-specs "Not a valid expression!" prog)]))
+      (hash-ref! exprhash expr
+                 (λ ()
+                   (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
+                     (set! exprc (+ 1 exprc))
+                     (set! icache (cons expr icache))))))
+
+    (define names (map (curryr munge type) exprs))
+    (timeline-push! 'compiler (+ varc size) (+ exprc varc))
+    (define ivec (list->vector (reverse icache)))
+    (define interpret (make-progs-interpreter vars ivec names))
+    (procedure-rename interpret (string->symbol (format "<eval-prog-~a>" interpreter-name)))))
+
 (define (compile-spec spec vars)
   (compose first (compile-specs (list spec) vars)))
 
@@ -149,89 +189,23 @@
 ;; that evaluates the program on a single input of intervals
 ;; returning intervals.
 (define (compile-specs specs vars)
-  ;; Instruction cache
-  (define icache '())
-  (define exprhash
-    (make-hash
-     (for/list ([var vars] [i (in-naturals)])
-       (cons var i))))
-
-  ; Counts
-  (define size 0)
-  (define exprc 0)
-  (define varc (length vars))
-
-  ; Translates programs into an instruction sequence
-  (define (munge prog)
-    (set! size (+ 1 size))
-    (define expr
-      (match prog
-       [(? number?) (list (const (ival (bf prog))))]
-       [(? variable?) prog]
-       [`(if ,c ,t ,f)
-        (list ival-if (munge c) (munge t) (munge f))]
-       [(list op args ...)
-        (cons (operator-info op 'ival) (map munge args))]
-       [_ (raise-argument-error 'compile-specs "Not a valid expression!" prog)]))
-    (hash-ref! exprhash expr
-              (λ ()
-                (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                  (set! exprc (+ 1 exprc))
-                  (set! icache (cons expr icache))))))
-
-  (define names (map munge specs))
-  (timeline-push! 'compiler (+ varc size) (+ exprc varc))
-  (define ivec (list->vector (reverse icache)))
-  (define interpret (make-progs-interpreter vars ivec names))
-  (procedure-rename interpret (string->symbol "<eval-prog-ival>")))
+  ((make-compiler
+    (lambda (prog _) (ival (bf prog)))
+    (curryr operator-info 'ival) (curryr operator-info 'itype)
+    ival-if 'bool
+    "ival")
+   specs vars 'real))
 
 ;; Compiles a program of operator implementations into a procedure
 ;; that evaluates the program on a single input of representation values
 ;; returning representation values.
 (define (compile-progs exprs ctx)
-  (define repr (context-repr ctx))
-  (define vars (context-vars ctx))
-
-  ;; Expression cache
-  (define icache '())
-  (define exprhash
-    (make-hash
-     (for/list ([var vars] [i (in-naturals)])
-       (cons var i))))
-
-  ; Counts
-  (define size 0)
-  (define exprc 0)
-  (define varc (length vars))
-
-  ; Translates programs into an instruction sequence
-  (define (munge prog repr)
-    (set! size (+ 1 size))
-    (define expr
-      (match prog
-       [(? number?) (list (const (real->repr prog repr)))]
-       [(? variable?) prog]
-       [`(if ,c ,t ,f)
-        (list (λ (c ift iff) (if c ift iff))
-              (munge c (get-representation 'bool))
-              (munge t repr)
-              (munge f repr))]
-       [(list op args ...)
-        (define fn (impl-info op 'fl))
-        (define atypes (impl-info op 'itype))
-        (cons fn (map munge args atypes))]
-       [_ (raise-argument-error 'eval-prog "Not a valid expression!" prog)]))
-    (hash-ref! exprhash expr
-              (λ ()
-                (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                  (set! exprc (+ 1 exprc))
-                  (set! icache (cons expr icache))))))
-
-  (define names (for/list ([expr exprs]) (munge expr repr)))
-  (timeline-push! 'compiler (+ varc size) (+ exprc varc))
-  (define ivec (list->vector (reverse icache)))
-  (define interpret (make-progs-interpreter vars ivec names))
-  (procedure-rename interpret (string->symbol "<eval-prog-fl>")))
+  ((make-compiler
+    real->repr
+    (curryr impl-info 'fl) (curryr impl-info 'itype)
+    (λ (c ift iff) (if c ift iff)) (get-representation 'bool)
+    "fl")
+   exprs (context-vars ctx) (context-repr ctx)))
 
 ;; This is a transcription of egg-herbie/src/math.rs, lines 97-149
 (define (eval-application op . args)


### PR DESCRIPTION
Share code between the two compiler versions. The specs version passes around a type that isn't really used, but this might not be the worst thing in the world because @AYadrov might want to modify the types during munge to have variable precision for the trigonometric functions.