### PR TITLE
Fix test failures when trying to test the `pow1/3` rule

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -192,7 +192,11 @@
 
   (define compile
     (make-compiler 'ival
-                   #:input->value (lambda (prog _) (ival (bf prog)))
+                   #:input->value
+                   (lambda (prog _)
+                     (define lo (parameterize ([bf-rounding-mode 'down]) (bf prog)))
+                     (define hi (parameterize ([bf-rounding-mode 'up]) (bf prog)))
+                     (ival lo hi))
                    #:op->procedure (lambda (op) (operator-info (real-op op) 'ival))
                    #:op->itypes (lambda (op) (operator-info (real-op op) 'itype))
                    #:if-procedure ival-if


### PR DESCRIPTION
Recent changes to Rival have broken this rule. But that's because they uncovered a hidden bug: exact constants like `1/3` would be compiled into a point interval `[x, x]`, where `x` is a bigfloat approximation to 1/3. Note that that doesn't actually include 1/3! Rival recently got more precise with intervals like this, and as a result it now correctly reports that `pow` fails on all points in that interval. So this PR fixes the compiler to round each constant both ways and form an interval that way. This might slow Herbie down slightly, but it's probably not a big effect and it's only in bigfloat mode. If this is really a big problem, we could be more clever, like only rounding both ways when `x != float(x) or precision < 53`.