### PR TITLE
Remove a bad precondition from the `tanhf` benchmark

### DIFF
--- a/bench/hamming/trigonometry.fpcore
+++ b/bench/hamming/trigonometry.fpcore
@@ -58,7 +58,6 @@
 ; of the error using this rewrite.
 (FPCore (x)
  :name "tanhf (example 3.4)"
- :pre (and (<= (- INFINITY) x) (<= x INFINITY))
  :alt 
  (! :description (platform libm)
   (tan (/ x 2)))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -185,10 +185,10 @@
   [ival ival-e])
 
 (define-operator (INFINITY) real
-  [ival (λ () (ival +inf.bf))])
+  [ival (λ () (ival (bfprev +inf.bf) +inf.bf))])
 
 (define-operator (NAN) real
-  [ival (λ () (ival +nan.bf))])
+  [ival (λ () ival-illegal)])
 
 (define-operator (TRUE) bool
   [ival (const (ival-bool true))])


### PR DESCRIPTION
The `tanhf` benchmark has the following benchmark, I think this was added in Herbie Gold: `(and (<= (- INFINITY) x) (<= x INFINITY))`. Besides not really making sense (this is true of literally all values!) it is also invalid in Rival because INFINITY is not a real number. This was causing crashes.

This PR removes the nonsensical precondition and fixes the crashes by making INFINITY denote to an interval (from max-val to infinity).