### PR TITLE
Add feature to always compact certain timeline tables

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -78,8 +78,6 @@
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference (hash-ref exacts-hash expr) approx repr)]))
       (hash-update! errs (car expr) (curry cons err))))
-  (timeline-compact! 'outcomes)
-  (timeline-compact! 'mixsample)
 
   (for/list ([expr (in-list exprs)] [subexprs (in-list subexprss)])
     (for/hash ([subexpr (in-list subexprs)])

--- a/src/error-table.rkt
+++ b/src/error-table.rkt
@@ -60,8 +60,6 @@
       (hash-update! error-count-hash expr (lambda (x) (set-add x pt))))
     
     (define exacts (apply subexprs-fn pt))
-    (timeline-compact! 'outcomes)
-    (timeline-compact! 'mixsamples)
 
     (define exacts-hash
       (make-immutable-hash (map cons subexprs-list exacts)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -163,8 +163,6 @@
           expr) 
         '()))
   
-  (timeline-compact! 'mixsample)
-
   (void))
 
 ;; Returns the locations of `subexpr` within `expr`
@@ -308,7 +306,6 @@
   (*start-prog* (alt-expr initial))
   (define table (make-alt-table pcontext initial context))
   (define simplified* (append (append-map (curryr starting-alts context) simplified) simplified))
-  (timeline-compact! 'mixsample)
   (timeline-event! 'eval)
   (define-values (errss costs) (atab-eval-altns table simplified* context))
   (timeline-event! 'prune)

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -143,12 +143,9 @@
             (loop (+ 1 sampled) 0 (cons pt points) (cons exs exactss)))]
        [else
         (when (>= skipped (*max-skipped-points*))
-          (timeline-compact! 'outcomes)
           (raise-herbie-error "Cannot sample enough valid points."
                               #:url "faq.html#sample-valid-points"))
         (loop sampled (+ 1 skipped) points exactss)])))
-  (timeline-compact! 'mixsample)
-  (timeline-compact! 'outcomes)
   (cons outcomes (cons points (flip-lists exactss))))
 
 
@@ -166,7 +163,6 @@
     (parameterize ([ground-truth-require-convergence #f])
       ;; TODO: Should make-sampler allow multiple contexts?
       (make-sampler (first ctxs) pre fn)))
-  (timeline-compact! 'mixsample)
   (timeline-event! 'sample)
   ;; TODO: should batch-prepare-points allow multiple contexts?
   (match-define (cons table2 results) (batch-prepare-points fn (first ctxs) sampler))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -248,7 +248,7 @@
   (define (on-timeout)
     (parameterize ([*timeline-disabled* timeline-disabled?])
       (timeline-load! timeline)
-      (timeline-compact! 'outcomes)
+      (timeline-event! 'end)
       (match command 
         ['improve (job-result test 'timeout (*timeout*) (timeline-extract) (warning-log) #f)]
         [_ (error 'run-herbie "command ~a timed out" command)])))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -34,11 +34,12 @@
   (when *timeline-active-key*
     (hash-update! (car (unbox (*timeline*))) *timeline-active-key*
                   (curry append *timeline-active-value*) '())
-    (for ([key (in-list always-compact)])
-      (timeline-compact! key))
     (set! *timeline-active-key* #f))
   
   (unless (*timeline-disabled*)
+    (for ([key (in-list always-compact)]
+          #:when (hash-has-key? (car (unbox (*timeline*))) key))
+      (timeline-compact! key))
     (define b (make-hasheq (list (cons 'type (~a type))
                                  (cons 'time (current-inexact-milliseconds)))))
     (set-box! (*timeline*) (cons b (unbox (*timeline*))))))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -10,7 +10,7 @@
   (timeline-push! (symbol? jsexpr? ... . -> . void?))
   (timeline-adjust! (symbol? symbol? jsexpr? ... . -> . void?))
   (timeline-start! (symbol? jsexpr? ... . -> . (-> void?))))
- timeline-load! timeline-extract timeline-compact!
+ timeline-load! timeline-extract
  timeline-merge timeline-relink *timeline-disabled*)
 (module+ debug (provide *timeline*))
 
@@ -27,11 +27,15 @@
 (define *timeline-active-value* #f)
 
 (define *timeline-disabled* (make-parameter true))
+
+(define always-compact '(mixsample outcomes))
   
 (define (timeline-event! type)
   (when *timeline-active-key*
     (hash-update! (car (unbox (*timeline*))) *timeline-active-key*
                   (curry append *timeline-active-value*) '())
+    (for ([key (in-list always-compact)])
+      (timeline-compact! key))
     (set! *timeline-active-key* #f))
   
   (unless (*timeline-disabled*)

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -37,9 +37,10 @@
     (set! *timeline-active-key* #f))
   
   (unless (*timeline-disabled*)
-    (for ([key (in-list always-compact)]
-          #:when (hash-has-key? (car (unbox (*timeline*))) key))
-      (timeline-compact! key))
+    (when (pair? (unbox (*timeline*)))
+      (for ([key (in-list always-compact)]
+            #:when (hash-has-key? (car (unbox (*timeline*))) key))
+        (timeline-compact! key)))
     (define b (make-hasheq (list (cons 'type (~a type))
                                  (cons 'time (current-inexact-milliseconds)))))
     (set-box! (*timeline*) (cons b (unbox (*timeline*))))))


### PR DESCRIPTION
Basically, two of our timeline tables (`outcomes` and `mixsample`) are really really big. So far we've solved that by manually inserting calls to `timeline-compact!`, which reduce the size of the tables by merging duplicate rows. But that doesn't happen if Herbie times out, since then it doesn't do the `timeline-compact!` step either! So this PR adds a list of keys to always compact, so that you don't need to write `timeline-compact!` manually any more.