### PR TITLE
No repeats in tuning

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -237,7 +237,7 @@
   ; Repeating part calculation
 
   ; Copying new precisions into vprecs
-  (vector-copy! vprecs 0 new-vprecs) 
+  (vector-copy! vprecs 0 vprecs-new) 
   )
 
 ; This function goes through ivec and vregs and calculates (+ exponents base-precisions) for each operator in ivec

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -49,14 +49,14 @@
           (vector-set! vregs n arg))
         (for ([instr (in-vector ivec)] [n (in-naturals varc)]
                                        [precision (in-vector (if (zero? (*sampling-iteration*)) vstart-precs vprecs))]
-                                       [repeat (in-vector vrepeats)])
-          (when (not repeat)
-            (define timeline-stop! (timeline-start!/unsafe 'mixsample
-                                                           (symbol->string (object-name (car instr)))
-                                                           (- precision (remainder precision prec-threshold))))
-            (parameterize ([bf-precision precision])
-              (vector-set! vregs n (apply-instruction instr vregs)))
-            (timeline-stop!)))
+                                       [repeat (in-vector vrepeats)]
+                                       #:unless repeat)
+          (define timeline-stop! (timeline-start!/unsafe 'mixsample
+                                                         (symbol->string (object-name (car instr)))
+                                                         (- precision (remainder precision prec-threshold))))
+          (parameterize ([bf-precision precision])
+            (vector-set! vregs n (apply-instruction instr vregs)))
+          (timeline-stop!))
         
         (for/vector #:length rootlen ([root (in-vector rootvec)])
           (vector-ref vregs root)))

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -235,11 +235,14 @@
   (exponents-propogation ivec vregs vprecs-new varc vstart-precs)
   
   ; Repeating part calculation
+
+  ; Copying new precisions into vprecs
+  (vector-copy! vprecs 0 new-vprecs) 
   )
 
 ; This function goes through ivec and vregs and calculates (+ exponents base-precisions) for each operator in ivec
 ; Roughly speaking:
-;   vprecs-new[i] = max( *max-mpfr-prec* min( *base-tuning-precision* (+ exponents-from-above vstart-precs[i])),
+;   vprecs-new[i] = min( *max-mpfr-prec* max( *base-tuning-precision* (+ exponents-from-above vstart-precs[i])),
 ;   exponents-from-above = get-exponent(parent)
 (define (exponents-propogation ivec vregs vprecs-new varc vstart-precs)
   (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]   ; reversed over ivec

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -40,8 +40,9 @@
       (λ args
         (define timeline-stop! (timeline-start!/unsafe 'mixsample "backward-pass"
                                                        (* (*sampling-iteration*) 1000)))
-        (when (not (zero? (*sampling-iteration*)))
-          (backward-pass ivec varc vregs vprecs vstart-precs rootvec vrepeats)) ; back-pass
+        (if (zero? (*sampling-iteration*))
+            (vector-fill! vrepeats #f)
+            (backward-pass ivec varc vregs vprecs vstart-precs rootvec vrepeats)) ; back-pass
         (timeline-stop!)
         
         (for ([arg (in-list args)] [n (in-naturals)])
@@ -242,7 +243,7 @@
   (define (recursive-repeat-check reg)
     (define idx (- reg varc))
     (define flag #t)
-    (when (<= 0 idx)  ; if ivec[reg] is a variable - return #t, we do not change precision of a variable
+    (when (<= 0 idx)  ; if ivec[reg] is a variable - return #t, precision of a variable is always 53
       (define tail-regs (rest (vector-ref ivec idx)))
       (set! flag
             (if (empty? tail-regs)

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -352,12 +352,9 @@
                (max
                 (- (max xlo-exp ylo-exp) outlo-exp)
                 (- (max xhi-exp yhi-exp) outhi-exp))
-               (if (and (or (not (equal? xlo-sgn ylo-sgn)) ; slack part
-                            (not (equal? xhi-sgn yhi-sgn)))
-                        (or (>= 2 (abs (- xlo-exp ylo-exp)))
-                            (>= 2 (abs (- xhi-exp yhi-exp)))))
-                   (get-slack)
-                   0)))]
+               (if (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi)) ; slack part
+                   0
+                   (get-slack))))]
       
     [(equal? op ival-sub)
      ; log[Г-] = max(log[x], log[y]) - log[x - y]
@@ -388,12 +385,9 @@
                (max
                 (- (max xlo-exp yhi-exp) outlo-exp)
                 (- (max xhi-exp ylo-exp) outhi-exp))
-               (if (and (or (equal? xlo-sgn yhi-sgn) ; slack part
-                            (equal? xhi-sgn ylo-sgn))
-                        (or (>= 2 (abs (- xlo-exp yhi-exp)))
-                            (>= 2 (abs (- xhi-exp ylo-exp)))))
-                   (get-slack)
-                   0)))]
+               (if (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi)) ; slack part
+                   0
+                   (get-slack))))]
       
     [(equal? op ival-pow)
      ; log[Гpow] = max[ log(y) , log(y) + log[log(x)] ]
@@ -423,7 +417,7 @@
      (define out-exp
        (+ 1 (max (abs (log2-approx outlo))
                  (abs (log2-approx outhi)))
-          (if (xor (bigfloat-signbit outlo) (bigfloat-signbit outhi))
+          (if (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi))
               0                            ; both bounds are positive or negative
               (get-slack))))               ; tan is (-inf, +inf) or around zero
 
@@ -442,7 +436,7 @@
      (define out-exp
        (+ (min (log2-approx outlo)
                (log2-approx outhi))
-          (if (xor (bigfloat-signbit outlo) (bigfloat-signbit outhi))
+          (if (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi))
               0                         ; both bounds are positive or negative
               (- (get-slack)))))        ; Condition of uncertainty,
      ; slack is negated because it is to be subtracted below
@@ -463,7 +457,7 @@
      (max 0
           (+ 1 (max (- (log2-approx outlo))  ; main formula
                     (- (log2-approx outhi)))
-             (if (xor (bigfloat-signbit outlo) (bigfloat-signbit outhi)) ; slack part
+             (if (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi)) ; slack part
                  0                           ; both bounds are positive or negative
                  (get-slack))))]             ; output crosses 0.bf - uncertainty
 
@@ -517,8 +511,8 @@
           (+ (max (+ (- xlo-exp outlo-exp) 1)
                   (+ (- xhi-exp outhi-exp) 1))
        
-             (if (and (xor (bigfloat-signbit ylo) (bigfloat-signbit yhi))
-                      (xor (bigfloat-signbit outlo) (bigfloat-signbit outhi)))
+             (if (and (equal? (bigfloat-signbit ylo) (bigfloat-signbit yhi))
+                      (equal? (bigfloat-signbit outlo) (bigfloat-signbit outhi)))
                  0                ; y and out don't cross 0
                  (get-slack))))]   ; y or output crosses 0
     [(equal? op ival-fma)
@@ -549,7 +543,7 @@
                                    zhi-exp)))
      (max 0
           (- condition-lhs (min outlo-exp outhi-exp)
-             (if (xor (bigfloat-signbit outhi) (bigfloat-signbit outlo)) ; cancellation when output crosses 0
+             (if (equal? (bigfloat-signbit outhi) (bigfloat-signbit outlo)) ; cancellation when output crosses 0
                  0
                  (- (get-slack)))))]
     

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -239,8 +239,20 @@
   ; Step 3. Repeating precisions check
   ; vrepeats[i] = #t if the node has the same precision as an iteration before and children have #t flag as well
   ; vrepeats[i] = #f if the node doesn't have the same precision as an iteration before or at least one child has #f flag
-  (define first-iter (equal? 1 (*sampling-iteration*)))
-  (define (recursive-repeat-check reg)
+  (for ([instr (in-vector ivec)]
+        [prec-old (in-vector (if (equal? 1 (*sampling-iteration*)) vstart-precs vprecs))]
+        [prec-new (in-vector vprecs-new)]
+        [n (in-naturals)])
+    (if (and (equal? prec-new prec-old)
+             (andmap identity (map (lambda (x) (if (>= x varc)
+                                                   (vector-ref vrepeats (- x varc))
+                                                   #t))
+                                   (rest instr))))
+        (vector-set! vrepeats n #t)
+        (vector-set! vrepeats n #f)))
+  
+  #;(define first-iter (equal? 1 (*sampling-iteration*)))
+  #;(define (recursive-repeat-check reg)
     (define idx (- reg varc))
     (define flag #t)
     (when (<= 0 idx)  ; if ivec[reg] is a variable - return #t, precision of a variable is always 53
@@ -256,7 +268,7 @@
       (vector-set! vrepeats idx flag))
     flag)
     
-  (for/vector #:length rootlen ([root-reg (in-vector rootvec)])
+  #;(for/vector #:length rootlen ([root-reg (in-vector rootvec)])
     (when (and
            (<= varc root-reg)                                       ; when root is not a variable
            (bigfloat? (ival-lo (vector-ref vregs root-reg))))

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require math/bigfloat math/flonum rival)
+;; Faster than bigfloat-exponent and avoids an expensive offset & contract check.
 (require (only-in math/private/bigfloat/mpfr mpfr-exp))
 (require "syntax/syntax.rkt" "syntax/types.rkt"
          "common.rkt" "timeline.rkt" "float.rkt" "config.rkt")

--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -251,29 +251,6 @@
         (vector-set! vrepeats n #t)
         (vector-set! vrepeats n #f)))
   
-  #;(define first-iter (equal? 1 (*sampling-iteration*)))
-  #;(define (recursive-repeat-check reg)
-    (define idx (- reg varc))
-    (define flag #t)
-    (when (<= 0 idx)  ; if ivec[reg] is a variable - return #t, precision of a variable is always 53
-      (define tail-regs (rest (vector-ref ivec idx)))
-      (set! flag
-            (if (empty? tail-regs)
-                (equal? (vector-ref vprecs-new idx)
-                        (if first-iter (vector-ref vstart-precs idx) (vector-ref vprecs idx)))
-                (and
-                 (equal? (vector-ref vprecs-new idx)
-                         (if first-iter (vector-ref vstart-precs idx) (vector-ref vprecs idx)))
-                 (andmap identity (map recursive-repeat-check tail-regs)))))
-      (vector-set! vrepeats idx flag))
-    flag)
-    
-  #;(for/vector #:length rootlen ([root-reg (in-vector rootvec)])
-    (when (and
-           (<= varc root-reg)                                       ; when root is not a variable
-           (bigfloat? (ival-lo (vector-ref vregs root-reg))))
-      (recursive-repeat-check root-reg)))
-  
   ; Step 4. Copying new precisions into vprecs
   (vector-copy! vprecs 0 vprecs-new))
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -90,7 +90,7 @@
 (define *ground-truth-extra-bits* (make-parameter 20))
 
 (define *sampling-iteration* (make-parameter 0))
-(define *tuning-final-output-prec* (make-parameter 73)) ; precision of the final output when tuning
+(define *base-tuning-precision* (make-parameter 73))
 (define *max-sampling-iterations* (make-parameter 5))
 
 ;; The maximum size of an egraph


### PR DESCRIPTION
This branch introduces an optimization for real evaluations. This optimization allows to skip reevaluation of an operation if a) this operation has the same precision as an iteration before b) children of this operation have the same precisions as an iteration before and their children as well (recursion).