### PR TITLE
Extend the CI to build both `x86` and `arm64` macOS packages

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -9,15 +9,24 @@ jobs:
   distribute:
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        include:
+          - os: macos-latest
+            arch: aarch64
+          - os: macos-13
+            arch: x86
+          - os: ubuntu-latest
+            arch: x86
+          - os: windows-latest
+            arch: x86
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.12
         with:
-            version: 8.11
+            version: 8.12
+            architecture: ${{ matrix.arch }}
       - name: Cache Racket dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.12
+        uses: Bogdanp/setup-racket@v1.11
         with:
             version: 8.12
             architecture: ${{ matrix.arch }}

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -13,11 +13,11 @@ jobs:
           - os: macos-latest
             arch: aarch64
           - os: macos-13
-            arch: x86
+            arch: x64
           - os: ubuntu-latest
-            arch: x86
+            arch: x64
           - os: windows-latest
-            arch: x86
+            arch: x64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.11
         with:
-          version: "8.11"
+          version: 8.12
       - name: Install Rust compiler
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,16 @@ jobs:
         include:
           - os: windows-latest
             os-name: windows
+            arch: x86
           - os: ubuntu-20.04  # keep old for glibc compatability
             os-name: ubuntu
+            arch: x86
           - os: macos-latest
+            os-name: macOS-m1
+            arch: arm64
+          - os: macos-13
             os-name: macOS
+            arch: x86
 
     runs-on: ${{ matrix.os }}
 
@@ -27,6 +33,7 @@ jobs:
         uses: Bogdanp/setup-racket@v1.11
         with:
           version: 8.11
+          architecture: ${{ matrix.arch }}
 
       - name: Install Rust compiler
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
         include:
           - os: windows-latest
             os-name: windows
-            arch: x86
+            arch: x64
           - os: ubuntu-20.04  # keep old for glibc compatability
             os-name: ubuntu
-            arch: x86
+            arch: x64
           - os: macos-latest
             os-name: macOS-m1
             arch: arm64
           - os: macos-13
             os-name: macOS
-            arch: x86
+            arch: x64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: [ '8.0', '8.11' ]
+        racket-version: [ '8.0', '8.12' ]
         precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.11
         with:
-          version: "8.11"
+          version: "8.12"
       - name: Install Rust compiler
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v1.11
         with:
-          version: "8.11"
+          version: "8.12"
       - name: Install Rust compiler
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -6,14 +6,6 @@
 ;; Packaging information
 
 (define pkg-desc "A tool for automatically improving the accuracy of floating point expressions")
-(define pkg-authors
-  '("Pavel Panchekha"
-    "Alex Sanchez-Stern"
-    "David Thien"
-    "Jason Qiu"
-    "James Wilcox"
-    "Zachary Tatlock"
-    "Jack Firth"))
 
 ;; The `herbie` command-line tool
 


### PR DESCRIPTION
Merging this PR is one of a couple of steps to get M1 macOS packages working, but this is very exciting!