### PR TITLE
Backward-pass precision propogation bug

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -292,7 +292,7 @@
     (for ([x (in-list tail-registers)]
           [new-exp (in-list new-exponents)]
           #:when (>= x varc)) ; when tail register is not a variable
-      (when (> (+ exps-from-above new-exp (vector-ref vstart-precs (- x varc))) (vector-ref vprecs-new (- x varc))) ; check whether this op already has a precision that is higher
+      (when (> (+ exps-from-above new-exp) (vector-ref vprecs-new (- x varc))) ; check whether this op already has a precision that is higher
         (vector-set! vprecs-new (- x varc) (+ exps-from-above new-exp))))))
 
 (define (ival-max-log2-approx x)


### PR DESCRIPTION
This bug was introduced by #774.
This bug loses ~100bits of precision in some cases where it is needed.
The changed line of code checked whether precision increased of an operation before increasing, where new precision was calculated slightly wrong.
As a result, a lot of points spin without converging.
The bug was revealed by analyzing `powComplex, real part` benchmark.