### PR TITLE
Output something when Herbie crashes generating a web page

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -62,7 +62,7 @@
     (response 200 #"OK" (current-seconds) #"text"
               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
               (λ (out)
-                (with-handlers ([exn:fail? (page-error-handler result page)])
+                (with-handlers ([exn:fail? (page-error-handler result page out)])
                   (make-page page out result (*demo-output*) #f))))]
    [else
     (next-dispatcher)]))
@@ -229,9 +229,10 @@
               ;; Output results
               (make-directory (build-path (*demo-output*) path))
               (for ([page (all-pages result)])
-                (with-handlers ([exn:fail? (page-error-handler result page)])
-                  (call-with-output-file (build-path (*demo-output*) path page)
-                    (λ (out) (make-page page out result (*demo-output*) #f)))))
+                (call-with-output-file (build-path (*demo-output*) path page)
+                  (λ (out) 
+                    (with-handlers ([exn:fail? (page-error-handler result page out)])
+                      (make-page page out result (*demo-output*) #f)))))
               (update-report result path seed
                              (build-path (*demo-output*) "results.json")
                              (build-path (*demo-output*) "index.html")))

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -15,11 +15,14 @@
   (define success-pages '("interactive.js" "points.json"))
   (append default-pages (if good? success-pages empty)))
 
-(define ((page-error-handler result page) e)
+(define ((page-error-handler result page out) e)
   (define test (job-result-test result))
-  ((error-display-handler)
-   (format "Error generating `~a` for \"~a\":\n~a\n" page (test-name test) (exn-message e))
-   e))
+  (eprintf "Error generating `~a` for \"~a\":\n  ~a\n"
+           page (test-name test) (exn-message e))
+  (parameterize ([current-error-port out])
+    (display "<!doctype html><pre>" out)
+    ((error-display-handler) (exn-message e) e)
+    (display "</pre>" out)))
 
 (define (make-page page out result output? profile?)
   (define test (job-result-test result))

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -29,10 +29,11 @@
     (set-seed! seed)
     (define error? #f)
     (for ([page (all-pages result)])
-      (with-handlers ([exn:fail? (λ (e) ((page-error-handler result page) e) (set! error? #t))])
-        (call-with-output-file (build-path rdir page)
-          #:exists 'replace
-          (λ (out) (make-page page out result #t profile?)))))
+      (call-with-output-file (build-path rdir page)
+        #:exists 'replace
+        (λ (out)
+          (with-handlers ([exn:fail? (λ (e) ((page-error-handler result page out) e) (set! error? #t))])
+            (make-page page out result #t profile?)))))
 
     (define out (get-table-data result dirname))
     (if error? (struct-copy table-row out [status "crash"]) out)]


### PR DESCRIPTION
Herbie sometimes crashes when generating a web page. At the moment, that output goes to the console, which isn't really the best option (it's hard to get to on nightly). This PR instead makes it output the error trace to the page it was generating, which maybe also isn't ideal but at least it's easy to find by clicking around.