### PR TITLE
Categorize all rules as sound or unsound

### DIFF
--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -167,13 +167,13 @@
                         '((rname input output) ...))]))
 
 ; Commutativity
-(define-ruleset* commutativity (arithmetic simplify fp-safe)
+(define-ruleset* commutativity (arithmetic simplify fp-safe sound)
   #:type ([a real] [b real])
   [+-commutative     (+ a b)               (+ b a)]
   [*-commutative     (* a b)               (* b a)])
 
 ; Associativity
-(define-ruleset* associativity (arithmetic simplify)
+(define-ruleset* associativity (arithmetic simplify sound)
   #:type ([a real] [b real] [c real])
   [associate-+r+     (+ a (+ b c))         (+ (+ a b) c)]
   [associate-+l+     (+ (+ a b) c)         (+ a (+ b c))]
@@ -188,17 +188,17 @@
   [associate-*r/     (* a (/ b c))         (/ (* a b) c)]
   [associate-*l/     (* (/ a b) c)         (/ (* a c) b)]
   [associate-/r*     (/ a (* b c))         (/ (/ a b) c)]
-  [associate-/l*     (/ (* b c) a)         (/ b (/ a c))]
   [associate-/r/     (/ a (/ b c))         (* (/ a b) c)]
-  [associate-/l/     (/ (/ b c) a)         (/ b (* a c))])
+  [associate-/l/     (/ (/ b c) a)         (/ b (* a c))]
+  [associate-/l*     (/ (* b c) a)         (* b (/ c a))])
 
 ; Counting
-(define-ruleset* counting (arithmetic simplify)
+(define-ruleset* counting (arithmetic simplify sound)
   #:type ([x real])
   [count-2   (+ x x)   (* 2 x)])
 
 ; Distributivity
-(define-ruleset* distributivity (arithmetic simplify)
+(define-ruleset* distributivity (arithmetic simplify sound)
   #:type ([a real] [b real] [c real])
   [distribute-lft-in      (* a (+ b c))         (+ (* a b) (* a c))]
   [distribute-rgt-in      (* a (+ b c))         (+ (* b a) (* c a))]
@@ -210,7 +210,7 @@
   [distribute-rgt1-in     (+ a (* c a))         (* (+ c 1) a)])
 
 ; Safe Distributiviity
-(define-ruleset* distributivity-fp-safe (arithmetic simplify fp-safe)
+(define-ruleset* distributivity-fp-safe (arithmetic simplify fp-safe sound)
   #:type ([a real] [b real])
   [distribute-lft-neg-in  (neg (* a b))           (* (neg a) b)]
   [distribute-rgt-neg-in  (neg (* a b))           (* a (neg b))]
@@ -221,22 +221,24 @@
   [distribute-frac-neg    (/ (neg a) b)           (neg (/ a b))]
   [distribute-neg-frac    (neg (/ a b))           (/ (neg a) b)])
 
-(define-ruleset* cancel-sign-fp-safe (arithmetic simplify fp-safe)
+(define-ruleset* cancel-sign-fp-safe (arithmetic simplify fp-safe sound)
   #:type ([a real] [b real] [c real])
   [cancel-sign-sub      (- a (* (neg b) c))     (+ a (* b c))]
   [cancel-sign-sub-inv  (- a (* b c))           (+ a (* (neg b) c))])
 
 ; Difference of squares
-(define-ruleset* difference-of-squares-canonicalize (polynomials simplify)
+(define-ruleset* difference-of-squares-canonicalize (polynomials simplify sound)
   #:type ([a real] [b real])
   [swap-sqr              (* (* a b) (* a b))   (* (* a a) (* b b))]
   [unswap-sqr            (* (* a a) (* b b))   (* (* a b) (* a b))]
   [difference-of-squares (- (* a a) (* b b))   (* (+ a b) (- a b))]
   [difference-of-sqr-1   (- (* a a) 1)         (* (+ a 1) (- a 1))]
   [difference-of-sqr--1  (+ (* a a) -1)        (* (+ a 1) (- a 1))]
+  [pow-sqr               (* (pow a b) (pow a b)) (pow a (* 2 b))])
+
+(define-ruleset* sqr-pow-expand (polynomials simplify))
+  #:type ([a real] [b real])
   [sqr-pow               (pow a b)             (* (pow a (/ b 2)) (pow a (/ b 2)))]
-  [pow-sqr               (* (pow a b) (pow a b)) (pow a (* 2 b))]
-  )
 
 (define-ruleset* difference-of-squares-flip (polynomials)
   #:type ([a real] [b real])
@@ -244,69 +246,78 @@
   [flip--     (- a b)  (/ (- (* a a) (* b b)) (+ a b))])
 
 ; Identity
-(define-ruleset* id-reduce (arithmetic simplify)
+(define-ruleset* id-reduce (arithmetic simplify sound)
   #:type ([a real])
   [remove-double-div (/ 1 (/ 1 a))         a]
   [rgt-mult-inverse  (* a (/ 1 a))         1]
   [lft-mult-inverse  (* (/ 1 a) a)         1])
 
-(define-ruleset* id-reduce-fp-safe-nan (arithmetic simplify fp-safe-nan)
+(define-ruleset* id-reduce-fp-safe-nan (arithmetic simplify fp-safe-nan sound)
   #:type ([a real])
   [+-inverses        (- a a)               0]
-  [*-inverses        (/ a a)               1]
   [div0              (/ 0 a)               0]
   [mul0-lft          (* 0 a)               0]
   [mul0-rgt          (* a 0)               0])
 
-(define-ruleset* id-reduce-fp-safe (arithmetic simplify fp-safe)
+(define-ruleset* id-reduce-divself (arithmetic simplify fp-safe-nan)
+  #:type ([a real])
+  [*-inverses        (/ a a)               1])
+
+(define-ruleset* id-reduce-fp-safe (arithmetic simplify fp-safe sound)
   #:type ([a real])
   [+-lft-identity    (+ 0 a)               a]
   [+-rgt-identity    (+ a 0)               a]
   [--rgt-identity    (- a 0)               a]
   [sub0-neg          (- 0 a)               (neg a)]
-  [remove-double-neg (neg (neg a))             a]
+  [remove-double-neg (neg (neg a))         a]
   [*-lft-identity    (* 1 a)               a]
   [*-rgt-identity    (* a 1)               a]
   [/-rgt-identity    (/ a 1)               a]
   [mul-1-neg         (* -1 a)              (neg a)])
 
-(define-ruleset* nan-transform-fp-safe (arithmetic simplify fp-safe)
+(define-ruleset* nan-transform-fp-safe (arithmetic simplify fp-safe sound)
   #:type ([a real] [b real])
   [sub-neg           (- a b)               (+ a (neg b))]
-  [unsub-neg         (+ a (neg b))           (- a b)]
-  [neg-sub0          (neg b)                 (- 0 b)]
-  [neg-mul-1         (neg a)                 (* -1 a)])
+  [unsub-neg         (+ a (neg b))         (- a b)]
+  [neg-sub0          (neg b)               (- 0 b)]
+  [neg-mul-1         (neg a)               (* -1 a)])
 
-(define-ruleset* id-transform (arithmetic)
+(define-ruleset* id-transform-safe (arithmetic sound)
   #:type ([a real] [b real])
   [div-inv           (/ a b)               (* a (/ 1 b))]
-  [un-div-inv        (* a (/ 1 b))         (/ a b)]
+  [un-div-inv        (* a (/ 1 b))         (/ a b)])
+
+(define-ruleset* id-transform-clear-num (arithmetic)
+  #:type ([a real] [b real])
   [clear-num         (/ a b)               (/ 1 (/ b a))])
 
 
-(define-ruleset* id-transform-fp-safe (arithmetic fp-safe)
+(define-ruleset* id-transform-fp-safe (arithmetic fp-safe sound)
   #:type ([a real])
   [*-un-lft-identity a                     (* 1 a)])
 
 ; Difference of cubes
-(define-ruleset* difference-of-cubes (polynomials)
+(define-ruleset* difference-of-cubes (polynomials sound)
   #:type ([a real] [b real])
   [sum-cubes        (+ (pow a 3) (pow b 3))
                     (* (+ (* a a) (- (* b b) (* a b))) (+ a b))]
   [difference-cubes (- (pow a 3) (pow b 3))
-                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))]
+                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))])
+
+(define-ruleset* difference-of-cubes-flip (polynomials)
+  #:type ([a real] [b real])
   [flip3-+          (+ a b)
                     (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
   [flip3--          (- a b)
                     (/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b))))])
 
 ; Dealing with fractions
-(define-ruleset* fractions-distribute (fractions simplify)
+(define-ruleset* fractions-distribute (fractions simplify sound)
   #:type ([a real] [b real] [c real] [d real])
   [div-sub     (/ (- a b) c)        (- (/ a c) (/ b c))]
   [times-frac  (/ (* a b) (* c d))  (* (/ a c) (/ b d))])
 
-(define-ruleset* fractions-transform (fractions)
+(define-ruleset* fractions-transform (fractions sound)
   #:type ([a real] [b real] [c real] [d real])
   [sub-div     (- (/ a c) (/ b c))  (/ (- a b) c)]
   [frac-add    (+ (/ a b) (/ c d))  (/ (+ (* a d) (* b c)) (* b d))]
@@ -315,17 +326,17 @@
   [frac-2neg   (/ a b)              (/ (neg a) (neg b))])
 
 ; Square root
-(define-ruleset* squares-reduce (arithmetic simplify)
+(define-ruleset* squares-reduce (arithmetic simplify sound)
   #:type ([x real])
   [rem-square-sqrt   (* (sqrt x) (sqrt x))     x]
   [rem-sqrt-square   (sqrt (* x x))     (fabs x)])
 
-(define-ruleset* squares-reduce-fp-sound (arithmetic simplify fp-safe)
+(define-ruleset* squares-reduce-fp-sound (arithmetic simplify fp-safe sound)
   #:type ([x real])
   [sqr-neg           (* (neg x) (neg x))        (* x x)]
   [sqr-abs           (* (fabs x) (fabs x))      (* x x)])
   
-(define-ruleset* fabs-reduce (arithmetic simplify fp-safe)
+(define-ruleset* fabs-reduce (arithmetic simplify fp-safe sound)
   #:type ([x real] [a real] [b real])
   [fabs-fabs         (fabs (fabs x))            (fabs x)]
   [fabs-sub          (fabs (- a b))             (fabs (- b a))]
@@ -334,24 +345,27 @@
   [fabs-mul          (fabs (* a b))             (* (fabs a) (fabs b))]
   [fabs-div          (fabs (/ a b))             (/ (fabs a) (fabs b))])
   
-(define-ruleset* fabs-expand (arithmetic fp-safe)
+(define-ruleset* fabs-expand (arithmetic fp-safe sound)
   #:type ([x real] [a real] [b real])
   [neg-fabs          (fabs x)                   (fabs (neg x))]
   [mul-fabs          (* (fabs a) (fabs b))      (fabs (* a b))]
   [div-fabs          (/ (fabs a) (fabs b))      (fabs (/ a b))])
 
+(define-ruleset* squares-transform-sound (arithmetic sound)
+  #:type ([x real] [y real])
+  [sqrt-pow1         (sqrt (pow x y))       (pow x (/ y 2))]
+  [sqrt-pow2         (pow (sqrt x) y)       (pow x (/ y 2))]
+  [sqrt-unprod       (* (sqrt x) (sqrt y))  (sqrt (* x y))]
+  [sqrt-undiv        (/ (sqrt x) (sqrt y))  (sqrt (/ x y))])
+
 (define-ruleset* squares-transform (arithmetic)
   #:type ([x real] [y real])
   [sqrt-prod         (sqrt (* x y))         (* (sqrt x) (sqrt y))]
   [sqrt-div          (sqrt (/ x y))         (/ (sqrt x) (sqrt y))]
-  [sqrt-pow1         (sqrt (pow x y))       (pow x (/ y 2))]
-  [sqrt-pow2         (pow (sqrt x) y)       (pow x (/ y 2))]
-  [sqrt-unprod       (* (sqrt x) (sqrt y))  (sqrt (* x y))]
-  [sqrt-undiv        (/ (sqrt x) (sqrt y))  (sqrt (/ x y))]
   [add-sqr-sqrt      x                      (* (sqrt x) (sqrt x))])
 
 ; Cube root
-(define-ruleset* cubes-reduce (arithmetic simplify)
+(define-ruleset* cubes-reduce (arithmetic simplify sound)
   #:type ([x real])
   [rem-cube-cbrt    (pow (cbrt x) 3)                    x]
   [rem-cbrt-cube    (cbrt (pow x 3))                    x]
@@ -359,13 +373,13 @@
   [rem-3cbrt-rft    (* (cbrt x) (* (cbrt x) (cbrt x)))  x]
   [cube-neg         (pow (neg x) 3)                     (neg (pow x 3))])
 
-(define-ruleset* cubes-distribute (arithmetic simplify)
+(define-ruleset* cubes-distribute (arithmetic simplify sound)
   #:type ([x real] [y real])
   [cube-prod       (pow (* x y) 3) (* (pow x 3) (pow y 3))]
   [cube-div        (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
   [cube-mult       (pow x 3)       (* x (* x x))])
 
-(define-ruleset* cubes-transform (arithmetic)
+(define-ruleset* cubes-transform (arithmetic sound)
   #:type ([x real] [y real])
   [cbrt-prod         (cbrt (* x y))           (* (cbrt x) (cbrt y))]
   [cbrt-div          (cbrt (/ x y))           (/ (cbrt x) (cbrt y))]
@@ -374,34 +388,37 @@
   [add-cube-cbrt     x                        (* (* (cbrt x) (cbrt x)) (cbrt x))]
   [add-cbrt-cube     x                        (cbrt (* (* x x) x))])
 
-(define-ruleset* cubes-canonicalize (arithmetic simplify)
+(define-ruleset* cubes-canonicalize (arithmetic simplify sound)
   #:type ([x real])
   [cube-unmult       (* x (* x x))          (pow x 3)])
+
+(define-ruleset* exp-expand-sound (exponents sound)
+  #:type ([x real])
+  [add-log-exp  x                    (log (exp x))])
 
 ; Exponentials
 (define-ruleset* exp-expand (exponents)
   #:type ([x real])
-  [add-exp-log  x                    (exp (log x))]
-  [add-log-exp  x                    (log (exp x))])
+  [add-exp-log  x                    (exp (log x))])
 
-(define-ruleset* exp-reduce (exponents simplify)
+(define-ruleset* exp-reduce (exponents simplify sound)
   #:type ([x real])
   [rem-exp-log  (exp (log x))        x]
   [rem-log-exp  (log (exp x))        x])
 
-(define-ruleset* exp-constants (exponents simplify fp-safe)
+(define-ruleset* exp-constants (exponents simplify fp-safe sound)
   [exp-0        (exp 0)              1]
   [exp-1-e      (exp 1)              (E)]
   [1-exp        1                    (exp 0)]
   [e-exp-1      (E)                  (exp 1)])
 
-(define-ruleset* exp-distribute (exponents simplify)
+(define-ruleset* exp-distribute (exponents simplify sound)
   #:type ([a real] [b real])
   [exp-sum      (exp (+ a b))        (* (exp a) (exp b))]
   [exp-neg      (exp (neg a))          (/ 1 (exp a))]
   [exp-diff     (exp (- a b))        (/ (exp a) (exp b))])
 
-(define-ruleset* exp-factor (exponents simplify)
+(define-ruleset* exp-factor (exponents simplify sound)
   #:type ([a real] [b real])
   [prod-exp     (* (exp a) (exp b))  (exp (+ a b))]
   [rec-exp      (/ 1 (exp a))        (exp (neg a))]
@@ -413,11 +430,11 @@
   [exp-lft-cube (exp (* a 3))        (pow (exp a) 3)])
 
 ; Powers
-(define-ruleset* pow-reduce (exponents simplify)
+(define-ruleset* pow-reduce (exponents simplify sound)
   #:type ([a real])
   [unpow-1        (pow a -1)                 (/ 1 a)])
 
-(define-ruleset* pow-reduce-fp-safe (exponents simplify fp-safe)
+(define-ruleset* pow-reduce-fp-safe (exponents simplify fp-safe sound)
   #:type ([a real])
   [unpow1         (pow a 1)                  a])
 
@@ -426,63 +443,103 @@
   [unpow0         (pow a 0)                  1]
   [pow-base-1     (pow 1 a)                  1])
 
-(define-ruleset* pow-expand-fp-safe (exponents fp-safe)
+(define-ruleset* pow-expand-fp-safe (exponents fp-safe sound)
   #:type ([a real])
   [pow1           a                           (pow a 1)])
 
-(define-ruleset* pow-canonicalize (exponents simplify)
+(define-ruleset* pow-canonicalize-sound (exponents simplify sound)
   #:type ([a real] [b real])
   [exp-to-pow      (exp (* (log a) b))        (pow a b)]
-  [pow-plus        (* (pow a b) a)            (pow a (+ b 1))]
   [unpow1/2        (pow a 1/2)                (sqrt a)]
   [unpow2          (pow a 2)                  (* a a)]
   [unpow3          (pow a 3)                  (* (* a a) a)]
   [unpow1/3        (pow a 1/3)                (cbrt a)])
 
-(define-ruleset* pow-transform (exponents)
+(define-ruleset* pow-canonicalize (exponents simplify)
+  #:type ([a real] [b real])
+  [pow-plus        (* (pow a b) a)            (pow a (+ b 1))])
+
+(define-ruleset* pow-transform-sound (exponents sound)
   #:type ([a real] [b real] [c real])
   [pow-exp          (pow (exp a) b)             (exp (* a b))]
-  [pow-to-exp       (pow a b)                   (exp (* (log a) b))]
-  [pow-prod-up      (* (pow a b) (pow a c))     (pow a (+ b c))]
   [pow-prod-down    (* (pow b a) (pow c a))     (pow (* b c) a)]
   [pow-pow          (pow (pow a b) c)           (pow a (* b c))]
-  [pow-neg          (pow a (neg b))               (/ 1 (pow a b))]
+  [pow-prod-up      (* (pow a b) (pow a c))     (pow a (+ b c))]
   [pow-flip         (/ 1 (pow a b))             (pow a (neg b))]
+  [pow-neg          (pow a (neg b))             (/ 1 (pow a b))]
   [pow-div          (/ (pow a b) (pow a c))     (pow a (- b c))]
-  [pow-sub          (pow a (- b c))             (/ (pow a b) (pow a c))]
-  [pow-unpow        (pow a (* b c))             (pow (pow a b) c)]
-  [unpow-prod-up    (pow a (+ b c))             (* (pow a b) (pow a c))]
-  [unpow-prod-down  (pow (* b c) a)             (* (pow b a) (pow c a))]
   [pow1/2           (sqrt a)                    (pow a 1/2)]
   [pow2             (* a a)                     (pow a 2)]
   [pow1/3           (cbrt a)                    (pow a 1/3)]
   [pow3             (* (* a a) a)               (pow a 3)])
 
+(define-ruleset* pow-transform (exponents)
+  #:type ([a real] [b real] [c real])
+  [pow-to-exp       (pow a b)                   (exp (* (log a) b))]
+  [pow-sub          (pow a (- b c))             (/ (pow a b) (pow a c))]
+  [pow-unpow        (pow a (* b c))             (pow (pow a b) c)]
+  [unpow-prod-up    (pow a (+ b c))             (* (pow a b) (pow a c))]
+  [unpow-prod-down  (pow (* b c) a)             (* (pow b a) (pow c a))])
+
 (define-ruleset* pow-transform-fp-safe-nan (exponents simplify fp-safe-nan)
   #:type ([a real])
   [pow-base-0       (pow 0 a)                   0])
 
-(define-ruleset* pow-transform-fp-safe (exponents fp-safe)
+(define-ruleset* pow-transform-fp-safe (exponents fp-safe sound)
   #:type ([a real])
   [inv-pow          (/ 1 a)                     (pow a -1)])
+
+(define-ruleset* log-distribute-sound (exponents simplify sound)
+  #:type ([a real] [b real])
+  [log-rec      (log (/ 1 a))       (neg (log a))]
+  [log-E        (log (E))           1])
 
 ; Logarithms
 (define-ruleset* log-distribute (exponents simplify)
   #:type ([a real] [b real])
   [log-prod     (log (* a b))       (+ (log a) (log b))]
   [log-div      (log (/ a b))       (- (log a) (log b))]
-  [log-rec      (log (/ 1 a))       (neg (log a))]
-  [log-pow      (log (pow a b))     (* b (log a))]
-  [log-E        (log (E))           1])
+  [log-pow      (log (pow a b))     (* b (log a))])
 
-(define-ruleset* log-factor (exponents)
+(define-ruleset* log-factor (exponents sound)
   #:type ([a real] [b real])
   [sum-log      (+ (log a) (log b))  (log (* a b))]
   [diff-log     (- (log a) (log b))  (log (/ a b))]
-  [neg-log      (neg (log a))          (log (/ 1 a))])
+  [neg-log      (neg (log a))        (log (/ 1 a))])
 
 ; Trigonometry
-(define-ruleset* trig-reduce (trigonometry simplify)
+(define-ruleset* trig-reduce-fp-sound (trigonometry simplify fp-safe sound)
+  [sin-0       (sin 0)               0]
+  [cos-0       (cos 0)               1]
+  [tan-0       (tan 0)               0])
+
+(define-ruleset* trig-reduce-fp-sound-nan (trigonometry simplify fp-safe-nan sound)
+  #:type ([x real])
+  [sin-neg     (sin (neg x))           (neg (sin x))]
+  [cos-neg     (cos (neg x))           (cos x)]
+  [tan-neg     (tan (neg x))           (neg (tan x))])
+
+(define-ruleset* trig-expand-fp-safe (trignometry fp-safe sound)
+  #:type ([x real])
+  [sqr-sin-b   (* (sin x) (sin x))       (- 1 (* (cos x) (cos x)))]
+  [sqr-cos-b   (* (cos x) (cos x))       (- 1 (* (sin x) (sin x)))])
+
+(define-ruleset* trig-inverses (trigonometry sound)
+  #:type ([x real])
+  [sin-asin    (sin (asin x))         x]
+  [cos-acos    (cos (acos x))         x]
+  [tan-atan    (tan (atan x))         x]
+  [atan-tan    (atan (tan x))         (remainder x (PI))]
+  [asin-sin    (asin (sin x))         (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2))]
+  [acos-cos    (acos (cos x))         (fabs (remainder x (* 2 (PI))))])
+
+(define-ruleset* trig-inverses-simplified (trigonometry sound)
+  #:type ([x real])
+  [atan-tan-s  (atan (tan x))         x]
+  [asin-sin-s  (asin (sin x))         x]
+  [acos-cos-s  (acos (cos x))         x])
+
+(define-ruleset* trig-reduce-sound (trigonometry simplify sound)
   #:type ([a real] [b real] [x real])
   [cos-sin-sum (+ (* (cos a) (cos a)) (* (sin a) (sin a))) 1]
   [1-sub-cos   (- 1 (* (cos a) (cos a)))   (* (sin a) (sin a))]
@@ -510,9 +567,12 @@
   [tan-PI/3    (tan (/ (PI) 3))        (sqrt 3)]
   [tan-PI      (tan (PI))              0]
   [tan-+PI     (tan (+ x (PI)))        (tan x)]
-  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   [hang-0p-tan (/ (sin a) (+ 1 (cos a)))     (tan (/ a 2))]
-  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))]
+  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))])
+
+(define-ruleset* trig-reduce (trigonometry simplify)
+  #:type ([a real] [b real] [x real])
+  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
   [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))]
   [hang-p-tan  (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))
@@ -520,42 +580,28 @@
   [hang-m-tan  (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))
                (tan (/ (- a b) 2))])
 
-(define-ruleset* trig-reduce-fp-sound (trigonometry simplify fp-safe)
-  [sin-0       (sin 0)               0]
-  [cos-0       (cos 0)               1]
-  [tan-0       (tan 0)               0])
-
-(define-ruleset* trig-reduce-fp-sound-nan (trigonometry simplify fp-safe-nan)
-  #:type ([x real])
-  [sin-neg     (sin (neg x))           (neg (sin x))]
-  [cos-neg     (cos (neg x))           (cos x)]
-  [tan-neg     (tan (neg x))           (neg (tan x))])
-
-(define-ruleset* trig-expand (trigonometry)
-  #:type ([x real] [y real] [a real] [b real])
+(define-ruleset* trig-expand (trigonometry sound)
+  #:type ([x real] [y real] [a real] [b real]
   [sin-sum     (sin (+ x y))             (+ (* (sin x) (cos y)) (* (cos x) (sin y)))]
   [cos-sum     (cos (+ x y))             (- (* (cos x) (cos y)) (* (sin x) (sin y)))]
   [tan-sum     (tan (+ x y))             (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y))))]
   [sin-diff    (sin (- x y))             (- (* (sin x) (cos y)) (* (cos x) (sin y)))]
   [cos-diff    (cos (- x y))             (+ (* (cos x) (cos y)) (* (sin x) (sin y)))]
-  [sin-2       (sin (* 2 x))
-               (* 2 (* (sin x) (cos x)))]
-  [sin-3       (sin (* 3 x))
-               (- (* 3 (sin x)) (* 4 (pow (sin x) 3)))]
+  [sin-2       (sin (* 2 x))             (* 2 (* (sin x) (cos x)))]
+  [sin-3       (sin (* 3 x))             (- (* 3 (sin x)) (* 4 (pow (sin x) 3)))]
   [2-sin       (* 2 (* (sin x) (cos x)))
                (sin (* 2 x))]
   [3-sin       (- (* 3 (sin x)) (* 4 (pow (sin x) 3)))
                (sin (* 3 x))]
-  [cos-2       (cos (* 2 x))
-               (- (* (cos x) (cos x)) (* (sin x) (sin x)))]
-  [cos-3       (cos (* 3 x))
-               (- (* 4 (pow (cos x) 3)) (* 3 (cos x)))]
+  [cos-2       (cos (* 2 x))             (- (* (cos x) (cos x)) (* (sin x) (sin x)))]
+  [cos-3       (cos (* 3 x))             (- (* 4 (pow (cos x) 3)) (* 3 (cos x)))]
   [2-cos       (- (* (cos x) (cos x)) (* (sin x) (sin x)))
                (cos (* 2 x))]
   [3-cos       (- (* 4 (pow (cos x) 3)) (* 3 (cos x)))
-               (cos (* 3 x))]
-  [tan-2       (tan (* 2 x))             (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x))))]
-  [2-tan       (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x)))) (tan (* 2 x))]
+               (cos (* 3 x))])
+
+(define-ruleset* trig-expand-sound (trigonometry sound)
+  #:type ([x real] [y real] [a real] [b real])
   [sqr-sin-a   (* (sin x) (sin x))       (- 1/2 (* 1/2 (cos (* 2 x))))]
   [sqr-cos-a   (* (cos x) (cos x))       (+ 1/2 (* 1/2 (cos (* 2 x))))]
   [diff-sin    (- (sin x) (sin y))       (* 2 (* (sin (/ (- x y) 2)) (cos (/ (+ x y) 2))))]
@@ -568,33 +614,19 @@
   [diff-atan   (- (atan x) (atan y))     (atan2 (- x y) (+ 1 (* x y)))]
   [sum-atan    (+ (atan x) (atan y))     (atan2 (+ x y) (- 1 (* x y)))]
   [tan-quot    (tan x)                   (/ (sin x) (cos x))]
-  [quot-tan    (/ (sin x) (cos x))       (tan x)]
+  [quot-tan    (/ (sin x) (cos x))       (tan x)])
+
+(define-ruleset* trig-expand (trigonometry)
+  #:type ([x real] [y real] [a real] [b real])
+  [tan-2       (tan (* 2 x))             (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x))))]
+  [2-tan       (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x)))) (tan (* 2 x))]
+
   [tan-hang-p  (tan (/ (+ a b) 2))
                (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))]
   [tan-hang-m  (tan (/ (- a b) 2))
                (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))])
 
-(define-ruleset* trig-expand-fp-safe (trignometry fp-safe)
-  #:type ([x real])
-  [sqr-sin-b   (* (sin x) (sin x))       (- 1 (* (cos x) (cos x)))]
-  [sqr-cos-b   (* (cos x) (cos x))       (- 1 (* (sin x) (sin x)))])
-
-(define-ruleset* trig-inverses (trigonometry)
-  #:type ([x real])
-  [sin-asin    (sin (asin x))         x]
-  [cos-acos    (cos (acos x))         x]
-  [tan-atan    (tan (atan x))         x]
-  [atan-tan    (atan (tan x))         (remainder x (PI))]
-  [asin-sin    (asin (sin x))         (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2))]
-  [acos-cos    (acos (cos x))         (fabs (remainder x (* 2 (PI))))])
-
-(define-ruleset* trig-inverses-simplified (trigonometry)
-  #:type ([x real])
-  [atan-tan-s  (atan (tan x))         x]
-  [asin-sin-s  (asin (sin x))         x]
-  [acos-cos-s  (acos (cos x))         x])
-
-(define-ruleset* atrig-expand (trigonometry)
+(define-ruleset* atrig-expand (trigonometry sound)
   #:type ([x real])
   [cos-asin    (cos (asin x))         (sqrt (- 1 (* x x)))]
   [tan-asin    (tan (asin x))         (/ x (sqrt (- 1 (* x x))))]
@@ -609,7 +641,7 @@
   [atan-neg    (atan (neg x))         (neg (atan x))])
 
 ; Hyperbolic trigonometric functions
-(define-ruleset* htrig-reduce (hyperbolic simplify)
+(define-ruleset* htrig-reduce (hyperbolic simplify sound)
   #:type ([x real])
   [sinh-def    (sinh x)               (/ (- (exp x) (exp (neg x))) 2)]
   [cosh-def    (cosh x)               (/ (+ (exp x) (exp (neg x))) 2)]
@@ -620,41 +652,43 @@
   [sinh-+-cosh (+ (cosh x) (sinh x))  (exp x)]
   [sinh---cosh (- (cosh x) (sinh x))  (exp (neg x))])
 
+(define-ruleset* htrig-expand-sound (hyperbolic sound)
+  #:type ([x real] [y real])
+  [sinh-undef  (- (exp x) (exp (neg x)))         (* 2 (sinh x))]
+  [cosh-undef  (+ (exp x) (exp (neg x)))         (* 2 (cosh x))]
+  [tanh-undef  (/ (- (exp x) (exp (neg x))) (+ (exp x) (exp (neg x)))) (tanh x)]
+  [cosh-sum    (cosh (+ x y))                    (+ (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
+  [cosh-diff   (cosh (- x y))                    (- (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
+  [cosh-2      (cosh (* 2 x))                    (+ (* (sinh x) (sinh x)) (* (cosh x) (cosh x)))]
+  [cosh-1/2    (cosh (/ x 2))                    (sqrt (/ (+ (cosh x) 1) 2))]
+  [sinh-sum    (sinh (+ x y))                    (+ (* (sinh x) (cosh y)) (* (cosh x) (sinh y)))]
+  [sinh-diff   (sinh (- x y))                    (- (* (sinh x) (cosh y)) (* (cosh x) (sinh y)))]
+  [sinh-2      (sinh (* 2 x))                    (* 2 (* (sinh x) (cosh x)))]
+  [sinh-1/2    (sinh (/ x 2))                    (/ (sinh x) (sqrt (* 2 (+ (cosh x) 1))))]
+  [tanh-2      (tanh (* 2 x))                    (/ (* 2 (tanh x)) (+ 1 (* (tanh x) (tanh x))))]
+  [tanh-1/2    (tanh (/ x 2))                    (/ (sinh x) (+ (cosh x) 1))]
+  [sum-sinh    (+ (sinh x) (sinh y))             (* 2 (* (sinh (/ (+ x y) 2)) (cosh (/ (- x y) 2))))]
+  [sum-cosh    (+ (cosh x) (cosh y))             (* 2 (* (cosh (/ (+ x y) 2)) (cosh (/ (- x y) 2))))]
+  [diff-sinh   (- (sinh x) (sinh y))             (* 2 (* (cosh (/ (+ x y) 2)) (sinh (/ (- x y) 2))))]
+  [diff-cosh   (- (cosh x) (cosh y))             (* 2 (* (sinh (/ (+ x y) 2)) (sinh (/ (- x y) 2))))])
+
 (define-ruleset* htrig-expand (hyperbolic)
   #:type ([x real] [y real])
-  [sinh-undef  (- (exp x) (exp (neg x)))                       (* 2 (sinh x))]
-  [cosh-undef  (+ (exp x) (exp (neg x)))                       (* 2 (cosh x))]
-  [tanh-undef  (/ (- (exp x) (exp (neg x))) (+ (exp x) (exp (neg x)))) (tanh x)]
-  [cosh-sum    (cosh (+ x y))         (+ (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
-  [cosh-diff   (cosh (- x y))         (- (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
-  [cosh-2      (cosh (* 2 x))         (+ (* (sinh x) (sinh x)) (* (cosh x) (cosh x)))]
-  [cosh-1/2    (cosh (/ x 2))         (sqrt (/ (+ (cosh x) 1) 2))]
-  [sinh-sum    (sinh (+ x y))         (+ (* (sinh x) (cosh y)) (* (cosh x) (sinh y)))]
-  [sinh-diff   (sinh (- x y))         (- (* (sinh x) (cosh y)) (* (cosh x) (sinh y)))]
-  [sinh-2      (sinh (* 2 x))         (* 2 (* (sinh x) (cosh x)))]
-  [sinh-1/2    (sinh (/ x 2))         (/ (sinh x) (sqrt (* 2 (+ (cosh x) 1))))]
-  [tanh-sum    (tanh (+ x y))         (/ (+ (tanh x) (tanh y)) (+ 1 (* (tanh x) (tanh y))))]
-  [tanh-2      (tanh (* 2 x))         (/ (* 2 (tanh x)) (+ 1 (* (tanh x) (tanh x))))]
-  [tanh-1/2    (tanh (/ x 2))         (/ (sinh x) (+ (cosh x) 1))]
-  [tanh-1/2*   (tanh (/ x 2))         (/ (- (cosh x) 1) (sinh x))]
-  [sum-sinh    (+ (sinh x) (sinh y))  (* 2 (* (sinh (/ (+ x y) 2)) (cosh (/ (- x y) 2))))]
-  [sum-cosh    (+ (cosh x) (cosh y))  (* 2 (* (cosh (/ (+ x y) 2)) (cosh (/ (- x y) 2))))]
-  [diff-sinh   (- (sinh x) (sinh y))  (* 2 (* (cosh (/ (+ x y) 2)) (sinh (/ (- x y) 2))))]
-  [diff-cosh   (- (cosh x) (cosh y))  (* 2 (* (sinh (/ (+ x y) 2)) (sinh (/ (- x y) 2))))])
+  [tanh-sum    (tanh (+ x y))                    (/ (+ (tanh x) (tanh y)) (+ 1 (* (tanh x) (tanh y))))]
+  [tanh-1/2*   (tanh (/ x 2))                    (/ (- (cosh x) 1) (sinh x))])
 
-(define-ruleset* htrig-expand-fp-safe (hyperbolic fp-safe)
+(define-ruleset* htrig-expand-fp-safe (hyperbolic fp-safe sound)
   #:type ([x real])
-  [sinh-neg    (sinh (neg x))           (neg (sinh x))]
+  [sinh-neg    (sinh (neg x))         (neg (sinh x))]
   [sinh-0      (sinh 0)               0]
-  [cosh-neg    (cosh (neg x))           (cosh x)]
+  [cosh-neg    (cosh (neg x))         (cosh x)]
   [cosh-0      (cosh 0)               1])
 
-(define-ruleset* ahtrig-expand (hyperbolic)
+(define-ruleset* ahtrig-expand (hyperbolic sound)
   #:type ([x real])
   [asinh-def   (asinh x)              (log (+ x (sqrt (+ (* x x) 1))))]
   [acosh-def   (acosh x)              (log (+ x (sqrt (- (* x x) 1))))]
   [atanh-def   (atanh x)              (/ (log (/ (+ 1 x) (- 1 x))) 2)]
-  [acosh-2     (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x))]
   [asinh-2     (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x))]
   [sinh-asinh  (sinh (asinh x))       x]
   [sinh-acosh  (sinh (acosh x))       (sqrt (- (* x x) 1))]
@@ -665,6 +699,10 @@
   [tanh-asinh  (tanh (asinh x))       (/ x (sqrt (+ 1 (* x x))))]
   [tanh-acosh  (tanh (acosh x))       (/ (sqrt (- (* x x) 1)) x)]
   [tanh-atanh  (tanh (atanh x))       x])
+
+(define-ruleset* ahtrig-expand (hyperbolic)
+  #:type ([x real])
+  [acosh-2     (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x))])
 
 (define-ruleset* compare-reduce (bools simplify fp-safe-nan)
   #:type ([x real] [y real])
@@ -677,7 +715,7 @@
   [not-lte      (not (<= x y))   (>  x y)]
   [not-gte      (not (>= x y))   (<  x y)])
 
-(define-ruleset* branch-reduce (branches simplify fp-safe)
+(define-ruleset* branch-reduce (branches simplify fp-safe sound)
   #:type ([a bool] [b bool] [x real] [y real])
   [if-true        (if (TRUE) x y)       x]
   [if-false       (if (FALSE) x y)      y]


### PR DESCRIPTION
The idea long-term is to have `simplify` and `preprocessing` only use sound rewrite rules. But for now, this PR just classifies the rule without making any other changes, except that it also fixes a bug in `associate-*l/` to make it more valid.