### PR TITLE
Change timeline table for sampling to sort by time

### DIFF
--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -397,7 +397,7 @@
 (define (render-phase-outcomes outcomes)
   `((dt "Results")
     (dd (table ([class "times"])
-         ,@(for/list ([rec (in-list (sort outcomes > #:key fourth))])
+         ,@(for/list ([rec (in-list (sort outcomes > #:key first))])
              (match-define (list time precision category count) rec)
              `(tr (td ,(format-time time)) (td ,(~a count) "×")
                   (td ,(~a precision)) (td ,(~a category))))))))


### PR DESCRIPTION
This got lost during my optimizations to `timeline-start!`