### PR TITLE
Up the sampling rate to 1000Hz

### DIFF
--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -279,7 +279,7 @@
         (profile-thunk
          (λ () (compute-result test))
          #:order 'total
-         #:delay 0.01
+         #:delay 0.001
          #:render (λ (p order) (write-json (profile->json p) profile?)))
         (compute-result test)))
 


### PR DESCRIPTION
Well, if 100Hz works, maybe 1000Hz also works. 1000Hz is actually a pretty normal sampling rate (I believe it is the default for Linux `perf` and more accurate profiles is worth investing in. Let's see what the slowdown is actually like; 100Hz was unmeasurable.