### PR TITLE
Clean up sampling

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -84,7 +84,7 @@
 (define (prepend-argument fn val pcontext ctx)
   (define pts (for/list ([(pt ex) (in-pcontext pcontext)]) pt))
   (define (new-sampler) (cons val (random-ref pts)))
-  (apply mk-pcontext (cdr (batch-prepare-points fn ctx new-sampler))))
+  (apply mk-pcontext (cdr (batch-prepare-points fn (list ctx) new-sampler))))
 
 ;; Accepts a list of sindices in one indexed form and returns the
 ;; proper splitpoints in float form. A crucial constraint is that the

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -67,8 +67,11 @@
        y)))
   compiled-spec)
 
-(define (ival-eval repr fn pt [iter 0] [precision (*starting-prec*)])
+(define (ival-eval fn ctxs pt [iter 0] [precision (*starting-prec*)])
   (define start (current-inexact-milliseconds))
+  (define <-bfs
+    (for/list ([ctx (in-list ctxs)])
+      (representation-bf->repr (context-repr ctx))))
   (define-values (status final-prec value)
     (let loop ([iter iter] [precision precision])
       (define exs
@@ -80,31 +83,40 @@
       (define precision* (exact-floor (* precision 2)))
       (cond
         [err
-         (values err (if (*use-mixed-precision*) iter precision) +nan.0)]
+         (values err (if (*use-mixed-precision*) iter precision)
+          #f)]
         [(not err?)
-         (define infinite?
-           (ival-lo (is-infinite-interval repr (apply ival-or exs))))
-         (values (if infinite? 'infinite 'valid) (if (*use-mixed-precision*) iter precision) exs)]
-        [(if (*use-mixed-precision*) (> iter* (*max-sampling-iterations*)) (> precision* (*max-mpfr-prec*)))
-         (values 'exit (if (*use-mixed-precision*) iter precision) +nan.0)]
+         (define any-inf? #f)
+         (define out
+           (for/list ([ex exs] [<-bf <-bfs])
+             (define fl (<-bf (ival-lo ex)))
+             (when (and (eq? <-bf bigfloat->flonum) (infinite? fl))
+               (set! any-inf? #t))
+             fl))
+         (values (if any-inf? 'infinite 'valid)
+                 (if (*use-mixed-precision*) iter precision)
+                 out)]
+        [(if (*use-mixed-precision*)
+             (> iter* (*max-sampling-iterations*))
+             (> precision* (*max-mpfr-prec*)))
+         (values 'exit (if (*use-mixed-precision*) iter precision) #f)]
         [else
          (loop iter* precision*)])))
   (timeline-push!/unsafe 'outcomes (- (current-inexact-milliseconds) start)
                          final-prec (~a status) 1)
-  (values status precision value))
+  (values status value))
 
 ; ENSURE: all contexts have the same list of variables
 (define (eval-progs-real progs ctxs)
   (define repr (context-repr (car ctxs)))
   (define fn (make-search-func '(TRUE) progs ctxs))
-  (define (f . pt)
-    (define-values (result prec exs) (ival-eval repr fn pt))
+  (define (<eval-prog-real> . pt)
+    (define-values (result exs) (ival-eval fn ctxs pt))
     (match exs
       [(? list?)
-      (for/list ([ex exs] [ctx* ctxs])
-        ((representation-bf->repr (context-repr ctx*)) (ival-lo ex)))]
-      [(? nan?)
-      (for/list ([ctx* ctxs])
-        ((representation-bf->repr (context-repr ctx*)) +nan.bf))]))
-  (procedure-rename f '<eval-prog-real>))
+       exs]
+      [#f
+       (for/list ([ctx* ctxs])
+         ((representation-bf->repr (context-repr ctx*)) +nan.bf))]))
+  <eval-prog-real>)
 

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -83,19 +83,10 @@
       (define precision* (exact-floor (* precision 2)))
       (cond
         [err
-         (values err (if (*use-mixed-precision*) iter precision)
-          #f)]
+         (values err (if (*use-mixed-precision*) iter precision) #f)]
         [(not err?)
-         (define any-inf? #f)
-         (define out
-           (for/list ([ex exs] [<-bf <-bfs])
-             (define fl (<-bf (ival-lo ex)))
-             (when (and (eq? <-bf bigfloat->flonum) (infinite? fl))
-               (set! any-inf? #t))
-             fl))
-         (values (if any-inf? 'infinite 'valid)
-                 (if (*use-mixed-precision*) iter precision)
-                 out)]
+         (values 'valid (if (*use-mixed-precision*) iter precision)
+                 (for/list ([ex exs] [<-bf <-bfs]) (<-bf (ival-lo ex))))]
         [(if (*use-mixed-precision*)
              (> iter* (*max-sampling-iterations*))
              (> precision* (*max-mpfr-prec*)))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -109,30 +109,31 @@
 
 ;; Part 3: computing exact values by recomputing at higher precisions
 
-(define (batch-prepare-points fn ctx sampler)
+(define (batch-prepare-points fn ctxs sampler)
   ;; If we're using the bf fallback, start at the max precision
-  (define repr (context-repr ctx))
-  (define <-bf (representation-bf->repr repr))
   (define outcomes (make-hash))
 
   (define-values (points exactss)
     (let loop ([sampled 0] [skipped 0] [points '()] [exactss '()])
       (define pt (sampler))
 
-      (define-values (status precision out)
+      (define-values (status exs)
         (parameterize ([*use-mixed-precision* #t])
-          (ival-eval repr fn pt)))
+          (ival-eval fn ctxs pt)))
       (hash-update! outcomes status (curry + 1) 0)
 
       (when (equal? status 'exit)
         (warn 'ground-truth #:url "faq.html#ground-truth"
               "could not determine a ground truth"
-              #:extra (for/list ([var (context-vars ctx)] [val pt])
+              #:extra (for/list ([var (context-vars (first ctxs))] [val pt])
                         (format "~a = ~a" var val))))
 
+      (define is-bad?
+        (for/or ([input (in-list pt)] [ctx (in-list ctxs)])
+          ((representation-special-value? (context-repr ctx)) input)))
+
       (cond
-       [(and (list? out) (not (ormap (representation-special-value? repr) pt)))
-        (define exs (map (compose <-bf ival-lo) out))
+       [(and (list? exs) (not is-bad?))
         (if (>= (+ 1 sampled) (*num-points*))
             (values (cons pt points) (cons exs exactss))
             (loop (+ 1 sampled) 0 (cons pt points) (cons exs exactss)))]
@@ -159,8 +160,7 @@
       ;; TODO: Should make-sampler allow multiple contexts?
       (make-sampler (first ctxs) pre fn)))
   (timeline-event! 'sample)
-  ;; TODO: should batch-prepare-points allow multiple contexts?
-  (match-define (cons table2 results) (batch-prepare-points fn (first ctxs) sampler))
+  (match-define (cons table2 results) (batch-prepare-points fn ctxs sampler))
   (define total (apply + (hash-values table2)))
   (when (> (hash-ref table2 'infinite 0.0) (* 0.2 total))
    (warn 'inf-points #:url "faq.html#inf-points"

--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -92,7 +92,8 @@
         (timeline-push! 'sampling n (make-sampling-table ctx true false other))
 
         (define n* (remainder n (length (first rects))))
-        (if (or (>= n depth) (empty? (search-space-other space)))
+        (if (or (>= n depth) (empty? (search-space-other space))
+                (>= (length other) (expt 2 depth)))
             (cons
              (append (search-space-true space) (search-space-other space))
              (make-sampling-table ctx true false other))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -42,7 +42,7 @@
   (for ([pt (in-list pts)] [v1 (in-list exs)])
     (with-check-info* (map make-check-info fv pt)
       (λ ()
-        (define-values (status prec v2) (ival-eval repr fn pt))
+        (define-values (status v2) (ival-eval repr fn pt))
         (with-check-info (['lhs v1] ['rhs v2] ['status status])
           (when (and (real? v2) (nan? v2) (not (set-member? '(exit unsamplable) status)))
             (fail "Right hand side returns NaN")))))))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -42,7 +42,7 @@
   (for ([pt (in-list pts)] [v1 (in-list exs)])
     (with-check-info* (map make-check-info fv pt)
       (λ ()
-        (define-values (status v2) (ival-eval repr fn pt))
+        (define-values (status v2) (ival-eval fn (list ctx) pt))
         (with-check-info (['lhs v1] ['rhs v2] ['status status])
           (when (and (real? v2) (nan? v2) (not (set-member? '(exit unsamplable) status)))
             (fail "Right hand side returns NaN")))))))


### PR DESCRIPTION
- Don't `analyze` forever we start with lots of hyperrects
- Don't return precision from `ival-eval` (no one uses it)
- Do ival->repr conversion inside `ival-eval` (removes duplication)
- Only check for infinities for `binary64` repr (not sure about this, but it's slow)