### PR TITLE
Remove unsound simplify rules

### DIFF
--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -87,10 +87,10 @@
     [(? variable?) expr]
     [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))
      (make-addition-node (combine-aterms (gather-additive-terms expr)))]
-    [(or `(* ,_ ...) `(/ ,_ ...) `(sqrt ,_) `(cbrt ,_))
+    [(or `(* ,_ ...) `(/ ,_ ...) `(sqrt ,_) `(cbrt ,_) `(pow ,_ ,_))
      (make-multiplication-node (combine-mterms (gather-multiplicative-terms expr)))]
     [`(exp (* ,c (log ,x)))
-     `(pow ,x ,c)]
+     (simplify-node* `(pow ,x ,c))]
     [else
      (simplify-inverses expr)]))
 
@@ -284,5 +284,7 @@
     [`(-1 . ,x) `(/ 1 ,x)]
     [`(1/2 . ,x) `(sqrt ,x)]
     [`(-1/2 . ,x) `(/ 1 (sqrt ,x))]
+    [`(1/3 . ,x) `(cbrt ,x)]
+    [`(-1/3 . ,x) `(/ 1 (cbrt ,x))]
     [`(,power . ,x) `(pow ,x ,power)]))
 

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -120,9 +120,9 @@
     [`(/ ,num ,den)
      (taylor-quotient (taylor var num) (taylor var den))]
     [`(sqrt ,arg)
-     (taylor-sqrt (taylor var arg))]
+     (taylor-sqrt var (taylor var arg))]
     [`(cbrt ,arg)
-     (taylor-cbrt (taylor var arg))]
+     (taylor-cbrt var (taylor var arg))]
     [`(exp ,arg)
      (let ([arg* (normalize-series (taylor var arg))])
        (if (positive? (car arg*))
@@ -164,9 +164,12 @@
     [`(pow ,base ,(? exact-integer? power))
      (taylor-pow (normalize-series (taylor var base)) power)]
     [`(pow ,base 1/2)
-     (taylor-sqrt (taylor var base))]
+     (taylor-sqrt var (taylor var base))]
     [`(pow ,base 1/3)
-     (taylor-cbrt (taylor var base))]
+     (taylor-cbrt var (taylor var base))]
+    [`(pow ,base 2/3)
+     (define tx (taylor var base))
+     (taylor-cbrt var (taylor-mult tx tx))]
     [`(pow ,base ,power)
      (taylor var `(exp (* ,power (log ,base))))]
     [`(sinh ,arg)
@@ -183,10 +186,10 @@
      (taylor-quotient x- x+)]
     [`(asinh ,x)
      (define tx (taylor var x))
-     (taylor-log var (taylor-add tx (taylor-sqrt (taylor-add (taylor-mult tx tx) (taylor-exact 1)))))]
+     (taylor-log var (taylor-add tx (taylor-sqrt var (taylor-add (taylor-mult tx tx) (taylor-exact 1)))))]
     [`(acosh ,x)
      (define tx (taylor var x))
-     (taylor-log var (taylor-add tx (taylor-sqrt (taylor-add (taylor-mult tx tx) (taylor-exact -1)))))]
+     (taylor-log var (taylor-add tx (taylor-sqrt var (taylor-add (taylor-mult tx tx) (taylor-exact -1)))))]
     [`(atanh ,x)
      (define tx (taylor var x))
      (taylor-mult (taylor-exact 1/2)
@@ -292,13 +295,21 @@
                              `(* ,(f i) (/ ,(b (- n i)) ,(b 0))))))))))
   (cons (- noff doff) f))
 
-(define (taylor-sqrt num)
-  (let* ([num* (normalize-series num)]
-         [offset (car num*)]
-         [offset* (if (even? offset) offset (+ offset 1))]
-         [coeffs (cdr num*)]
-         [coeffs* (if (even? offset) coeffs (λ (n) (if (= n 0) 0 (coeffs (- n 1)))))]
-         [hash (make-hash)])
+(define (modulo-series var n series)
+  (match-define (cons offset coeffs) (normalize-series series))
+  (define offset* (+ offset (modulo (- offset) n)))
+  (define (coeffs* i)
+    (match i
+      [0 (make-sum
+          (for/list ([j (in-range (modulo offset n))])
+            `(* ,(coeffs j) (pow ,var ,(+ j (modulo (- offset) n))))))]
+      [_ #:when (< i n) 0]
+      [_ (coeffs (+ (- i n) (modulo offset n)))]))
+  (cons offset* (if (= offset offset*) coeffs coeffs*)))
+
+(define (taylor-sqrt var num)
+  (match-define (cons offset* coeffs*) (modulo-series var 2 num))
+  (let* ([hash (make-hash)])
     (hash-set! hash 0 (simplify `(sqrt ,(coeffs* 0))))
     (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 2 (sqrt ,(coeffs* 0))))))
     (letrec ([f (λ (n)
@@ -318,13 +329,9 @@
                                         (* 2 ,(f 0)))])))))])
       (cons (/ offset* 2) f))))
 
-(define (taylor-cbrt num)
-  (let* ([num* (normalize-series num)]
-         [offset (car num*)]
-         [offset* (- offset (modulo offset 3))]
-         [coeffs (cdr num*)]
-         [coeffs* (if (= (modulo offset 3) 0) coeffs (λ (n) (if (= n 0) 0 (coeffs (+ n (modulo offset 3))))))]
-         [f0 (simplify `(cbrt ,(coeffs* 0)))]
+(define (taylor-cbrt var num)
+  (match-define (cons offset* coeffs*) (modulo-series var 3 num))
+  (let* ([f0 (simplify `(cbrt ,(coeffs* 0)))]
          [hash (make-hash)])
     (hash-set! hash 0 f0)
     (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt (* ,f0 ,f0))))))
@@ -503,5 +510,9 @@
     (build-list n fn))
 
   (check-equal? (coeffs '(sin x)) '(0 1 0 -1/6 0 1/120 0))
+  (check-equal? (coeffs '(sqrt (+ 1 x))) '(1 1/2 -1/8 1/16 -5/128 7/256 -21/1024))
   (check-equal? (coeffs '(cbrt (+ 1 x))) '(1 1/3 -1/9 5/81 -10/243 22/729 -154/6561))
+  (check-equal? (coeffs '(sqrt x)) '((sqrt x) 0 0 0 0 0 0))
+  (check-equal? (coeffs '(cbrt x)) '((cbrt x) 0 0 0 0 0 0))
+  (check-equal? (coeffs '(cbrt (* x x))) '((cbrt (pow x 2)) 0 0 0 0 0 0))
   )

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -98,6 +98,7 @@
       (match-define (list rules groups _) ruleset)
       (when (and (ormap (curry flag-set? 'rules) groups)
                  (set-member? groups 'simplify)
+                 (set-member? groups 'sound)
                  (filter rule-ops-supported? rules))
         (for ([rule (in-list rules)])
           (sow rule))))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -578,7 +578,6 @@
 
 (define-ruleset* trig-reduce (trigonometry simplify)
   #:type ([a real] [b real] [x real])
-  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
   [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))]
   [hang-p-tan  (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -470,7 +470,10 @@
   [pow-prod-up      (* (pow a b) (pow a c))     (pow a (+ b c))]
   [pow-flip         (/ 1 (pow a b))             (pow a (neg b))]
   [pow-neg          (pow a (neg b))             (/ 1 (pow a b))]
-  [pow-div          (/ (pow a b) (pow a c))     (pow a (- b c))]
+  [pow-div          (/ (pow a b) (pow a c))     (pow a (- b c))])
+
+(define-ruleset* pow-specialize-sound (exponents sound)
+  #:type ([a real])
   [pow1/2           (sqrt a)                    (pow a 1/2)]
   [pow2             (* a a)                     (pow a 2)]
   [pow1/3           (cbrt a)                    (pow a 1/3)]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -311,10 +311,7 @@
   [sum-cubes        (+ (pow a 3) (pow b 3))
                     (* (+ (* a a) (- (* b b) (* a b))) (+ a b))]
   [difference-cubes (- (pow a 3) (pow b 3))
-                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))])
-
-(define-ruleset* difference-of-cubes-flip (polynomials)
-  #:type ([a real] [b real])
+                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))]
   [flip3-+          (+ a b)
                     (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
   [flip3--          (- a b)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -97,7 +97,7 @@
     (for ([(_ ruleset) (in-dict (*rulesets*))])
       (match-define (list rules groups _) ruleset)
       (when (and (ormap (curry flag-set? 'rules) groups)
-                 (set-member? groups 'sound)
+                 (set-member? groups 'simplify)
                  (filter rule-ops-supported? rules))
         (for ([rule (in-list rules)])
           (sow rule))))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -573,11 +573,7 @@
   [hang-0p-tan (/ (sin a) (+ 1 (cos a)))     (tan (/ a 2))]
   [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))]
   [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
-  [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))])
-
-(define-ruleset* trig-reduce (trigonometry simplify)
-  #:type ([a real] [b real] [x real])
-  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
+  [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))]
   [hang-p-tan  (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))
                (tan (/ (+ a b) 2))]
   [hang-m-tan  (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -456,7 +456,7 @@
   #:type ([a real])
   [pow1           a                           (pow a 1)])
 
-(define-ruleset* pow-canonicalize-sound (exponents simplify sound)
+(define-ruleset* pow-canonicalize (exponents simplify sound)
   #:type ([a real] [b real])
   [exp-to-pow      (exp (* (log a) b))        (pow a b)]
   [unpow1/2        (pow a 1/2)                (sqrt a)]
@@ -574,12 +574,13 @@
   [tan-PI      (tan (PI))              0]
   [tan-+PI     (tan (+ x (PI)))        (tan x)]
   [hang-0p-tan (/ (sin a) (+ 1 (cos a)))     (tan (/ a 2))]
-  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))])
+  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))]
+  [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
+  [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))])
 
 (define-ruleset* trig-reduce (trigonometry simplify)
   #:type ([a real] [b real] [x real])
-  [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
-  [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))]
+  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   [hang-p-tan  (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))
                (tan (/ (+ a b) 2))]
   [hang-m-tan  (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -97,7 +97,7 @@
     (for ([(_ ruleset) (in-dict (*rulesets*))])
       (match-define (list rules groups _) ruleset)
       (when (and (ormap (curry flag-set? 'rules) groups)
-                 (set-member? groups 'simplify)
+                 (set-member? groups 'sound)
                  (filter rule-ops-supported? rules))
         (for ([rule (in-list rules)])
           (sow rule))))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -248,7 +248,7 @@
   [difference-of-sqr--1  (+ (* a a) -1)        (* (+ a 1) (- a 1))]
   [pow-sqr               (* (pow a b) (pow a b)) (pow a (* 2 b))])
 
-(define-ruleset* sqr-pow-expand (polynomials simplify)
+(define-ruleset* sqr-pow-expand (polynomials)
   #:type ([a real] [b real])
   [sqr-pow               (pow a b)             (* (pow a (/ b 2)) (pow a (/ b 2)))])
 
@@ -501,7 +501,7 @@
   [log-E        (log (E))           1])
 
 ; Logarithms
-(define-ruleset* log-distribute (exponents simplify)
+(define-ruleset* log-distribute (exponents)
   #:type ([a real] [b real])
   [log-prod     (log (* a b))       (+ (log a) (log b))]
   [log-div      (log (/ a b))       (- (log a) (log b))]
@@ -582,7 +582,7 @@
   [hang-m-tan  (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))
                (tan (/ (- a b) 2))])
 
-(define-ruleset* trig-reduce (trigonometry simplify)
+(define-ruleset* trig-reduce (trigonometry)
   #:type ([a real] [b real] [x real])
   [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   )

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -98,7 +98,6 @@
       (match-define (list rules groups _) ruleset)
       (when (and (ormap (curry flag-set? 'rules) groups)
                  (set-member? groups 'simplify)
-                 (set-member? groups 'sound)
                  (filter rule-ops-supported? rules))
         (for ([rule (in-list rules)])
           (sow rule))))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -311,7 +311,10 @@
   [sum-cubes        (+ (pow a 3) (pow b 3))
                     (* (+ (* a a) (- (* b b) (* a b))) (+ a b))]
   [difference-cubes (- (pow a 3) (pow b 3))
-                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))]
+                    (* (+ (* a a) (+ (* b b) (* a b))) (- a b))])
+
+(define-ruleset* difference-of-cubes-flip (polynomials)
+  #:type ([a real] [b real])
   [flip3-+          (+ a b)
                     (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
   [flip3--          (- a b)
@@ -453,7 +456,7 @@
   #:type ([a real])
   [pow1           a                           (pow a 1)])
 
-(define-ruleset* pow-canonicalize (exponents simplify sound)
+(define-ruleset* pow-canonicalize-sound (exponents simplify sound)
   #:type ([a real] [b real])
   [exp-to-pow      (exp (* (log a) b))        (pow a b)]
   [unpow1/2        (pow a 1/2)                (sqrt a)]
@@ -470,10 +473,7 @@
   [pow-prod-up      (* (pow a b) (pow a c))     (pow a (+ b c))]
   [pow-flip         (/ 1 (pow a b))             (pow a (neg b))]
   [pow-neg          (pow a (neg b))             (/ 1 (pow a b))]
-  [pow-div          (/ (pow a b) (pow a c))     (pow a (- b c))])
-
-(define-ruleset* pow-specialize-sound (exponents sound)
-  #:type ([a real])
+  [pow-div          (/ (pow a b) (pow a c))     (pow a (- b c))]
   [pow1/2           (sqrt a)                    (pow a 1/2)]
   [pow2             (* a a)                     (pow a 2)]
   [pow1/3           (cbrt a)                    (pow a 1/3)]
@@ -574,7 +574,11 @@
   [tan-PI      (tan (PI))              0]
   [tan-+PI     (tan (+ x (PI)))        (tan x)]
   [hang-0p-tan (/ (sin a) (+ 1 (cos a)))     (tan (/ a 2))]
-  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))]
+  [hang-0m-tan (/ (neg (sin a)) (+ 1 (cos a))) (tan (/ (neg a) 2))])
+
+(define-ruleset* trig-reduce (trigonometry simplify)
+  #:type ([a real] [b real] [x real])
+  [tan-+PI/2   (tan (+ x (/ (PI) 2)))  (/ -1 (tan x))]
   [hang-p0-tan (/ (- 1 (cos a)) (sin a))     (tan (/ a 2))]
   [hang-m0-tan (/ (- 1 (cos a)) (neg (sin a))) (tan (/ (neg a) 2))]
   [hang-p-tan  (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))


### PR DESCRIPTION
This PR continues to work on removing unsoundness in Herbie, specifically by fixing `taylor-sqrt` and `taylor-cbrt` to give sensible results for series expansions of functions like `sqrt(x)` and `cbrt(x + x^2)`. However, removing the unsound rules during simplify still hurts performance. My plan is to merge this as is, and work on disabling them later.