### PR TITLE
Fixed preprocessing JSON conversion

### DIFF
--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -240,9 +240,6 @@
             (training-error . ,err2)
             (preprocessing . ,(map (curry map symbol->string) preprocessing)))]))
 
-;; preprocessing is a list of lists and the inner lists start with a symbol,
-;; which is illegal for converting to json.
-
 (define (render-proof-json proof soundiness pcontext ctx)
       (for/list ([step proof] [sound soundiness])
           (define-values (dir rule loc expr) (splice-proof-step step))

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -238,7 +238,10 @@
             (prev . ,(render-json prev pcontext pcontext2 ctx))
             (error . ,err)
             (training-error . ,err2)
-            (preprocessing . ,preprocessing))]))
+            (preprocessing . ,(map (curry map symbol->string) preprocessing)))]))
+
+;; preprocessing is a list of lists and the inner lists start with a symbol,
+;; which is illegal for converting to json.
 
 (define (render-proof-json proof soundiness pcontext ctx)
       (for/list ([step proof] [sound soundiness])


### PR DESCRIPTION
This PR corrects a bug in converting preprocessing information to JSON that caused any run with preprocessing to crash on `herbie web` instances.

The preprocessing operator was represented as a `symbol`, which is unsupported by JSON conversion; this PR converts these symbols to JSON-legal strings.