### PR TITLE
Clean up the main loop a bit by splitting things into functions

### DIFF
--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -275,6 +275,7 @@
             ['local-error (get-local-error test pcontext)]
             ['sample (get-sample test)]
             [_ (error 'compute-result "unknown command ~a" command)]))
+        (timeline-event! 'end)
         (define time (- (current-inexact-milliseconds) start-time))
         (job-result test 'success time (timeline-extract) (warning-log) result))))
   


### PR DESCRIPTION
This PR basically continues the endless battle to make the mainloop maintainable by splitting the `extract!` function into a few separate functions, and similarly moving Barhgav's explanations to a new `explain!` function. In the process, I managed to add a use of `batch-errors` and rewrite one complicated function into a simpler one.