### PR TITLE
Up the profile sampling rate to 100Hz

### DIFF
--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -279,6 +279,7 @@
         (profile-thunk
          (λ () (compute-result test))
          #:order 'total
+         #:delay 0.01
          #:render (λ (p order) (write-json (profile->json p) profile?)))
         (compute-result test)))
 


### PR DESCRIPTION
Herbie by default runs with a sampling profiler with a sampling rate of 20Hz. This PR ups it to 50Hz to try to get more accurate profiles. Frankly, if 100Hz works I'll try 250Hz and so on; we should go as high as possible before it starts creating a noticeable performance drag.