### PR TITLE
change loc of proof initial 'goal' term to empty list instead of false

### DIFF
--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -54,7 +54,7 @@
          (for ([arg (in-list args)] [i (in-naturals 1)])
            (loop arg (cons i loc)))]
         [_ (void)]))
-    (k 'Goal #f #f step)))
+    (k 'Goal #f '() step)))
 
 ;; HTML renderer for derivations
 (define/contract (render-history altn pcontext pcontext2 ctx)


### PR DESCRIPTION
This PR changes the location term of the goal proof step from `false` to the empty list `'()`. This functionally changes nothing in Herbie.

When a derivation is described as a list of proof steps, there is always a step with direction "goal" which represents the original expression. Before this PR, this step had a location of `false`.

In every other place where a location is defined, the location is defined as a list. 
Changing this one instance where a location is defined as `false` instead of a list adds consistency by changing the type of `loc` from the sum type `Boolean | Array` to the type `Array`.