### PR TITLE
Fix duplication bug in register machine by splitting compile & link

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -144,25 +144,33 @@
     ; Translates programs into an instruction sequence of operations
     (define (munge prog)
       (set! size (+ 1 size))
-      (define expr
+      (define instruction ; This compiles to the register machine
         (match prog
-          [(? number?)
-           (list (const (input->value prog 'real)))]
-          [(literal value (app get-representation repr))
-           (list (const (input->value value repr)))]
+          [(? number?) prog]
+          [(? literal?) prog]
           [(? variable?) prog]
           [`(if ,c ,t ,f)
-           (list if-proc (munge c) (munge t) (munge f))]
+           (list 'if (munge c) (munge t) (munge f))]
           [(list op args ...)
-           (cons (op->proc op) (map munge args))]
+           (cons op (map munge args))]
           [_ (raise-argument-error 'compile-specs "Not a valid expression!" prog)]))
-      (hash-ref! exprhash expr
+      (hash-ref! exprhash instruction
                  (λ ()
+                   (define expr ; Think links to actual functions to execute
+                     (match instruction
+                       [(? number? value)
+                        (list (const (input->value value 'real)))]
+                       [(literal value (app get-representation repr))
+                        (list (const (input->value value repr)))]
+                       ;No (? variable? var) case, already in the cache
+                       [`(if ,c ,t ,f) (list if-proc c t f)]
+                       [(list op args ...) (cons (op->proc op) args)]))
                    (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                           (set! exprc (+ 1 exprc))
-                           (set! icache (cons expr icache))))))
+                     (set! exprc (+ 1 exprc))
+                     (set! icache (cons expr icache))))))
     
     (define names (map munge exprs))
+
     (timeline-push! 'compiler (+ varc size) (+ exprc varc))
     (define ivec (list->vector (reverse icache)))
     (make-progs-interpreter name vars ivec names)))


### PR DESCRIPTION
@AYadrov found this very tricky bug in Herbie's register machine compiler. The compiler compiles an expression (like `(+ (* a a) (* a a))`) into a sequence of instructions, like this:

```
; a => 0
(* 0 0) ; => 1
(+ 1 1) ; => 2
```

Note that the `(* a a)` operation ends up de-duplicated and computed only once. However, the instructions don't _actually_ look like that, because the first argument isn't a symbol, it is a function:

```
; a => 0
(#<procedure ival-mult> 0 0) ; => 1
(#<procedure ival-add> 1 1) ; => 2
```

This mostly works fine, but numerical constants don't. A numerical constant like `180` compiles to a zero-argument instruction like `(#<procudure const>)` and that means we make a new constant function that returns 180. However, these instructions now don't compare as equal, because two separate constant functions in Racket are not equal (each one allocates its own closure). This means that we were never de-duplicating numerical constants, and that in turn means that any expressions _containing_ numerical constants aren't deduplicated either. This can lead to big problems. For example, the "a from scaled-rotated-ellipse" benchmark, one of our slowest, contains the expression `(sin (* (/ angle 180) PI))` multiple times. But since it contains a numerical constant, we end up evaluating it—and therefore computing `sin`—multiple times, five specifically. This is a huge waste! And I bet it's worse in localize.

Great work @AYadrov and I am looking forward to nightlies on this!