### PR TITLE
Minor tweaks to Taylor expansion

### DIFF
--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -104,10 +104,12 @@
 (define (gen-series!)
   (when (flag-set? 'generate 'taylor)
     (timeline-event! 'series)
+    (timeline-push! 'inputs (map ~a (^queued^)))
     (define series-expansions
       (apply append
         (for/list ([altn (in-list (^queued^))] [n (in-naturals 1)])
           (filter-not (curry alt-equal? altn) (taylor-alt altn)))))
+    (timeline-push! 'outputs (map ~a series-expansions))
 
     ; Probably unnecessary, at least CI passes!
     (define (is-nan? x)

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -92,8 +92,8 @@
     (for* ([var (free-variables expr)] [transform-type transforms-to-try])
       (match-define (list name f finv) transform-type)
       (define timeline-stop! (timeline-start! 'series (~a expr) (~a var) (~a name)))
-      (for ([_ (in-range 4)])
       (define genexpr (approximate expr var #:transform (cons f finv)))
+      (for ([_ (in-range 6)])
         (define replace
           (with-handlers ([exn:fail:user:herbie:missing? (const #f)])
             (spec->prog (genexpr) (*context*))))


### PR DESCRIPTION
This PR:

- Make Taylor faster by batching the `*rules*` / `expand-accelerators` calls, which weirdly were a big fraction of the total runtime.
- Inlines `taylor-expr` into `taylor-alt`, which is a minor simplification
- Ups the number of Taylor terms from 4 to 6
- Adds some more logging to Taylor.