### PR TITLE
Fix installation instructions on Windows

### DIFF
--- a/www/doc/2.0/installing.html
+++ b/www/doc/2.0/installing.html
@@ -59,10 +59,11 @@ Welcome to Racket v8.9 [cs].
 
   <p>
     This installation method supports Windows, macOS, and Linux for
-    x86-64. It won't work for ARM computers, including recent Apple
-    computers. You may also need a working version
+    x86-64. You may also need a working version
     of <code>make</code>; on Windows, that might have to be installed
     separately.</p>
+
+  <P>But not if you use Windows lol</p>
 
   <p>First install Racket, as above. Then install Herbie from a package with:</p>
 


### PR DESCRIPTION
Currently the installation instructions on Windows have the problem that they are not mean enough to Windows users. This PR instead adds some insults to make Windows users feel worse lol.