### PR TITLE
Reorganize 'ground-truth.rkt' and 'sampling.rkt'

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -4,7 +4,8 @@
 (require "../common.rkt" "../alternative.rkt" "../timeline.rkt" "../errors.rkt"
          "../syntax/types.rkt" "../syntax/sugar.rkt" "../syntax/syntax.rkt"
          "../compiler.rkt" "../programs.rkt" "../points.rkt" "regimes.rkt"
-         "../float.rkt" "../pretty-print.rkt" "../ground-truth.rkt")
+         "../float.rkt" "../pretty-print.rkt" "../sampling.rkt" 
+         "../ground-truth.rkt")
 
 (provide combine-alts (struct-out sp) splitpoints->point-preds)
 

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -1,10 +1,34 @@
 #lang racket
 
-(require math/bigfloat rival)
-(require "syntax/sugar.rkt" "syntax/types.rkt"
-         "common.rkt" "compiler.rkt" "sampling.rkt" "timeline.rkt"
-         "errors.rkt")
-(provide sample-points batch-prepare-points make-search-func eval-progs-real)
+(require math/bigfloat
+         rival)
+
+(require "syntax/types.rkt"
+         "common.rkt"
+         "compiler.rkt")
+
+(provide eval-progs-real
+         ground-truth-require-convergence 
+         ival-eval
+         make-search-func)
+
+(define ground-truth-require-convergence (make-parameter #t))
+
+(define (is-infinite-interval repr interval)
+  (define <-bf (representation-bf->repr repr))
+  (define ->bf (representation-repr->bf repr))
+  ;; HACK: the comparisons to 0.bf is just about posits, where right now -inf.bf
+  ;; rounds to the NaR value, which then represents +inf.bf, which is positive.
+  (define (positive-inf? x)
+    (parameterize ([bf-rounding-mode 'nearest])
+      (and (bigfloat? x) (bf> x 0.bf) (bf= (->bf (<-bf x)) +inf.bf))))
+  (define (negative-inf? x)
+    (parameterize ([bf-rounding-mode 'nearest])
+      (and (bigfloat? x) (bf< x 0.bf) (bf= (->bf (<-bf x)) -inf.bf))))
+  (define ival-positive-infinite (monotonic->ival positive-inf?))
+  (define ival-negative-infinite (comonotonic->ival negative-inf?))
+  (ival-or (ival-positive-infinite interval)
+           (ival-negative-infinite interval)))
 
 (define (is-samplable-interval repr interval)
   (define <-bf (representation-bf->repr repr))
@@ -13,7 +37,6 @@
       (or (equal? lo* hi*) (and (number? lo*) (= lo* hi*)))))
   ((close-enough->ival close-enough?) interval))
 
-(define ground-truth-require-convergence (make-parameter #t))
 
 ;; Returns a function that maps an ival to a list of ivals
 ;; The first element of that function's output tells you if the input is good
@@ -43,6 +66,24 @@
         'unsamplable)
        y))))
 
+(define (ival-eval repr fn pt #:precision [precision (*starting-prec*)])
+  (let loop ([precision precision])
+    (define exs (parameterize ([bf-precision precision]) (apply fn pt)))
+    (match-define (ival err err?) (apply ival-or (map ival-error? exs)))
+    (define precision* (exact-floor (* precision 2)))
+    (cond
+     [err
+      (values err precision +nan.0)]
+     [(not err?)
+      (define infinite?
+      (ival-lo (is-infinite-interval repr (apply ival-or exs))))
+      (values (if infinite? 'infinite 'valid) precision exs)
+     ]
+     [(> precision* (*max-mpfr-prec*))
+      (values 'exit precision +nan.0)]
+     [else
+      (loop precision*)])))
+
 ; ENSURE: all contexts have the same list of variables
 (define (eval-progs-real progs ctxs)
   (define repr (context-repr (car ctxs)))
@@ -58,26 +99,3 @@
         ((representation-bf->repr (context-repr ctx*)) +nan.bf))]))
   (procedure-rename f '<eval-prog-real>))
 
-(define (combine-tables t1 t2)
-  (define t2-total (apply + (hash-values t2)))
-  (define t1-base (+ (hash-ref t1 'unknown 0) (hash-ref t1 'valid 0)))
-  (for/fold ([t1 (hash-remove (hash-remove t1 'unknown) 'valid)])
-      ([(k v) (in-hash t2)])
-    (hash-set t1 k (+ (hash-ref t1 k 0) (* (/ v t2-total) t1-base)))))
-
-(define (sample-points pre exprs ctxs)
-  (timeline-event! 'analyze)
-  (define fn (make-search-func pre exprs ctxs))
-  (match-define (cons sampler table)
-    (parameterize ([ground-truth-require-convergence #f])
-      ;; TODO: Should make-sampler allow multiple contexts?
-      (make-sampler (first ctxs) pre fn)))
-  (timeline-event! 'sample)
-  ;; TODO: should batch-prepare-points allow multiple contexts?
-  (match-define (cons table2 results) (batch-prepare-points fn (first ctxs) sampler))
-  (define total (apply + (hash-values table2)))
-  (when (> (hash-ref table2 'infinite 0.0) (* 0.2 total))
-   (warn 'inf-points #:url "faq.html#inf-points"
-    "~a of points produce a very large (infinite) output. You may want to add a precondition." 
-    (format-accuracy (- total (hash-ref table2 'infinite)) total #:unit "%")))
-  (cons (combine-tables table table2) results))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -13,14 +13,14 @@
          "alternative.rkt"
          "common.rkt"
          "conversions.rkt"
-         "error-table.rkt"
-         "ground-truth.rkt"     
+         "error-table.rkt"    
          "patch.rkt"
          "platform.rkt"
          "points.rkt"
          "preprocess.rkt"
          "programs.rkt"     
          "timeline.rkt"
+         "sampling.rkt"
          "soundiness.rkt")
 
 (provide (all-defined-out))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -3,9 +3,12 @@
          (only-in fpbench interval range-table-ref condition->range-table [expr? fpcore-expr?]))
 (require "searchreals.rkt" "errors.rkt" "common.rkt"
          "float.rkt" "syntax/types.rkt" "timeline.rkt" "config.rkt"
-         "syntax/sugar.rkt")
+         "syntax/sugar.rkt" "ground-truth.rkt")
 
-(provide make-sampler batch-prepare-points ival-eval)
+(provide batch-prepare-points
+         ival-eval
+         make-sampler 
+         sample-points)
 
 ;; Part 1: use FPBench's condition->range-table to create initial hyperrects
 
@@ -121,40 +124,6 @@
     (set! start now))
   log!)
 
-(define (ival-eval repr fn pt #:precision [precision (*starting-prec*)])
-  (let loop ([precision precision])
-    (define exs (parameterize ([bf-precision precision]) (apply fn pt)))
-    (match-define (ival err err?) (apply ival-or (map ival-error? exs)))
-    (define precision* (exact-floor (* precision 2)))
-    (cond
-     [err
-      (values err precision +nan.0)]
-     [(not err?)
-      (define infinite?
-      (ival-lo (is-infinite-interval repr (apply ival-or exs))))
-      (values (if infinite? 'infinite 'valid) precision exs)
-     ]
-     [(> precision* (*max-mpfr-prec*))
-      (values 'exit precision +nan.0)]
-     [else
-      (loop precision*)])))
-
-(define (is-infinite-interval repr interval)
-  (define <-bf (representation-bf->repr repr))
-  (define ->bf (representation-repr->bf repr))
-  ;; HACK: the comparisons to 0.bf is just about posits, where right now -inf.bf
-  ;; rounds to the NaR value, which then represents +inf.bf, which is positive.
-  (define (positive-inf? x)
-    (parameterize ([bf-rounding-mode 'nearest])
-      (and (bigfloat? x) (bf> x 0.bf) (bf= (->bf (<-bf x)) +inf.bf))))
-  (define (negative-inf? x)
-    (parameterize ([bf-rounding-mode 'nearest])
-      (and (bigfloat? x) (bf< x 0.bf) (bf= (->bf (<-bf x)) -inf.bf))))
-  (define ival-positive-infinite (monotonic->ival positive-inf?))
-  (define ival-negative-infinite (comonotonic->ival negative-inf?))
-  (ival-or (ival-positive-infinite interval)
-           (ival-negative-infinite interval)))
-
 (define (batch-prepare-points fn ctx sampler)
   ;; If we're using the bf fallback, start at the max precision
   (define repr (context-repr ctx))
@@ -186,3 +155,28 @@
         (loop sampled (+ 1 skipped) points exactss)])))
   (timeline-compact! 'outcomes)
   (cons outcomes (cons points (flip-lists exactss))))
+
+
+(define (combine-tables t1 t2)
+  (define t2-total (apply + (hash-values t2)))
+  (define t1-base (+ (hash-ref t1 'unknown 0) (hash-ref t1 'valid 0)))
+  (for/fold ([t1 (hash-remove (hash-remove t1 'unknown) 'valid)])
+      ([(k v) (in-hash t2)])
+    (hash-set t1 k (+ (hash-ref t1 k 0) (* (/ v t2-total) t1-base)))))
+
+(define (sample-points pre exprs ctxs)
+  (timeline-event! 'analyze)
+  (define fn (make-search-func pre exprs ctxs))
+  (match-define (cons sampler table)
+    (parameterize ([ground-truth-require-convergence #f])
+      ;; TODO: Should make-sampler allow multiple contexts?
+      (make-sampler (first ctxs) pre fn)))
+  (timeline-event! 'sample)
+  ;; TODO: should batch-prepare-points allow multiple contexts?
+  (match-define (cons table2 results) (batch-prepare-points fn (first ctxs) sampler))
+  (define total (apply + (hash-values table2)))
+  (when (> (hash-ref table2 'infinite 0.0) (* 0.2 total))
+   (warn 'inf-points #:url "faq.html#inf-points"
+    "~a of points produce a very large (infinite) output. You may want to add a precondition." 
+    (format-accuracy (- total (hash-ref table2 'infinite)) total #:unit "%")))
+  (cons (combine-tables table table2) results))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -2,7 +2,7 @@
 
 (require rackunit)
 (require "../common.rkt" "../compiler.rkt" "../float.rkt"
-         "../ground-truth.rkt" "types.rkt" "../load-plugin.rkt"
+         "../sampling.rkt" "types.rkt" "../load-plugin.rkt"
          "rules.rkt" (submod "rules.rkt" internals)
          "sugar.rkt" "../core/egg-herbie.rkt")
 


### PR DESCRIPTION
This PR addresses problems with import cycles encountered by @broughjt with accelerators. Reorganizes procedures in `ground-truth.rkt` and `sampling.rkt`:

 - `ground-truth.rkt` - the minimal number of procedures to compute ground truth values
 - `sampling.rkt` - all sampling procedures (uses `ground-truth.rkt`)

Hopefully `ground-truth.rkt` can import a minimal number of files.