### PR TITLE
Missing config file for ci

### DIFF
--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -8,6 +8,7 @@
          "core/matcher.rkt"
          "core/simplify.rkt"
          "core/taylor.rkt"
+         "config.rkt"
          "accelerator.rkt"
          "alternative.rkt"
          "common.rkt"


### PR DESCRIPTION
Unable to run the  following CI command.
```
racket infra/ci.rkt --precision binary64 --seed 0 be
nch/hamming/

src/patch.rkt:96:26: *taylor-order-limit*: unbound identifier
  in: *taylor-order-limit*
  location...:
   src/patch.rkt:96:26
```