### PR TITLE
Fix crashes in `format-prelude-instruction`

### DIFF
--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -142,16 +142,15 @@
      (define x* (string->symbol (string-append (symbol->string x) "_m")))
      (define r (list-ref (context-var-reprs ctx) (index-of (context-vars ctx) x)))
      (define e (list (get-parametric-operator 'fabs r) x))
-     (define c (context (list x*) r r))
+     (define c (context (list x) r r))
      (format "~a = ~a" x* (converter* e c))]
     [(list 'negabs x)
-     (define x-string (symbol->string x))
-     (define x* (string->symbol (string-append x-string "_m")))
-     (define r (list-ref (context-var-reprs ctx) (index-of (context-vars ctx) x)))
+     (define x* (string->symbol (format "~a_m" x)))
+     (define r (context-lookup ctx x))
      (define e* (list (get-parametric-operator 'fabs r) x))
-     (define x-sign (string->symbol (string-append x-string "_s")))
+     (define x-sign (string->symbol (format "~a_s" x)))
      (define e-sign (list (get-parametric-operator 'copysign r r) 1 x))
-     (define c (context (list x*) r r))
+     (define c (context (list x) r r))
      (list
       (format "~a = ~a" x* (converter* e* c))
       (format "~a = ~a" x-sign (converter* e-sign c)))]

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -152,8 +152,8 @@
      (define e-sign (list (get-parametric-operator 'copysign r r) 1 x))
      (define c (context (list x) r r))
      (list
-      (format "~a = ~a" x* (converter* e* c))
-      (format "~a = ~a" x-sign (converter* e-sign c)))]
+      (format "~a = ~a" (format "~a\\_m" x) (converter* e* c))
+      (format "~a = ~a" (format "~a\\_s" x) (converter* e-sign c)))]
     [(list 'sort vs ...)
      (define vs (context-vars ctx))
      (define vs* (context-vars ctx*))


### PR DESCRIPTION
We were using the wrong variable name and that was causing problems.