### PR TITLE
Fix rewrite once

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -8,7 +8,7 @@
          flip-lists drop-at find-duplicates partial-sums
          argmins argmaxs set-disjoint? subsequence? list-set* disjoint-set
          disjoint-set-find! disjoint-set-union! get-seed set-seed!
-         quasisyntax dict sym-append
+         quasisyntax dict sym-append string-replace*
          format-time format-bits format-accuracy format-cost web-resource
          (all-from-out "config.rkt"))
 
@@ -271,3 +271,10 @@
 (define (sym-append . args)
   (string->symbol (apply string-append (map ~a args))))
 
+(define/contract (string-replace* str changes)
+  (-> string? (listof (cons/c string? string?)) string?)
+  (let loop ([str str] [changes changes])
+    (match changes
+      [(? null?) str]
+      [_ (let ([change (car changes)])
+           (loop (string-replace str (car change) (cdr change)) (cdr changes)))])))

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -273,8 +273,6 @@
 
 (define/contract (string-replace* str changes)
   (-> string? (listof (cons/c string? string?)) string?)
-  (let loop ([str str] [changes changes])
-    (match changes
-      [(? null?) str]
-      [_ (let ([change (car changes)])
-           (loop (string-replace str (car change) (cdr change)) (cdr changes)))])))
+  (for/fold ([str str]) ([change changes])
+    (match-define (cons from to) change)
+    (string-replace str from to)))

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -60,7 +60,6 @@
            (list if-proc (munge c cond-type) (munge t type) (munge f type))]
           [(list op args ...)
            (cons (op->proc op) (map munge args (op->itypes op)))]
-          ;; (cons (operator-info op 'ival) (map munge args))]
           [_ (raise-argument-error 'compile-specs "Not a valid expression!" prog)]))
       (hash-ref! exprhash expr
                  (λ ()
@@ -81,8 +80,18 @@
   (define compile
     (make-compiler 'ival
                    #:input->value (lambda (prog _) (ival (bf prog)))
-                   #:op->procedure (lambda (op) (operator-info op 'ival))
-                   #:op->itypes (lambda (op) (operator-info op 'itype))
+                   #:op->procedure (lambda (op)
+                                    (match op
+                                      [(? repr-conv? impl) ; strangeness with specs
+                                       (operator-info (impl->operator impl) 'ival)]
+                                      [_
+                                       (operator-info op 'ival)]))
+                   #:op->itypes (lambda (op)
+                                  (match op
+                                    [(? repr-conv? impl) ; strangeness with specs
+                                     (operator-info (impl->operator impl) 'itype)]
+                                    [_
+                                     (operator-info op 'itype)]))
                    #:if-procedure ival-if
                    #:cond-type 'bool))
   (compile specs vars 'real))

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -169,21 +169,21 @@
 ;; that evaluates the program on a single input of intervals
 ;; returning intervals.
 (define (compile-specs specs vars)
+  ; strangeness with specs: need to check for `repr-conv?` operators
+  ; normally we'd call `repr-conv?` from `src/syntax/syntax.rkt`
+  ; but it will check the entire table of operators every call,
+  ; so greedily compute the set ahead of time
+  (define repr-convs (operator-all-impls 'cast))
+  (define (real-op op)
+    (if (member op repr-convs)
+        (impl->operator op)
+        op))
+
   (define compile
     (make-compiler 'ival
                    #:input->value (lambda (prog _) (ival (bf prog)))
-                   #:op->procedure (lambda (op)
-                                    (match op
-                                      [(? repr-conv? impl) ; strangeness with specs
-                                       (operator-info (impl->operator impl) 'ival)]
-                                      [_
-                                       (operator-info op 'ival)]))
-                   #:op->itypes (lambda (op)
-                                  (match op
-                                    [(? repr-conv? impl) ; strangeness with specs
-                                     (operator-info (impl->operator impl) 'itype)]
-                                    [_
-                                     (operator-info op 'itype)]))
+                   #:op->procedure (lambda (op) (operator-info (real-op op) 'ival))
+                   #:op->itypes (lambda (op) (operator-info (real-op op) 'itype))
                    #:if-procedure ival-if
                    #:cond-type 'bool))
   (compile specs vars 'real))

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -9,14 +9,6 @@
 
 (define *conversions* (make-parameter (hash)))
 
-(define/contract (string-replace* str changes)
-  (-> string? (listof (cons/c string? string?)) string?)
-  (let loop ([str str] [changes changes])
-    (match changes
-      [(? null?) str]
-      [_ (let ([change (car changes)])
-           (loop (string-replace str (car change) (cdr change)) (cdr changes)))])))
-
 (define (repr->symbol repr)
   (define replace-table `((" " . "_") ("(" . "") (")" . "")))
   (string->symbol (string-replace* (~a (representation-name repr)) replace-table)))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -124,3 +124,21 @@
 
     (timeline-push! 'outputs (map ~a (apply append variantss)))
     out]))
+
+(module+ test
+  (require rackunit)
+  (require "../syntax/types.rkt" "../load-plugin.rkt")
+  (load-herbie-builtins)
+
+  (define repr (get-representation 'binary64))
+  (*context* (make-debug-context '()))
+  (*context* (context-extend (*context*) 'x repr))
+  (*needed-reprs* (list repr))
+
+  (let ([chngs (rewrite-once '(+.f64 x x) (*context*) #:rules (*rules*))])
+    (check-equal? (length chngs) 13 (format "rewrites ~a" chngs)))
+
+  (let ([chngs (rewrite-once '(*.f64 x x) (*context*) #:rules (*rules*))])
+    (check-equal? (length chngs) 11 (format "rewrites ~a" chngs)))
+
+  (void))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -1,10 +1,14 @@
 #lang racket
 
-(require "../syntax/types.rkt" "../syntax/syntax.rkt" "../syntax/rules.rkt")
-(require "../common.rkt" "../programs.rkt" "../alternative.rkt" "egg-herbie.rkt"
-         "../timeline.rkt")
+(require "../syntax/syntax.rkt"
+         "../syntax/rules.rkt"
+         "../common.rkt"
+         "../programs.rkt"
+         "../timeline.rkt"
+         "egg-herbie.rkt")
 
-(provide pattern-match rewrite-expressions)
+(provide pattern-match
+         rewrite-expressions)
 
 ;;; Our own pattern matcher.
 ;;
@@ -114,7 +118,7 @@
     (match-define (cons variantss _) (run-egg e-input #t))
 
     (define out
-      (for/list ([expr exprs] [variants variantss])
+      (for/list ([variants variantss])
         (for/list ([variant (remove-duplicates variants)])
             (list variant e-input))))
 

--- a/src/reprs/runtime/utils.rkt
+++ b/src/reprs/runtime/utils.rkt
@@ -14,7 +14,7 @@
   (λ (x) (+ (fn x) shift-val)))
 
 (define (sym-append . args)
-  (define strs (map symbol->string args))
+  (define strs (map ~s args))
   (string->symbol (apply string-append strs)))
 
 (define-syntax-rule (define-constants repr [name impl-name value] ...)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -46,7 +46,7 @@
   (-> symbol? ruleset? void?)
   (when (dict-has-key? (*rulesets*) name)
     (warn 'rulesets "Duplicate ruleset ~a, skipping" name))
-  (*rulesets* (dict-set (*rulesets*) name ruleset)))
+  (*rulesets* (cons (cons name ruleset) (*rulesets*))))
 
 ;; Rules: fp-safe-simplify ⊂ simplify ⊂ all
 ;;

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -263,6 +263,8 @@
      `(if ,(prog->spec cond) ,(prog->spec ift) ,(prog->spec iff))]
     [`(,(? repr-conv? impl) ,body)
      `(,impl ,(prog->spec body))]
+    [`(,(? rewrite-repr-op? impl) ,body)
+     `(,impl ,(prog->spec body))]
     [`(,impl ,args ...)
      (define op (impl->operator impl))
      (define args* (map prog->spec args))
@@ -309,6 +311,9 @@
          (match-define (list irepr) (impl-info impl 'itype))
          (define-values (body* _) (loop body (struct-copy context ctx [repr irepr])))
          (values `(,impl ,body*) (impl-info impl 'otype))]
+        [`(,(? rewrite-repr-op? impl) ,body)
+         (define-values (body* repr*) (loop body ctx))
+         (values `(,impl ,body*) repr*)]
         [`(,op ,args ...)
          (define-values (args* atypes)
            (for/lists (args* atypes) ([arg args])

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -81,13 +81,13 @@
   (*needed-reprs* (map get-representation '(binary64 binary32 bool)))
   (define _ (*simplify-rules*))  ; force an update
 
-  (for* ([test-ruleset (*rulesets*)]
+  (for* ([(_ test-ruleset) (in-dict (*rulesets*))]
          [test-rule (first test-ruleset)]
          [test-rule* (rule->impl-rules test-rule)])
     (test-case (~a (rule-name test-rule*))
       (check-rule-correct test-rule*)))
 
-  (for* ([test-ruleset (*rulesets*)]
+  (for* ([(_ test-ruleset) (in-dict (*rulesets*))]
          [test-rule (first test-ruleset)]
          [test-rule* (rule->impl-rules test-rule)]
          #:when (set-member? (*fp-safe-simplify-rules*) test-rule*))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -4,7 +4,7 @@
 (require "../common.rkt" "../compiler.rkt" "../float.rkt"
          "../ground-truth.rkt" "types.rkt" "../load-plugin.rkt"
          "rules.rkt" (submod "rules.rkt" internals)
-         (submod "../core/egg-herbie.rkt" internals))
+         "../core/egg-herbie.rkt")
 
 (load-herbie-builtins)
 


### PR DESCRIPTION
This PR includes bug fixes and other non-platforms changes cleaved out from #683.
- `rewrite-once` just didn't work, left out of #672 (unit test included to ensure it works)
- compiler handles strangeness around casts in specs (Herbie IR weirdness, unfortunately the best workaround)

Should make review and merging of #683 easier.