### PR TITLE
Remove the `err-lsts` recomputation inside `infer-splitpoints`

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -4,7 +4,7 @@
          "../syntax/types.rkt" "../errors.rkt" "../points.rkt" "../float.rkt"
          "../compiler.rkt")
 
-(provide pareto-regimes infer-splitpoints (struct-out option) (struct-out si))
+(provide pareto-regimes (struct-out option) (struct-out si))
 
 (module+ test
   (require rackunit "../load-plugin.rkt")
@@ -23,28 +23,31 @@
 (struct si (cidx pidx) #:prefab)
 
 (define (pareto-regimes sorted ctx)
-  (define err-lsts (batch-errors (map alt-expr sorted) (*pcontext*) ctx))
-  (let loop ([alts sorted] [errs (hash)])
+  (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))
+  (let loop ([alts sorted] [errs (hash)] [err-lsts err-lsts])
     (cond
      [(null? alts) '()]
+     ; Only return one option if not pareto mode
+     [(and (not (*pareto-mode*)) (not (equal? alts sorted)))
+      '()]
      [else
       (define-values (opt new-errs) 
-        (infer-splitpoints alts #:errs errs ctx))
+        (infer-splitpoints alts err-lsts #:errs errs ctx))
       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
-      (cons opt (loop (take alts high) new-errs))])))
+      (cons opt (loop (take alts high) new-errs (take err-lsts high)))])))
 
 ;; `infer-splitpoints` and `combine-alts` are split so the mainloop
 ;; can insert a timeline break between them.
 
-(define (infer-splitpoints alts #:errs [cerrs (hash)] ctx)
+(define (infer-splitpoints alts err-lsts* #:errs [cerrs (hash)] ctx)
   (define branch-exprs
     (if (flag-set? 'reduce 'branch-expressions)
         (exprs-to-branch-on alts ctx)
         (context-vars ctx)))
   (timeline-event! 'regimes)
   (timeline-push! 'inputs (map (compose ~a alt-expr) alts))
-  (define err-lsts (batch-errors (map alt-expr alts) (*pcontext*) ctx))
   (define sorted-bexprs (sort branch-exprs (lambda (x y) (< (hash-ref cerrs x -1) (hash-ref cerrs y -1)))))
+  (define err-lsts (flip-lists err-lsts*))
 
   ;; invariant:
   ;; errs[bexpr] is some best option on branch expression bexpr computed on more alts than we have right now.
@@ -65,7 +68,6 @@
   (timeline-push! 'outputs
                   (for/list ([sidx (option-split-indices best)])
                     (~a (alt-expr (list-ref alts (si-cidx sidx))))))
-  (define err-lsts* (flip-lists err-lsts))
   (timeline-push! 'baseline (apply min (map errors-score err-lsts*)))
   (timeline-push! 'accuracy (errors-score (option-errors best)))
   (define repr (context-repr ctx))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -395,12 +395,9 @@
      [(and (flag-set? 'reduce 'regimes) (> (length all-alts) 1)
            (equal? (representation-type repr) 'real)
            (not (null? (context-vars ctx))))
-      (cond
-       [(*pareto-mode*)
-        (map (curryr combine-alts ctx) (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) ctx))]
-       [else
-        (define-values (option _) (infer-splitpoints all-alts ctx))
-        (list (combine-alts option ctx))])]
+      (define opts (pareto-regimes (sort all-alts < #:key (curryr alt-cost repr)) ctx))
+      (for/list ([opt (in-list opts)])
+        (combine-alts opt ctx))]
      [else
       (list (argmin score-alt all-alts))]))
   (define cleaned-alts


### PR DESCRIPTION
Basically, when doing `pareto-regimes`, we were recomputing the `err-lsts` every time the set of alts changed, but the set of alts just subsets so there's no reason to actually rerun the alt expressions themselves. Removing this recomputation makes Herbie about 1% faster in my tests, and also makes the interface to `regimes.rkt` a little nicer by moving the pareto case into `regimes.rkt`.