### PR TITLE
Faster Regimes

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -230,13 +230,13 @@
   ;; Vectors used to determine if our current alt is better than out running
   ;; best alt.
   (define best-alt-idx (make-vector number-of-points))
-  (define best-alt-cost (make-vector number-of-points))
+  (define best-alt-cost (make-flvector number-of-points))
 
   (for ([point-idx (in-range 0 number-of-points)])
    ;; Set and fill temporary vectors with starting data
    ;; #f for best index and positive infinite for best cost
    (vector-fill! best-alt-idx #f)
-   (vector-fill! best-alt-cost +inf.f)
+   (set! best-alt-cost (make-flvector number-of-points +inf.0))
 
    ;; For each alt loop over its vector of errors
    (for ([alt-idx (in-naturals)] [alt-error-sums (in-vector flvec-psums)])
@@ -250,9 +250,9 @@
        ;; if we have not set the best alt yet or
        ;; the current alt-error-sum is less then previous
        (when (or (not (vector-ref best-alt-idx prev-split-idx))
-                 (fl< current-error (vector-ref best-alt-cost prev-split-idx)))
+                 (fl< current-error (flvector-ref best-alt-cost prev-split-idx)))
         ;; update best cost and best index
-        (vector-set! best-alt-cost prev-split-idx current-error)
+        (flvector-set! best-alt-cost prev-split-idx current-error)
         (vector-set! best-alt-idx prev-split-idx alt-idx))))))
 
    ;; Save current values for the current point we are working on.
@@ -266,7 +266,7 @@
     (when (vector-ref can-split-vec (+ prev-split-idx 1))
      ;; Re compute the error sum for a potential better alt
      (define alt-error-sum (fl+ (flvector-ref result-error-sums prev-split-idx)
-                    (vector-ref best-alt-cost prev-split-idx) min-weight))
+                    (flvector-ref best-alt-cost prev-split-idx) min-weight))
      ;; pre-compute values for tie breaking
      (define current-best-alt-idx (vector-ref best-alt-idx prev-split-idx))
      ;; Check if the new alt-error-sum is better then the current

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -215,7 +215,7 @@
   ;; Vectors are now filled with starting data. Beginning main loop of the
   ;; regimes algorithm.
  
-  ;; Vectors used to determine if our current alt is better than out running
+  ;; Vectors used to determine if our current alt is better than our running
   ;; best alt.
   (define best-alt-idxs (make-vector number-of-points))
   (define best-alt-costs (make-flvector number-of-points))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -234,9 +234,10 @@
     (for ([prev-split-idx (in-range 0 point-idx)]
           [prev-alt-error-sum (in-flvector alt-error-sums)]
           [best-alt-idx (in-vector best-alt-idxs)]
-          [best-alt-cost (in-flvector best-alt-costs)])
+          [best-alt-cost (in-flvector best-alt-costs)]
+          [can-split (in-vector can-split-vec 1)]
+          #:when can-split)
      ;; Check if we can add a split point
-     (when (vector-ref can-split-vec (+ prev-split-idx 1))
       ;; compute the difference between the current error-sum and previous
       (let ([current-error (fl- (flvector-ref alt-error-sums point-idx)
                                 prev-alt-error-sum)])
@@ -245,7 +246,7 @@
        (when (or (not best-alt-idx) (fl< current-error best-alt-cost))
         ;; update best cost and best index
         (flvector-set! best-alt-costs prev-split-idx current-error)
-        (vector-set! best-alt-idxs prev-split-idx alt-idx))))))
+        (vector-set! best-alt-idxs prev-split-idx alt-idx)))))
 
    ;; Save current values for the current point we are working on.
    (define current-alt-error (flvector-ref result-error-sums point-idx))
@@ -257,8 +258,9 @@
    (for ([prev-split-idx (in-range 0 point-idx)]
          [r-error-sum (in-flvector result-error-sums)]
          [best-alt-idx (in-vector best-alt-idxs)]
-         [best-alt-cost (in-flvector best-alt-costs)])
-    (when (vector-ref can-split-vec (+ prev-split-idx 1))
+         [best-alt-cost (in-flvector best-alt-costs)]
+         [can-split (in-vector can-split-vec 1)]
+         #:when can-split)
      ;; Re compute the error sum for a potential better alt
      (define alt-error-sum (fl+ r-error-sum best-alt-cost min-weight))
      ;; pre-compute values for tie breaking
@@ -278,7 +280,7 @@
       (when set-cond
        (set! current-alt-error alt-error-sum)
        (set! current-alt-idx best-alt-idx)
-       (set! current-prev-idx prev-split-idx))))
+       (set! current-prev-idx prev-split-idx)))
    (flvector-set! result-error-sums point-idx current-alt-error)
    (vector-set! result-alt-idxs point-idx current-alt-idx)
    (vector-set! result-prev-idxs point-idx current-prev-idx))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -263,18 +263,16 @@
          #:when can-split)
      ;; Re compute the error sum for a potential better alt
      (define alt-error-sum (fl+ r-error-sum best-alt-cost min-weight))
-     ;; pre-compute values for tie breaking
-     (define current-best-alt-idx (vector-ref best-alt-idxs prev-split-idx))
      ;; Check if the new alt-error-sum is better then the current
      (define set-cond
       ;; give benefit to previous best alt
       (cond [(fl< alt-error-sum current-alt-error) #t]
             ;; Tie breaker if error are the same favor first alt
             [(and (fl= alt-error-sum current-alt-error)
-                  (> current-alt-idx current-best-alt-idx)) #t]
+                  (> current-alt-idx best-alt-idx)) #t]
             ;; Tie breaker for if error and alt is the same
             [(and (fl= alt-error-sum current-alt-error)
-                  (= current-alt-idx current-best-alt-idx)
+                  (= current-alt-idx best-alt-idx)
                   (> current-prev-idx prev-split-idx)) #t]
             [else #f]))
       (when set-cond

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -185,9 +185,10 @@
   (define num-candidates (vector-length err-lsts-vec))
   (define num-points (vector-length can-split-vec))
   (define min-weight (fl num-points))
+
   (define (make-vec-psum lst) 
    (flvector-sums (list->flvector lst)))
-  (define flvec-psums (vector-map make-vec-psum err-lsts-vec)) 
+  (define flvec-psums (vector-map make-vec-psum err-lsts-vec))
 
   (define test (and #f 
     (= num-candidates 2) ))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -189,7 +189,7 @@
    (flvector-sums (list->flvector lst)))
   (define flvec-psums (vector-map make-vec-psum err-lsts-vec)) 
 
-  (define test (and 
+  (define test (and #f 
     (= num-candidates 2) ))
     ;; /(fl= (fl 63.999295387023416) (flvector-ref (vector-ref flvec-psums 0) 0))
     ;; (fl= (fl 57.458771367809156) (flvector-ref (vector-ref flvec-psums 0) 1))))
@@ -228,9 +228,9 @@
           (when test 
           (eprintf "\nprev-loop(~a)[acost: ~a]\n" prev-split-idx acost))
           ;; For each previous split point, we need the best candidate to fill the new regime
-         (when 
-          (vector-ref can-split-vec (+ prev-split-idx 1))
-          (let ([best #f] [bcost #f])
+        (define best #f)
+        (define bcost #f)
+         (when (vector-ref can-split-vec (+ prev-split-idx 1))
             (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
               (let ([cost (fl- (flvector-ref psum point-idx)
                              (flvector-ref psum prev-split-idx))])
@@ -238,27 +238,22 @@
                 (eprintf "\ncidx(~a) cost[~a] ~a - ~a\n" cidx cost (flvector-ref psum point-idx) (flvector-ref psum prev-split-idx))
                 (eprintf "point[~a] prev[~a] best[~a] bcost[~a]\n" 
                          point-idx prev-split-idx best bcost))
-                (when (or (not best) (fl< cost bcost))
-                  
-              (when test
-                  (eprintf "SET: bcost[~a] was: ~a\n" cost bcost))
+                (when (or (not best) (fl< cost bcost))   
+                  (when test (eprintf "SET: bcost[~a] was: ~a\n" cost bcost))
                   (set! bcost cost)
-              (when test
-                  (eprintf "SET: best[~a] was: ~a\n" cidx best))
+                  (when test (eprintf "SET: best[~a] was: ~a\n" cidx best))
                   (set! best cidx))))
-            (define temp (fl+ (flvector-ref v-alt-cost prev-split-idx) bcost))
+            (define t (fl+ (flvector-ref v-alt-cost prev-split-idx) bcost))
             (when test
-            (eprintf "[temp ~a, acost: ~a] [prev: ~a bcost: ~a]\n" temp acost (flvector-ref v-alt-cost prev-split-idx) bcost))
-            (when 
-              (fl< temp acost)
-              
+            (eprintf "[temp ~a, acost: ~a] [prev: ~a bcost: ~a]\n" t acost (flvector-ref v-alt-cost prev-split-idx) bcost))
+            (when (fl< t acost)
             (when test
-              (eprintf "acost(set): old:~a new:~a\n" acost temp))
+              (eprintf "acost(set): old:~a new:~a\n" acost t))
               ;; give benefit to new best alt
-              (set! acost (fl- temp min-weight)) 
+              (set! acost (fl- t min-weight)) 
               (set! a-cost acost)
               (set! a-best best)
-              (set! a-prev-idx prev-split-idx)))))
+              (set! a-prev-idx prev-split-idx))))
         (flvector-set! vec-alt-cost point-idx a-cost)
         (vector-set! vec-cidx point-idx a-best)
         (vector-set! vec-pidx point-idx a-prev-idx)))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -282,13 +282,12 @@
   ;; Loop over results vectors in reverse and build the output split index list
   (define next number-of-points)
   (define split-idexs #f)
-  (for ([idx (in-range number-of-points 0 -1)])
-     (define i (- idx 1))
-     (define alt-idx (vector-ref result-alt-idxs i))
-     (define split-idx (vector-ref result-prev-idxs i))
-    (when (= idx next)
-      (set! next (+ split-idx 1))
-      (set! split-idexs (cond
-        [(false? split-idexs) (cons (si alt-idx number-of-points) '())]
-        [else (cons (si alt-idx idx) split-idexs)]))))
+  (for ([i (in-range (- number-of-points 1) -1 -1)]
+        #:when (= (+ i 1) next))
+   (define alt-idx (vector-ref result-alt-idxs i))
+   (define split-idx (vector-ref result-prev-idxs i))
+   (set! next (+ split-idx 1))
+   (set! split-idexs (cond
+    [(false? split-idexs) (cons (si alt-idx number-of-points) '())]
+    [else (cons (si alt-idx (+ i 1)) split-idexs)])))
  split-idexs)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -205,14 +205,12 @@
   (define result-alt-idxs (make-vector number-of-points 0))
   (define result-prev-idxs (make-vector number-of-points number-of-points))
 
-  ;; TODO invert loops to match core algorithm data priority
-  (for ([point-idx (in-range number-of-points)])
-    ;; record the error for each candidate
-    (for ([alt-idx (range number-of-alts)])
-     (define val (flvector-ref (vector-ref flvec-psums alt-idx) point-idx))
-     (when (< val (flvector-ref result-error-sums point-idx))
-      (flvector-set! result-error-sums point-idx val)
-      (vector-set! result-alt-idxs point-idx alt-idx))))
+  (for ([alt-idx (in-naturals)] [alt-errors (in-vector flvec-psums)])
+   (for ([point-idx (in-range number-of-points)]
+         [err (in-flvector alt-errors)]
+         #:when (< err (flvector-ref result-error-sums point-idx)))
+    (flvector-set! result-error-sums point-idx err)
+    (vector-set! result-alt-idxs point-idx alt-idx)))
 
   ;; Vectors are now filled with starting data. Beginning main loop of the
   ;; regimes algorithm.

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -265,20 +265,19 @@
    (for ([prev-split-idx (in-range 0 point-idx)])
     (when (vector-ref can-split-vec (+ prev-split-idx 1))
      ;; Re compute the error sum for a potential better alt
-     (define alt-error-sum (fl+ (fl+ (flvector-ref result-error-sums prev-split-idx)
-                    (vector-ref best-alt-cost prev-split-idx)) min-weight))
+     (define alt-error-sum (fl+ (flvector-ref result-error-sums prev-split-idx)
+                    (vector-ref best-alt-cost prev-split-idx) min-weight))
      ;; pre-compute values for tie breaking
-     (define adjusted-cost current-alt-error)
      (define current-best-alt-idx (vector-ref best-alt-idx prev-split-idx))
      ;; Check if the new alt-error-sum is better then the current
      (define set-cond
       ;; give benefit to previous best alt
-      (cond [(fl< alt-error-sum adjusted-cost) #t]
+      (cond [(fl< alt-error-sum current-alt-error) #t]
             ;; Tie breaker if error are the same favor first alt
-            [(and (fl= alt-error-sum adjusted-cost)
+            [(and (fl= alt-error-sum current-alt-error)
                   (> current-alt-idx current-best-alt-idx)) #t]
             ;; Tie breaker for if error and alt is the same
-            [(and (fl= alt-error-sum adjusted-cost)
+            [(and (fl= alt-error-sum current-alt-error)
                   (= current-alt-idx current-best-alt-idx)
                   (> current-prev-idx prev-split-idx)) #t]
             [else #f]))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -222,7 +222,7 @@
              (set! min-v val)]))
     (flvector-set! result-error-sums point-idx (fl min-v))
     (vector-set! result-alt-idxs point-idx min-idx)
-    (vector-set! result-prev-idxs point-idx -1))
+    (vector-set! result-prev-idxs point-idx number-of-points))
   
   ;; Vectors are now filled with starting data. Beginning main loop of the
   ;; regimes algorithm.
@@ -280,7 +280,7 @@
             ;; Tie breaker for if error and alt is the same
             [(and (fl= alt-error-sum adjusted-cost)
                   (= current-alt-idx current-best-alt-idx)
-                  (< current-prev-idx prev-split-idx)) #t]
+                  (> current-prev-idx prev-split-idx)) #t]
             [else #f]))
       (when set-cond
        (set! current-alt-error alt-error-sum)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -232,7 +232,9 @@
    (for ([alt-idx (in-naturals)] [alt-error-sums (in-vector flvec-psums)])
     ;; Loop over the points up to our current point
     (for ([prev-split-idx (in-range 0 point-idx)]
-          [prev-alt-error-sum (in-flvector alt-error-sums)] )
+          [prev-alt-error-sum (in-flvector alt-error-sums)]
+          [best-alt-idx (in-vector best-alt-idxs)]
+          [best-alt-cost (in-flvector best-alt-costs)])
      ;; Check if we can add a split point
      (when (vector-ref can-split-vec (+ prev-split-idx 1))
       ;; compute the difference between the current error-sum and previous
@@ -240,8 +242,7 @@
                                 prev-alt-error-sum)])
        ;; if we have not set the best alt yet or
        ;; the current alt-error-sum is less then previous
-       (when (or (not (vector-ref best-alt-idxs prev-split-idx))
-                 (fl< current-error (flvector-ref best-alt-costs prev-split-idx)))
+       (when (or (not best-alt-idx) (fl< current-error best-alt-cost))
         ;; update best cost and best index
         (flvector-set! best-alt-costs prev-split-idx current-error)
         (vector-set! best-alt-idxs prev-split-idx alt-idx))))))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -216,7 +216,7 @@
     ;; Find the min, no built in function to find smallest fl in vector
     (define min-v (flvector-ref vec-temp 0))
     (define min-idx 0)
-    (for ([val vec-temp] [idx (range number-of-alts)])
+    (for ([val (in-flvector vec-temp)] [idx (in-range number-of-alts)])
       (cond [(< val min-v)
              (set! min-idx idx)
              (set! min-v val)]))
@@ -292,7 +292,7 @@
   ;; Loop over results vectors in reverse and build the output split index list
   (define next number-of-points)
   (define split-idexs #f)
-  (for ([idx (range number-of-points 0 -1)])
+  (for ([idx (in-range number-of-points 0 -1)])
      (define i (- idx 1))
      (define alt-idx (vector-ref result-alt-idxs i))
      (define split-idx (vector-ref result-prev-idxs i))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -265,10 +265,10 @@
    (for ([prev-split-idx (in-range 0 point-idx)])
     (when (vector-ref can-split-vec (+ prev-split-idx 1))
      ;; Re compute the error sum for a potential better alt
-     (define alt-error-sum (fl+ (flvector-ref result-error-sums prev-split-idx)
-                    (vector-ref best-alt-cost prev-split-idx)))
+     (define alt-error-sum (fl+ (fl+ (flvector-ref result-error-sums prev-split-idx)
+                    (vector-ref best-alt-cost prev-split-idx)) min-weight))
      ;; pre-compute values for tie breaking
-     (define adjusted-cost (fl- current-alt-error min-weight))
+     (define adjusted-cost current-alt-error)
      (define current-best-alt-idx (vector-ref best-alt-idx prev-split-idx))
      ;; Check if the new alt-error-sum is better then the current
      (define set-cond

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -249,13 +249,13 @@
        (flvector-set! vec-temp cand-idx
         (flvector-ref (vector-ref flvec-psums cand-idx) point-idx)))
       ;; Find the min, no built in function to find smallest fl in vector
-      (define min (flvector-ref vec-temp 0))
+      (define min-v (flvector-ref vec-temp 0))
       (define min-idx 0)
       (for ([val vec-temp] [idx (range num-candidates)])
-        (cond [(< val min)
+        (cond [(< val min-v)
                (set! min-idx idx)
-               (set! min val)]))
-      (flvector-set! vec-acost point-idx (fl min))
+               (set! min-v val)]))
+      (flvector-set! vec-acost point-idx (fl min-v))
       (vector-set! vec-cidx point-idx min-idx)
       (vector-set! vec-pidx point-idx num-points))
     (values vec-acost vec-cidx vec-pidx))
@@ -272,18 +272,12 @@
   
   (define-values (pa pb pd) (initial))
   (define-values (fa fb fd)
-    ; short circuit if there is no other alts to consider
     (let loop ([pa pa] [pb pb] [pd pd])
     (define-values (na nb nd) (add-splitpoint pa pb pd))
-    (if (equal? nb pb) ;; only need to compare candidate index
+    (if (equal? na pa)
         (values na nb nd)
         (loop na nb nd))))
 
-  (when test
-    (eprintf "END\n") 
-    (eprintf "cost: ~a\n" pa)
-    (eprintf "alt: ~a\n" pb)
-    (eprintf "prev: ~a\n" pd))
     ;; From here down is messy code translating from 4 vectors back to
     ;; the original list of split points
     (define fixed-final (make-vector num-points))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -288,7 +288,7 @@
      (define split-idx (vector-ref result-prev-idxs i))
     (when (= idx next)
       (set! next (+ split-idx 1))
-      (cond [(false? split-idexs)
-             (set! split-idexs (cons (si alt-idx number-of-points) '()))]
-            [else (set! split-idexs (cons (si alt-idx idx) split-idexs))])))
+      (set! split-idexs (cond
+        [(false? split-idexs) (cons (si alt-idx number-of-points) '())]
+        [else (cons (si alt-idx idx) split-idexs)]))))
  split-idexs)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -218,8 +218,16 @@
        (when (vector-ref can-split-vec (+ prev-split-idx 1))
         (define t (fl+ (flvector-ref v-alt-cost prev-split-idx)
                        (vector-ref bcost prev-split-idx)))
-        ;; give benefit to previous best alt
-        (when (fl< t (fl- a-cost min-weight))
+        (define set-cond
+          ;; give benefit to previous best alt
+          (cond [(fl< t (fl- a-cost min-weight)) #t]
+                [(and (fl= t (fl- a-cost min-weight))
+                      (> a-best (vector-ref best prev-split-idx))) #t]
+                [(and (fl= t (fl- a-cost min-weight))
+                      (= a-best (vector-ref best prev-split-idx))
+                      (< a-prev-idx prev-split-idx)) #t]
+                [else #f]))
+        (when set-cond
          (set! a-cost t)
          (set! a-best (vector-ref best prev-split-idx))
          (set! a-prev-idx prev-split-idx))))
@@ -250,7 +258,7 @@
                (set! min-v val)]))
       (flvector-set! vec-acost point-idx (fl min-v))
       (vector-set! vec-cidx point-idx min-idx)
-      (vector-set! vec-pidx point-idx num-points))
+      (vector-set! vec-pidx point-idx -1))
     (values vec-acost vec-cidx vec-pidx))
 
   ;; prefix of p is for previous
@@ -280,6 +288,8 @@
       (define b (vector-ref fb idx))
       (define c (vector-ref fp idx))
       (define d (vector-ref fd idx))
+      (when (= d -1)
+        (set! d num-points))
       (vector-set! fixed-final idx (cand a b c d)))
 
   ;; start at (- num-points 1)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -208,6 +208,7 @@
      (define a-prev-idx (vector-ref v-pidx point-idx))
      ;; We take the CSE corresponding to the best choice of previous split point.
      ;; The default, not making a new split-point, gets a bonus of min-weight
+     (let ([acost (fl- a-cost min-weight)])
       (define best (make-vector point-idx #f))
       (define bcost (make-vector point-idx #f))
       (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
@@ -224,14 +225,15 @@
        (when (vector-ref can-split-vec (+ prev-split-idx 1))
         (define t (fl+ (flvector-ref v-alt-cost prev-split-idx)
                        (vector-ref bcost prev-split-idx)))
-        (when (fl< t (fl- (flvector-ref v-alt-cost point-idx) min-weight))
+        (when (fl< t acost)
+         (set! acost t)
          ;; give benefit to new best alt
-         (set! a-cost (fl- t min-weight))
+         (set! a-cost (fl- acost min-weight))
          (set! a-best (vector-ref best prev-split-idx))
          (set! a-prev-idx prev-split-idx))))
        (flvector-set! vec-alt-cost point-idx a-cost)
        (vector-set! vec-cidx point-idx a-best)
-       (vector-set! vec-pidx point-idx a-prev-idx))
+       (vector-set! vec-pidx point-idx a-prev-idx)))
   (values vec-alt-cost vec-cidx vec-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -248,7 +248,7 @@
         ;; update best cost and best index
         (flvector-set! best-alt-costs prev-split-idx current-error)
         (vector-set! best-alt-idxs prev-split-idx alt-idx)))))
-   ;; We have now have the index of the best alt and it's error up to our 
+   ;; We have now have the index of the best alt and its error up to our 
    ;; current point-idx.
    ;; Now we compare against our current best saved in the 3 vectors above
    (for ([prev-split-idx (in-range 0 point-idx)]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -208,7 +208,6 @@
      (define a-prev-idx (vector-ref v-pidx point-idx))
      ;; We take the CSE corresponding to the best choice of previous split point.
      ;; The default, not making a new split-point, gets a bonus of min-weight
-     (let ([acost (fl- a-cost min-weight)])
       (define best (make-vector point-idx #f))
       (define bcost (make-vector point-idx #f))
       (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
@@ -225,15 +224,14 @@
        (when (vector-ref can-split-vec (+ prev-split-idx 1))
         (define t (fl+ (flvector-ref v-alt-cost prev-split-idx)
                        (vector-ref bcost prev-split-idx)))
-        (when (fl< t acost)
-         (set! acost t)
-         ;; give benefit to new best alt
-         (set! a-cost (fl- acost min-weight))
+        ;; give benefit to previous best alt
+        (when (fl< t (fl- a-cost min-weight))
+         (set! a-cost t)
          (set! a-best (vector-ref best prev-split-idx))
          (set! a-prev-idx prev-split-idx))))
        (flvector-set! vec-alt-cost point-idx a-cost)
        (vector-set! vec-cidx point-idx a-best)
-       (vector-set! vec-pidx point-idx a-prev-idx)))
+       (vector-set! vec-pidx point-idx a-prev-idx))
   (values vec-alt-cost vec-cidx vec-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -201,29 +201,19 @@
   
   ;; These 3 vectors are will contain the output data and be used for
   ;; determining which alt is best for a given point
-  (define result-error-sums (make-flvector number-of-points))
-  (define result-alt-idxs (make-vector number-of-points))
-  (define result-prev-idxs (make-vector number-of-points))
+  (define result-error-sums (make-flvector number-of-points +inf.0))
+  (define result-alt-idxs (make-vector number-of-points 0))
+  (define result-prev-idxs (make-vector number-of-points number-of-points))
 
-  ;; Temporary vector used to find the alt with least error for each point
-  (define vec-temp (make-flvector number-of-alts))
   ;; TODO invert loops to match core algorithm data priority
   (for ([point-idx (in-range number-of-points)])
     ;; record the error for each candidate
     (for ([alt-idx (range number-of-alts)])
-     (flvector-set! vec-temp alt-idx
-      (flvector-ref (vector-ref flvec-psums alt-idx) point-idx)))
-    ;; Find the min, no built in function to find smallest fl in vector
-    (define min-v (flvector-ref vec-temp 0))
-    (define min-idx 0)
-    (for ([val (in-flvector vec-temp)] [idx (in-range number-of-alts)])
-      (cond [(< val min-v)
-             (set! min-idx idx)
-             (set! min-v val)]))
-    (flvector-set! result-error-sums point-idx (fl min-v))
-    (vector-set! result-alt-idxs point-idx min-idx)
-    (vector-set! result-prev-idxs point-idx number-of-points))
-  
+     (define val (flvector-ref (vector-ref flvec-psums alt-idx) point-idx))
+     (when (< val (flvector-ref result-error-sums point-idx))
+      (flvector-set! result-error-sums point-idx val)
+      (vector-set! result-alt-idxs point-idx alt-idx))))
+
   ;; Vectors are now filled with starting data. Beginning main loop of the
   ;; regimes algorithm.
  

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -231,8 +231,8 @@
           ;; For each previous split point, we need the best candidate to fill the new regime
         (define best #f)
         (define bcost #f)
-         (when (vector-ref can-split-vec (+ prev-split-idx 1))
-            (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
+          (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
+             (when (vector-ref can-split-vec (+ prev-split-idx 1))
               (let ([cost (fl- (flvector-ref psum point-idx)
                              (flvector-ref psum prev-split-idx))])
               (when test
@@ -243,7 +243,9 @@
                   (when test (eprintf "SET: bcost[~a] was: ~a\n" cost bcost))
                   (set! bcost cost)
                   (when test (eprintf "SET: best[~a] was: ~a\n" cidx best))
-                  (set! best cidx))))
+                  (set! best cidx)))))
+
+          (when (vector-ref can-split-vec (+ prev-split-idx 1))
             (define t (fl+ (flvector-ref v-alt-cost prev-split-idx) bcost))
             (when test
             (eprintf "[temp ~a, acost: ~a] [prev: ~a bcost: ~a]\n" t acost (flvector-ref v-alt-cost prev-split-idx) bcost))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -254,11 +254,13 @@
    ;; We have now have the index of the best alt and it's error up to our 
    ;; current point-idx.
    ;; Now we compare against our current best saved in the 3 vectors above
-   (for ([prev-split-idx (in-range 0 point-idx)])
+   (for ([prev-split-idx (in-range 0 point-idx)]
+         [r-error-sum (in-flvector result-error-sums)]
+         [best-alt-idx (in-vector best-alt-idxs)]
+         [best-alt-cost (in-flvector best-alt-costs)])
     (when (vector-ref can-split-vec (+ prev-split-idx 1))
      ;; Re compute the error sum for a potential better alt
-     (define alt-error-sum (fl+ (flvector-ref result-error-sums prev-split-idx)
-                    (flvector-ref best-alt-costs prev-split-idx) min-weight))
+     (define alt-error-sum (fl+ r-error-sum best-alt-cost min-weight))
      ;; pre-compute values for tie breaking
      (define current-best-alt-idx (vector-ref best-alt-idxs prev-split-idx))
      ;; Check if the new alt-error-sum is better then the current
@@ -275,7 +277,7 @@
             [else #f]))
       (when set-cond
        (set! current-alt-error alt-error-sum)
-       (set! current-alt-idx (vector-ref best-alt-idxs prev-split-idx))
+       (set! current-alt-idx best-alt-idx)
        (set! current-prev-idx prev-split-idx))))
    (flvector-set! result-error-sums point-idx current-alt-error)
    (vector-set! result-alt-idxs point-idx current-alt-idx)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -225,12 +225,12 @@
       ;; We take the CSE corresponding to the best choice of previous split point.
       ;; The default, not making a new split-point, gets a bonus of min-weight
       (let ([acost (fl- a-cost min-weight)])
+        (define best (make-vector point-idx #f))
+        (define bcost (make-vector point-idx #f))
         (for ([prev-split-idx (in-range 0 point-idx)])
           (when test 
           (eprintf "\nprev-loop(~a)[acost: ~a]\n" prev-split-idx acost))
           ;; For each previous split point, we need the best candidate to fill the new regime
-        (define best (make-vector point-idx #f))
-        (define bcost (make-vector point-idx #f))
           (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
              (when (vector-ref can-split-vec (+ prev-split-idx 1))
               (let ([cost (fl- (flvector-ref psum point-idx)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -261,23 +261,7 @@
       (vector-set! vec-pidx point-idx -1))
     (values vec-acost vec-cidx vec-pidx))
 
-  ;; prefix of p is for previous
-  ;; prefix of n is for next
-  ;; prefix of f is for final result vectors
-  ;; a for acost vectors
-  ;; b for candidate index
-  ;; c for alt index
-  ;; d for previous index
-  ;; This is where the high level bulk of the algorithm is applied
-  ;; We get the final splitpoints by applying add-splitpoints as many times as we want
-  
-  (define-values (pa pb pd) (initial))
-  (define-values (fa fb fd)
-    (let loop ([pa pa] [pb pb] [pd pd])
-    (define-values (na nb nd) (add-splitpoint pa pb pd))
-    (if (equal? na pa)
-        (values na nb nd)
-        (loop na nb nd))))
+  (define-values (fa fb fd) (add-splitpoint (initial)))
 
     ;; From here down is messy code translating from 4 vectors back to
     ;; the original list of split points

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -222,7 +222,10 @@
   (define best-alt-idxs (make-vector number-of-points))
   (define best-alt-costs (make-flvector number-of-points))
 
-  (for ([point-idx (in-range 0 number-of-points)])
+  (for ([point-idx (in-range 0 number-of-points)]
+        [current-alt-error (in-flvector result-error-sums)]
+        [current-alt-idx (in-vector result-alt-idxs)]
+        [current-prev-idx (in-vector result-prev-idxs)])
    ;; Set and fill temporary vectors with starting data
    ;; #f for best index and positive infinite for best cost
    (vector-fill! best-alt-idxs #f)
@@ -247,11 +250,6 @@
         ;; update best cost and best index
         (flvector-set! best-alt-costs prev-split-idx current-error)
         (vector-set! best-alt-idxs prev-split-idx alt-idx)))))
-
-   ;; Save current values for the current point we are working on.
-   (define current-alt-error (flvector-ref result-error-sums point-idx))
-   (define current-alt-idx (vector-ref result-alt-idxs point-idx))
-   (define current-prev-idx (vector-ref result-prev-idxs point-idx))
    ;; We have now have the index of the best alt and it's error up to our 
    ;; current point-idx.
    ;; Now we compare against our current best saved in the 3 vectors above

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -195,12 +195,6 @@
   ;; if we only consider indices to the left of that cse's index.
   ;; Given one of these lists, this function tries to add another splitindices to each cse.
   (define (add-splitpoint v-alt-cost v-cidx v-pidx)
-    
-    ;; output vectors
-    (define vec-alt-cost (make-flvector num-points))
-    (define vec-cidx (make-vector num-points))
-    (define vec-pidx (make-vector num-points))
-
     ;; If there's not enough room to add another splitpoint, just pass the sp-prev along.
     (for ([point-idx (in-range 0 num-points)])
      (define a-cost (flvector-ref v-alt-cost point-idx))
@@ -229,10 +223,10 @@
          (set! a-cost t)
          (set! a-best (vector-ref best prev-split-idx))
          (set! a-prev-idx prev-split-idx))))
-       (flvector-set! vec-alt-cost point-idx a-cost)
-       (vector-set! vec-cidx point-idx a-best)
-       (vector-set! vec-pidx point-idx a-prev-idx))
-  (values vec-alt-cost vec-cidx vec-pidx))
+       (flvector-set! v-alt-cost point-idx a-cost)
+       (vector-set! v-cidx point-idx a-best)
+       (vector-set! v-pidx point-idx a-prev-idx))
+  (values v-alt-cost v-cidx v-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,
   ;; accumulating the candidates that are the best we can do

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -208,7 +208,6 @@
      (define a-prev-idx (vector-ref v-pidx point-idx))
      ;; We take the CSE corresponding to the best choice of previous split point.
      ;; The default, not making a new split-point, gets a bonus of min-weight
-     (let ([acost (fl- a-cost min-weight)])
       (define best (make-vector point-idx #f))
       (define bcost (make-vector point-idx #f))
       (for ([cidx (in-naturals)] [psum (in-vector flvec-psums)])
@@ -220,19 +219,19 @@
                     (fl< cost (vector-ref bcost prev-split-idx)))
            (vector-set! bcost prev-split-idx cost)
            (vector-set! best prev-split-idx cidx))))))
+
       (for ([prev-split-idx (in-range 0 point-idx)])
        (when (vector-ref can-split-vec (+ prev-split-idx 1))
         (define t (fl+ (flvector-ref v-alt-cost prev-split-idx)
                        (vector-ref bcost prev-split-idx)))
-        (when (fl< t acost)
-         (set! acost t) 
+        (when (fl< t (fl- (flvector-ref v-alt-cost point-idx) min-weight))
          ;; give benefit to new best alt
-         (set! a-cost (fl- acost min-weight))
+         (set! a-cost (fl- t min-weight))
          (set! a-best (vector-ref best prev-split-idx))
          (set! a-prev-idx prev-split-idx))))
        (flvector-set! vec-alt-cost point-idx a-cost)
        (vector-set! vec-cidx point-idx a-best)
-       (vector-set! vec-pidx point-idx a-prev-idx)))
+       (vector-set! vec-pidx point-idx a-prev-idx))
   (values vec-alt-cost vec-cidx vec-pidx))
 
   ;; We get the initial set of cse's by, at every point-index,


### PR DESCRIPTION
This PR accomplishes the following changes to speed up regimes.

- Invert dependencies of alts and point index in core loop
- reuse vectors avoid allocation
- tie breaking function for when to update best alt
- remove initial and add-splitpoint function calls
- cleans up code to go from vectors to split index list
- comments explaining algorithm 