### PR TITLE
Desugar FPCore entered in the web demo before running it

### DIFF
--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -52,19 +52,19 @@
                               (or (syntax-column stx) (syntax-position stx))))
 
 (define (herbie-error->string err)
-  (with-output-to-string
-    (λ ()
+  (call-with-output-string
+    (λ (p)
       (match err
         [(exn:fail:user:herbie:syntax message marks url locations)
-         (eprintf "~a\n" message)
+         (fprintf p "~a\n" message)
          (for ([(stx message) (in-dict locations)])
-           (eprintf "  ~a\n" (format (syntax->error-format-string stx) message)))
+           (fprintf p "  ~a\n" (format (syntax->error-format-string stx) message)))
          (when url
-           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]
+           (fprintf p "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]
         [(exn:fail:user:herbie message marks url)
-         (eprintf "~a\n" message)
+         (fprintf p "~a\n" message)
          (when url
-           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]))))
+           (fprintf p "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]))))
 
 (define old-error-display-handler (error-display-handler))
 (error-display-handler

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -104,7 +104,6 @@
 (define (parse-test stx)
   (assert-program! stx)
   (define stx* (expand-core stx))
-  (expand-core stx*)
   (assert-program-typed! stx*)
   (define-values (func-name args props body)
     (match (syntax->datum stx*)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -313,8 +313,7 @@
                   "Please " (a ([href ,go-back]) "go back") " and try again."))))])
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
-       (assert-program! formula)
-       (assert-program-typed! formula)
+       (parse-test formula)
        (define hash (sha1 (open-input-string formula-str)))
        (body hash formula))]
     [_

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -305,9 +305,12 @@
            (λ (e)
              (response/error
               "Demo Error"
-              `(p "Invalid formula " (code ,formula-str) ". "
+              `(div
+                (h1 "Invalid formula")
+                (pre ,(herbie-error->string e))
+                (p
                   "Formula must be a valid program using only the supported functions. "
-                  "Please " (a ([href ,go-back]) "go back") " and try again.")))])
+                  "Please " (a ([href ,go-back]) "go back") " and try again."))))])
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
        (assert-program! formula)


### PR DESCRIPTION
This PR fixes #731. The issue is this. When the user submits a job through the web demo, we add it to a queue, and then later the worker thread pulls it out of the queue and works on it. But before putting it in the queue, we want to check it for syntax and type errors, so that the user gets fast feedback in that case. We were calling `assert-syntax!` and `assert-program-typed!` to do that, but we weren't running desugaring before type checking, so we were rejecting programs that actually would have worked.

This PR fixes that by using `parse-test` to check for syntax errors, and it also improves error messages in case things don't type check.