### PR TITLE
Fix egg proofs

### DIFF
--- a/egg-herbie/Cargo.lock
+++ b/egg-herbie/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "git+https://github.com/bksaiki/egg.git?branch=fix-proofs#977c89ac5eac7f4f183bfad00cd206508a258bdb"
+source = "git+https://github.com/egraphs-good/egg.git?rev=c11d03db646aca5f55df2632927eec958e1f4d4d#c11d03db646aca5f55df2632927eec958e1f4d4d"
 dependencies = [
  "env_logger",
  "fxhash",

--- a/egg-herbie/Cargo.lock
+++ b/egg-herbie/Cargo.lock
@@ -34,8 +34,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96beaf9d35dbc4686bc86a4ecb851fd6a406f0bf32d9f646b1225a5c5cf5b5d7"
+source = "git+https://github.com/bksaiki/egg.git?branch=fix-proofs#977c89ac5eac7f4f183bfad00cd206508a258bdb"
 dependencies = [
  "env_logger",
  "fxhash",
@@ -43,6 +42,9 @@ dependencies = [
  "indexmap",
  "instant",
  "log",
+ "num-bigint",
+ "num-traits",
+ "saturating",
  "smallvec",
  "symbol_table",
  "symbolic_expressions",
@@ -197,6 +199,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "smallvec"

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -5,8 +5,7 @@ authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2021"
 
 [dependencies]
-egg = "0.9.5"
-# egg = { git="https://github.com/egraphs-good/egg", rev="f7e9fd6cb87136d48f5275c8f60d98173ffc170a" }
+egg = { git = "https://github.com/bksaiki/egg.git", branch = "fix-proofs" }
 
 log = "0.4"
 indexmap = "1"

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
 edition = "2021"
 
 [dependencies]
-egg = { git = "https://github.com/bksaiki/egg.git", branch = "fix-proofs" }
+egg = { git = "https://github.com/egraphs-good/egg.git", rev = "c11d03db646aca5f55df2632927eec958e1f4d4d" }
 
 log = "0.4"
 indexmap = "1"

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -115,7 +115,7 @@ impl Default for ConstantFold {
 
 impl Analysis<Math> for ConstantFold {
     type Data = Option<(Constant, (PatternAst<Math>, Subst))>;
-    fn make(egraph: &EGraph, enode: &Math) -> Self::Data {
+    fn make(egraph: &mut EGraph, enode: &Math) -> Self::Data {
         if !egraph.analysis.constant_fold {
             return None;
         }


### PR DESCRIPTION
This PR updates Herbie's egg dependency to a newer version that fixes a long-standing bug in proofs (see egraphs-good/egg#310). 