### PR TITLE
Faster `search-func` and `eval` by using vectors

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -190,22 +190,25 @@
 
 ;; Like `compile-specs`, but for a single spec.
 (define (compile-spec spec vars)
-  (vector-ref (compile-specs (list spec) vars) 0))
+  (define core (compile-specs (list spec) vars))
+  (define (<compiled-spec> . xs) (vector-ref (apply core xs) 0))
+  <compiled-spec>)
 
 ;; Like `compile-progs`, but a single prog.
 (define (compile-prog expr ctx)
-  (vector-ref (compile-progs (list expr) ctx) 0))
+  (define core (compile-progs (list expr) ctx))
+  (define (<compiled-prog> . xs) (vector-ref (apply core xs) 0))
+  <compiled-prog>)
 
-(define (backward-pass ivec varc vregs vprecs vstart-precs root-regs)
+(define (backward-pass ivec varc vregs vprecs vstart-precs root-reg)
   (vector-fill! vprecs 0)
 
-  (for ([root-reg (in-vector root-regs)])
   (define result (vector-ref vregs root-reg))
   (when
       (equal? 1 (flonums-between
                  (bigfloat->flonum (ival-lo result))
                  (bigfloat->flonum (ival-hi result))))
-    (vector-set! vprecs (- root-reg varc) (get-slack))))
+    (vector-set! vprecs (- root-reg varc) (get-slack)))
   
   (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)] ; reversed over ivec
         [n (in-range (- (vector-length vregs) 1) -1 -1)])         ; reversed over indices of vregs

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -24,6 +24,8 @@
 ;; as well as the indices of the roots to extract.
 ;; name ::= 'fl or 'ival
 (define (make-progs-interpreter name vars ivec roots)
+  (define rootvec (list->vector roots))
+  (define rootlen (vector-length rootvec))
   (define varc (length vars))
   (define vreg-count (+ varc (vector-length ivec)))
   (define vregs (make-vector vreg-count))
@@ -57,7 +59,7 @@
           (vector-set! vregs n output)
           (timeline-stop!))
 
-        (for/list ([root (in-list roots)])
+        (for/vector #:length rootlen ([root (in-vector rootvec)])
           (vector-ref vregs root)))
    
       ; name is 'fl
@@ -69,7 +71,7 @@
             (for/list ([idx (in-list (cdr instr))])
               (vector-ref vregs idx)))
           (vector-set! vregs n (apply (car instr) srcs)))
-        (for/list ([root (in-list roots)])
+        (for/vector #:length rootlen ([root (in-vector rootvec)])
           (vector-ref vregs root)))))
 
 (define (get-slack)
@@ -188,21 +190,22 @@
 
 ;; Like `compile-specs`, but for a single spec.
 (define (compile-spec spec vars)
-  (compose first (compile-specs (list spec) vars)))
+  (vector-ref (compile-specs (list spec) vars) 0))
 
 ;; Like `compile-progs`, but a single prog.
 (define (compile-prog expr ctx)
-  (compose first (compile-progs (list expr) ctx)))
+  (vector-ref (compile-progs (list expr) ctx) 0))
 
-(define (backward-pass ivec varc vregs vprecs vstart-precs root-reg)
+(define (backward-pass ivec varc vregs vprecs vstart-precs root-regs)
   (vector-fill! vprecs 0)
 
+  (for ([root-reg (in-vector root-regs)])
   (define result (vector-ref vregs root-reg))
   (when
       (equal? 1 (flonums-between
                  (bigfloat->flonum (ival-lo result))
                  (bigfloat->flonum (ival-hi result))))
-    (vector-set! vprecs (- (vector-length vprecs) 1) (get-slack)))
+    (vector-set! vprecs (- root-reg varc) (get-slack))))
   
   (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)] ; reversed over ivec
         [n (in-range (- (vector-length vregs) 1) -1 -1)])         ; reversed over indices of vregs

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -49,8 +49,9 @@
       (for/list ([input (in-list inputs)]
                  [repr (context-var-reprs (car ctxs))])
         (if (ival? input) input (ival ((representation-repr->bf repr) input)))))
-    (match-define (list ival-pre ival-bodies ...) (apply fns inputs*))
-    (for/list ([y ival-bodies] [ctx ctxs])
+    (define outvec (apply fns inputs*))
+    (define ival-pre (vector-ref outvec 0))
+    (for/list ([y (in-vector outvec 1)] [ctx (in-list ctxs)])
       (define repr (context-repr ctx))
       (ival-then
        ; The two `invalid` ones have to go first, because later checks

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -78,7 +78,7 @@
   (define fn (compile-progs exprs ctx))
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (batch-errors-handler exprs point)])
-      (for/list ([out (in-list (apply fn point))])
+      (for/list ([out (in-vector (apply fn point))])
         (point-error out exact (context-repr ctx))))))
 
 ;; Herbie <=> JSON conversion for pcontext


### PR DESCRIPTION
Basically, this PR just switches to using vectors as the output of compiled progs/specs instead of lists. This should reduce allocations, avoid reversing lists, avoid traversing lists, and so on. It should save at least a few minutes. Plus, it turns out that the list in `make-search-func` was not using `in-list` and adding that annotation (now `in-vector`) should be a big speedup on its own.