### PR TITLE
FL type annotations for Regimes

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -217,7 +217,7 @@
         (for ([prev-split-idx (in-range 0 point-idx)])
           ;; For each previous split point, we need the best candidate to fill the new regime
          (when 
-          (vector-ref can-split-vec (vector-ref v-aidx prev-split-idx))
+          (unsafe-vector-ref can-split-vec (unsafe-vector-ref v-aidx prev-split-idx))
           (let ([best #f] [bcost #f])
             (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
               (let ([cost (unsafe-fl- (unsafe-flvector-ref psum point-idx)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -4,7 +4,6 @@
          "../syntax/types.rkt" "../errors.rkt" "../points.rkt" "../float.rkt"
          "../compiler.rkt")
 (require math/flonum)
-(require racket/unsafe/ops)
 (provide pareto-regimes (struct-out option) (struct-out si))
 
 (module+ test
@@ -207,36 +206,36 @@
     ;; If there's not enough room to add another splitpoint, just pass the sp-prev along.
     (define vec-aest (make-vector num-points))
     (for ([point-idx (in-range 0 num-points)])
-      (define aest-cost (unsafe-flvector-ref v-acost point-idx))
-      (define aest-best (unsafe-vector-ref v-cidx point-idx))
-      (define aest-bidx (unsafe-vector-ref v-aidx point-idx))
-      (define aest-prev-idx (unsafe-vector-ref v-pidx point-idx))
+      (define aest-cost (flvector-ref v-acost point-idx))
+      (define aest-best (vector-ref v-cidx point-idx))
+      (define aest-bidx (vector-ref v-aidx point-idx))
+      (define aest-prev-idx (vector-ref v-pidx point-idx))
       ;; We take the CSE corresponding to the best choice of previous split point.
       ;; The default, not making a new split-point, gets a bonus of min-weight
-      (let ([acost (- aest-cost min-weight)])
+      (let ([acost (fl- aest-cost min-weight)])
         (for ([prev-split-idx (in-range 0 point-idx)])
           ;; For each previous split point, we need the best candidate to fill the new regime
          (when 
-          (unsafe-vector-ref can-split-vec (unsafe-vector-ref v-aidx prev-split-idx))
+          (vector-ref can-split-vec (vector-ref v-aidx prev-split-idx))
           (let ([best #f] [bcost #f])
             (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
-              (let ([cost (unsafe-fl- (unsafe-flvector-ref psum point-idx)
-                             (unsafe-flvector-ref psum prev-split-idx))])
-                (when (or (not best) (unsafe-fl< cost bcost))
+              (let ([cost (fl- (flvector-ref psum point-idx)
+                             (flvector-ref psum prev-split-idx))])
+                (when (or (not best) (fl< cost bcost))
                   (set! bcost cost)
                   (set! best cidx))))
-            (define temp (unsafe-fl+ (unsafe-flvector-ref v-acost prev-split-idx) bcost))
+            (define temp (fl+ (flvector-ref v-acost prev-split-idx) bcost))
             (when 
-              (unsafe-fl< temp acost)
+              (fl< temp acost)
               (set! acost temp)
               (set! aest-cost acost)
               (set! aest-best best)
               (set! aest-bidx (+ point-idx 1))
               (set! aest-prev-idx prev-split-idx)))))
-        (unsafe-flvector-set! vec-acost point-idx aest-cost)
-        (unsafe-vector-set! vec-cidx point-idx aest-best)
-        (unsafe-vector-set! vec-aidx point-idx aest-bidx)
-        (unsafe-vector-set! vec-pidx point-idx aest-prev-idx)))
+        (flvector-set! vec-acost point-idx aest-cost)
+        (vector-set! vec-cidx point-idx aest-best)
+        (vector-set! vec-aidx point-idx aest-bidx)
+        (vector-set! vec-pidx point-idx aest-prev-idx)))
   (values vec-acost vec-cidx vec-aidx vec-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,
@@ -258,10 +257,10 @@
             (let ([cost (flvector-ref cand-psums point-idx)])
               (cand cost cand-idx (+ point-idx 1) num-points)))))
 
-      (unsafe-flvector-set! vec-acost point-idx (fl (cand-acost cse-min)))
-      (unsafe-vector-set! vec-cidx point-idx (cand-idx cse-min))
-      (unsafe-vector-set! vec-aidx point-idx (cand-point-idx cse-min))
-      (unsafe-vector-set! vec-pidx point-idx (cand-prev-idx cse-min)))
+      (flvector-set! vec-acost point-idx (fl (cand-acost cse-min)))
+      (vector-set! vec-cidx point-idx (cand-idx cse-min))
+      (vector-set! vec-aidx point-idx (cand-point-idx cse-min))
+      (vector-set! vec-pidx point-idx (cand-prev-idx cse-min)))
     (values vec-acost vec-cidx vec-aidx vec-pidx))
 
   ;; prefix of p is for previous

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -4,7 +4,7 @@
          "../syntax/types.rkt" "../errors.rkt" "../points.rkt" "../float.rkt"
          "../compiler.rkt")
 (require math/flonum)
-
+(require racket/unsafe/ops)
 (provide pareto-regimes (struct-out option) (struct-out si))
 
 (module+ test
@@ -178,8 +178,7 @@
 
 (define/contract (err-lsts->split-indices err-lsts can-split)
   (->i ([e (listof list)] [cs (listof boolean?)]) 
-       [result (cs) (curry valid-splitindices? cs)])
-  ;; TODO add internal function
+        [result (cs) (curry valid-splitindices? cs)])
   (define can-split-vec (list->vector can-split))
   (define err-lsts-vec (list->vector err-lsts))
   ;; We have num-candidates candidates, each of whom has error lists of length num-points.
@@ -208,10 +207,10 @@
     ;; If there's not enough room to add another splitpoint, just pass the sp-prev along.
     (define vec-aest (make-vector num-points))
     (for ([point-idx (in-range 0 num-points)])
-      (define aest-cost (flvector-ref v-acost point-idx))
-      (define aest-best (vector-ref v-cidx point-idx))
-      (define aest-bidx (vector-ref v-aidx point-idx))
-      (define aest-prev-idx (vector-ref v-pidx point-idx))
+      (define aest-cost (unsafe-flvector-ref v-acost point-idx))
+      (define aest-best (unsafe-vector-ref v-cidx point-idx))
+      (define aest-bidx (unsafe-vector-ref v-aidx point-idx))
+      (define aest-prev-idx (unsafe-vector-ref v-pidx point-idx))
       ;; We take the CSE corresponding to the best choice of previous split point.
       ;; The default, not making a new split-point, gets a bonus of min-weight
       (let ([acost (- aest-cost min-weight)])
@@ -221,23 +220,23 @@
           (vector-ref can-split-vec (vector-ref v-aidx prev-split-idx))
           (let ([best #f] [bcost #f])
             (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
-              (let ([cost (- (flvector-ref psum point-idx)
-                             (flvector-ref psum prev-split-idx))])
-                (when (or (not best) (< cost bcost))
+              (let ([cost (unsafe-fl- (unsafe-flvector-ref psum point-idx)
+                             (unsafe-flvector-ref psum prev-split-idx))])
+                (when (or (not best) (unsafe-fl< cost bcost))
                   (set! bcost cost)
                   (set! best cidx))))
-            (define temp (+ (flvector-ref v-acost prev-split-idx) bcost))
+            (define temp (unsafe-fl+ (unsafe-flvector-ref v-acost prev-split-idx) bcost))
             (when 
-              (< temp acost) 
+              (unsafe-fl< temp acost)
               (set! acost temp)
               (set! aest-cost acost)
               (set! aest-best best)
               (set! aest-bidx (+ point-idx 1))
               (set! aest-prev-idx prev-split-idx)))))
-        (flvector-set! vec-acost point-idx aest-cost)
-        (vector-set! vec-cidx point-idx aest-best)
-        (vector-set! vec-aidx point-idx aest-bidx)
-        (vector-set! vec-pidx point-idx aest-prev-idx)))
+        (unsafe-flvector-set! vec-acost point-idx aest-cost)
+        (unsafe-vector-set! vec-cidx point-idx aest-best)
+        (unsafe-vector-set! vec-aidx point-idx aest-bidx)
+        (unsafe-vector-set! vec-pidx point-idx aest-prev-idx)))
   (values vec-acost vec-cidx vec-aidx vec-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,
@@ -250,6 +249,7 @@
     (define vec-pidx (make-vector num-points))
     (for ([point-idx (in-range num-points)])
       ;; TODO this is kinda sloppy using #cand for only vector construction
+      ;; Also slow because lots of allocations but only runs once
       (define cse-min (vector-argmin cand-acost
         ;; Consider all the candidates we could put in this region
         ;; by sorting candidates
@@ -257,10 +257,11 @@
           ([cand-idx (range num-candidates)] [cand-psums flvec-psums])
             (let ([cost (flvector-ref cand-psums point-idx)])
               (cand cost cand-idx (+ point-idx 1) num-points)))))
-      (flvector-set! vec-acost point-idx (fl (cand-acost cse-min)))
-      (vector-set! vec-cidx point-idx (cand-idx cse-min))
-      (vector-set! vec-aidx point-idx (cand-point-idx cse-min))
-      (vector-set! vec-pidx point-idx (cand-prev-idx cse-min)))
+
+      (unsafe-flvector-set! vec-acost point-idx (fl (cand-acost cse-min)))
+      (unsafe-vector-set! vec-cidx point-idx (cand-idx cse-min))
+      (unsafe-vector-set! vec-aidx point-idx (cand-point-idx cse-min))
+      (unsafe-vector-set! vec-pidx point-idx (cand-prev-idx cse-min)))
     (values vec-acost vec-cidx vec-aidx vec-pidx))
 
   ;; prefix of p is for previous


### PR DESCRIPTION
This PR adds FL type annotations to regimes add-split point function increasing the performance by ~2x over current version.

[Metrics for fl branch](https://nightly.cs.washington.edu/reports/herbie/1710263105:nightly:zane-regimes-fl:fe07cd4dc6/timeline.html)
[Metrics for main](https://nightly.cs.washington.edu/reports/herbie/1710245633:nightly:main:d14d36a196/timeline.html)