### PR TITLE
Batch e-graph growing operations to speed up soundiness

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -358,7 +358,7 @@
   (egraph-query exprs rules ctx iter-limit node-limit const-folding?))
 
 (define (run-egg input variants?
-                 #:proof-input [proof-input '()]
+                 #:proof-inputs [proof-inputs '()]
                  #:proof-ignore-when-unsound? [proof-ignore-when-unsound? #f])
   (define egg-graph (make-egraph))
   (define ctx (egraph-query-ctx input))
@@ -380,17 +380,21 @@
           (for/list ([iter (in-range (length iter-data))])
             (egraph-get-simplest egg-graph id iter)))))
   
-  (match proof-input
-    [(cons start end)
-     #:when (not (and (egraph-is-unsound-detected egg-graph) proof-ignore-when-unsound?))
-     (when (not (egraph-is-equal egg-graph start end ctx))
-        (error "Cannot get proof: start and end are not equal.\n start: ~a \n end: ~a" start end))
+  (define proofs
+    (for/list ([proof-input (in-list proof-inputs)])
+      (cond
+        [(not (and (egraph-is-unsound-detected egg-graph) proof-ignore-when-unsound?))
+         (match-define (cons start end) proof-input)
+         (unless (egraph-is-equal egg-graph start end ctx)
+           (error "Cannot get proof: start and end are not equal.\n start: ~a \n end: ~a" start end))
 
-     (define proof (egraph-get-proof egg-graph start end ctx))
-     (when (null? proof)
-       (error (format "Failed to produce proof for ~a to ~a" start end)))
-     (cons variants proof)]
-    [_ (cons variants #f)]))
+         (define proof (egraph-get-proof egg-graph start end ctx))
+         (when (null? proof)
+           (error (format "Failed to produce proof for ~a to ~a" start end)))
+         proof]
+        [else #f])))
+
+  (cons variants proofs))
 
 (define (egraph-get-simplest egraph-data node-id iteration)
   (define ptr (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))


### PR DESCRIPTION
This PR speeds up the "Soundiness" phase in Herbie that produces the proofs. For example, for quadratic, soundiness goes from ~30% of runtime to ~13%.

The basic optimization is simple. In soundiness, for each simplify or rewrite alt, we construct the start and end expression, re-create the e-graph that it was extracted from, and construct the proof they are equal. The PR just batches these proofs, so that if two proofs are for the same e-graph, the e-graph is grown once and then all proofs for it are extracted one-by-one. This is way faster, because the total number of e-graphs in question is very small—bounded by 8 but often smaller because later iterations often don't generate useful alts.

Note that I don't bother batching, say, evaluating each expression at a point because that's already basically free.