### PR TITLE
Speed up `batch-localize-cost` with more batching

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -99,7 +99,7 @@
 (define *proof-max-string-length* (make-parameter 10000))
 
 ;; In localization, the maximum number of locations returned
-(define *localize-expressions-limit* (make-parameter 10))
+(define *localize-expressions-limit* (make-parameter 4))
 
 ;; How long of a Taylor series to generate; too long and we time out
 (define *taylor-order-limit* (make-parameter 4))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -99,7 +99,7 @@
 (define *proof-max-string-length* (make-parameter 10000))
 
 ;; In localization, the maximum number of locations returned
-(define *localize-expressions-limit* (make-parameter 4))
+(define *localize-expressions-limit* (make-parameter 10))
 
 ;; How long of a Taylor series to generate; too long and we time out
 (define *taylor-order-limit* (make-parameter 4))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -5,8 +5,8 @@
          "../syntax/syntax.rkt" "../alternative.rkt" "../platform.rkt" 
          "simplify.rkt" "egg-herbie.rkt" "../syntax/rules.rkt")
 
-(provide batch-localize-error batch-localize-cost local-error-as-tree compute-local-errors
-         all-subexpressions )
+(provide batch-localize-both local-error-as-tree compute-local-errors
+         all-subexpressions)
 
 (define (all-subexpressions expr)
   (remove-duplicates
@@ -23,44 +23,33 @@
               [(list op args ...)
                (for ([arg args]) (loop arg))])))))
 
-;; Returns a list of expressions sorted by increasing local error
-(define (batch-localize-error exprs ctx)
-  (define errss
-    (if (null? exprs) empty (compute-local-errors exprs ctx)))
+(define (batch-localize-both exprs ctx)
+  (define subexprs (append-map all-subexpressions exprs))
+  (define expr->cost  (platform-cost-proc (*active-platform*)))
 
-  (for/list ([expr (in-list exprs)] [errs (in-list errss)])
+  (define simplifieds
+    (simplify-batch (make-egg-query subexprs (*simplify-rules*))))
+
+  (define errs (compute-local-errors exprs ctx))
+  (define localize-errss
     (sort
      (sort
-      (for/list ([(expr err) (in-hash errs)]
-                 #:when (list? expr))
-                (cons err expr))
+      (for/list ([(subexpr err) (in-hash errs)]
+                 #:when (list? subexpr))
+        (cons err subexpr))
       expr<? #:key cdr)
-     > #:key (compose errors-score car))))
-     
+     > #:key (compose errors-score car)))
 
-
-;;Returns a list of lists of subexpresions and their cost different sorted by increasing local cost in the form (diff, expr)
-(define (batch-localize-cost exprs ctx)
-  ;;Creates a function to get the cost of a expr
-  (define expr->cost  (platform-cost-proc (*active-platform*)))
-  ;;For each expression takes the subexpressions and a the simplified version of those subexpression then for each subexpression it computes the difference between the two and return a sorted list of pairs of (subexpr and diff).
-  (for/list ([expr (in-list exprs)])
-    (define subexprs (all-subexpressions expr))
-    (define simple-subexprs (simplify-batch (make-egg-query subexprs (*simplify-rules*))))
-
-      (sort 
-        (for/list ([subexpr (in-list subexprs)]
-                  [simple-subexpr (in-list simple-subexprs)]
-                  #:when (list? subexpr))
-                  (cons (- (expr->cost subexpr (context-repr ctx)) (expr->cost (last simple-subexpr) (context-repr ctx)))
-                         subexpr)
-                  )
-      > #:key car)  
-    )
-  )
-      
-
-
+  (define localize-costs
+    (sort 
+     (for/list ([subexpr (in-list subexprs)]
+                [simplified (in-list simplifieds)]
+                #:when (list? subexpr))
+       (cons (- (expr->cost subexpr (repr-of subexpr ctx))
+                (expr->cost (last simplified) (repr-of subexpr ctx)))
+             subexpr))
+      > #:key car))
+  (values localize-errss localize-costs))
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors exprs ctx)
@@ -101,9 +90,8 @@
            (ulp-difference (hash-ref exacts-hash expr) approx repr)]))
       (hash-update! errs expr (curry cons err))))
 
-  (for/list ([expr (in-list exprs)] [subexprs (in-list subexprss)])
-    (for/hash ([subexpr (in-list subexprs)])
-      (values subexpr (reverse (hash-ref errs subexpr))))))
+  (for*/hash ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
+    (values subexpr (reverse (hash-ref errs subexpr)))))
 
 ;; Compute the local error of every subexpression of `prog`
 ;; and returns the error information as an S-expr in the

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -97,7 +97,7 @@
 ;; and returns the error information as an S-expr in the
 ;; same shape as `prog`
 (define (local-error-as-tree expr ctx)
-  (define errs (first (compute-local-errors (list expr) ctx)))
+  (define errs (compute-local-errors (list expr) ctx))
   (let loop ([expr expr])
     (match expr
       [(list op args ...) (cons (hash-ref errs expr) (map loop args))]

--- a/src/error-table.rkt
+++ b/src/error-table.rkt
@@ -9,8 +9,9 @@
 (define (actual-errors expr pcontext)
   (match-define (cons subexprs pt-errorss)
     (flip-lists
-     (hash->list (compute-local-errors (list expr)
-                                       (*context*)))))
+     (hash->list (first (compute-local-errors (list expr)
+                                       (*context*))))))
+
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/error-table.rkt
+++ b/src/error-table.rkt
@@ -9,8 +9,8 @@
 (define (actual-errors expr pcontext)
   (match-define (cons subexprs pt-errorss)
     (flip-lists
-     (hash->list (car (compute-local-errors (list expr)
-                                            (*context*))))))
+     (hash->list (compute-local-errors (list expr)
+                                       (*context*)))))
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -203,6 +203,7 @@
     (raise-user-error 'localize! "No alt chosen. Run (choose-alts!) or (choose-alt! n) to choose one"))
   (timeline-event! 'localize)
   (define repr (context-repr (*context*)))
+  (define num-exprs (length (^next-alts^)))
   (define-values (loc-errs loc-costs)
      (batch-localize-both (map alt-expr (^next-alts^)) (*context*)))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -204,20 +204,24 @@
   (timeline-event! 'localize)
   (define repr (context-repr (*context*)))
   (define num-exprs (length (^next-alts^)))
-  (define-values (loc-errs loc-costs)
+  (define-values (loc-errss loc-costss)
      (batch-localize-both (map alt-expr (^next-alts^)) (*context*)))
 
   ; high-error locations
   (^locs^
     (remove-duplicates 
       (append 
-       (for/list ([(err expr) (in-dict loc-errs)]
+       (for/list ([loc-errs (in-list loc-errss)]
+                  #:when true
+                  [(err expr) (in-dict loc-errs)]
                   [i (in-range (*localize-expressions-limit*))])
          (timeline-push! 'locations (~a expr) "accuracy" (errors-score err)
                          (not (patch-table-has-expr? expr)) (~a (representation-name repr)))
          expr)
         ;;Timeline will push duplicates
-        (for/list ([(cost-diff expr) (in-dict loc-costs)]
+        (for/list ([loc-costs (in-list loc-costss)]
+                   #:when true
+                   [(cost-diff expr) (in-dict loc-costs)]
                    [i (in-range (*localize-expressions-limit*))])
           (timeline-push! 'locations (~a expr) "cost-diff" cost-diff
                           (not (patch-table-has-expr? expr)) (~a (representation-name repr)))


### PR DESCRIPTION
The main goal of this PR is to speed up `batch-localize-cost`  by doing more batching. Specifically, right now we call `batch-localize-cost` with five exprs. Then for each one we do a simplify batch. Instead, this PR does one big simplify batch for all five exprs together. This is faster (one batch, not five) and simpler (due to a bit of refactoring).

This PR does a couple of other things, too:
- `batch-localize-errors` now returns a single hash, instead of one hash per input expr. Turns out we didn't need that extra structure, and it was making things messy
- I merged `batch-localize-errors` and `batch-localize-cost`. This isn't strictly necessary but after nightly runs I expect to try using simplified subexprs instead of the original subexprs for localize, which I think will lead to more (though minor) speedups.

The result of this PR is a ~30% speedup to `localize`, saving us I project ~5 minutes in nightlies. The current split is that error localization is about 60% of localize time and cost localization is about 40%.