### PR TITLE
Fixed derivation bug on graph.html

### DIFF
--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -75,9 +75,9 @@
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li ([class "event"]) "Using strategy " (code ,(~a strategy))))]
 
-    [(alt prog 'add-preprocessing _ _)
+    [(alt prog 'add-preprocessing `(,prev) _)
       ;; TODO message to user is? proof later
-      '(,@(render-history prev pcontext pcontext2 ctx)
+      `(,@(render-history prev pcontext pcontext2 ctx)
         (li "Add Preprocessing"))]	
 
     [(alt _ `(regimes ,splitpoints) prevs _)


### PR DESCRIPTION
This fixes a small bug with the graph.html page not displaying the Derivations for the alt as shown below.

![Derivation](https://github.com/herbie-fp/herbie/assets/39070793/d702c177-bca0-4a13-be5a-c66c269708ae)
