### PR TITLE
Simplify `munge` and `all-subexpressions` by removing type logic

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2022 Herbie Project
+Copyright (c) 2015-2024 Herbie Project
 Modified work Copyright 2016 Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/egg-herbie/info.rkt
+++ b/egg-herbie/info.rkt
@@ -11,3 +11,5 @@
   '("rackunit-lib"))
 
 (define deps '(("base" #:version "8.0")))
+
+(define license 'MIT)

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -109,9 +109,8 @@
                        #:input->value input->value
                        #:op->procedure op->proc
                        #:op->itypes op->itypes
-                       #:if-procedure if-proc
-                       #:cond-type cond-type)
-  (lambda (exprs vars type)
+                       #:if-procedure if-proc)
+  (lambda (exprs vars)
     ;; Instruction cache
     (define icache '())
     (define exprhash
@@ -126,7 +125,6 @@
     ; Translates programs into an instruction sequence of operations
     (define (munge prog)
       (set! size (+ 1 size))
-      (define type (if (equal? type 'real) (type-of prog) (repr-of prog)))
       (define expr
         (match prog
           [(? number?)
@@ -173,9 +171,8 @@
                      (ival lo hi))
                    #:op->procedure (lambda (op) (operator-info (real-op op) 'ival))
                    #:op->itypes (lambda (op) (operator-info (real-op op) 'itype))
-                   #:if-procedure ival-if
-                   #:cond-type 'bool))
-  (compile specs vars 'real))
+                   #:if-procedure ival-if))
+  (compile specs vars))
 
 ;; Compiles a program of operator implementations into a procedure
 ;; that evaluates the program on a single input of representation values
@@ -186,9 +183,8 @@
                    #:input->value real->repr
                    #:op->procedure (lambda (op) (impl-info op 'fl))
                    #:op->itypes (lambda (op) (impl-info op 'itype))
-                   #:if-procedure (λ (c ift iff) (if c ift iff))
-                   #:cond-type (get-representation 'bool)))
-  (compile exprs (context-vars ctx) (context-repr ctx)))
+                   #:if-procedure (λ (c ift iff) (if c ift iff))))
+  (compile exprs (context-vars ctx)))
 
 ;; Like `compile-specs`, but for a single spec.
 (define (compile-spec spec vars)

--- a/src/error-table.rkt
+++ b/src/error-table.rkt
@@ -2,7 +2,7 @@
 
 (require racket/set math/bigfloat)
 (require "points.rkt" "syntax/types.rkt" "core/localize.rkt" "common.rkt"
-         "ground-truth.rkt" "syntax/sugar.rkt" "timeline.rkt")
+         "ground-truth.rkt" "syntax/sugar.rkt" "timeline.rkt" "programs.rkt")
 
 (provide actual-errors predicted-errors)
 
@@ -36,24 +36,17 @@
 (define (predicted-errors expr ctx pctx)
   (define cond-thres (bf 100))
   
-  (define subexprs
-    (all-subexpressions expr (context-repr ctx)))
-  (define subexprs-list (map car subexprs))
-  (define spec-list (map prog->spec subexprs-list))
+  (define subexprs (all-subexpressions expr))
+  (define spec-list (map prog->spec subexprs))
  
   (define ctx-list
     (for/list ([subexpr (in-list subexprs)])
-      (struct-copy context ctx [repr (cdr subexpr)])))
+      (struct-copy context ctx [repr (repr-of subexpr ctx)])))
 
-  (define repr-hash
-    (make-immutable-hash (map cons
-                              subexprs-list
-                              (map context-repr ctx-list))))
- 
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
  
   (define error-count-hash
-    (make-hash (map (lambda (x) (cons x '())) subexprs-list)))
+    (make-hash (map (lambda (x) (cons x '())) subexprs)))
   
   (for ([(pt _) (in-pcontext pctx)])
     (define (mark-erroneous! expr)
@@ -62,14 +55,13 @@
     (define exacts (apply subexprs-fn pt))
 
     (define exacts-hash
-      (make-immutable-hash (map cons subexprs-list exacts)))
+      (make-immutable-hash (map cons subexprs exacts)))
     (define (exacts-ref subexpr)
       (define exacts-val (hash-ref exacts-hash subexpr))
-       ((representation-repr->bf
-                              (hash-ref repr-hash subexpr))
-                             exacts-val))
+       ((representation-repr->bf (repr-of subexpr ctx))
+        exacts-val))
  
-    (for/list ([subexpr subexprs-list])
+    (for/list ([subexpr subexprs])
       (define subexpr-val (exacts-ref subexpr))
       
       (match subexpr

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -40,3 +40,5 @@
       '("syntax/test-rules.rkt" ; These take too long, package server gives us 60s
         "sampling.rkt") ; These require the benchmarks
       '()))
+
+(define license 'MIT)


### PR DESCRIPTION
Since literal values now know their own precisions, the `munge` and `all-subexpressions` functions can be simpler.  I think this PR is a small refactor that helps with the long-term goal of moving real computation to Rival.