### PR TITLE
Faster code for sampling a point

### DIFF
--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -95,15 +95,12 @@
 
 ; ENSURE: all contexts have the same list of variables
 (define (eval-progs-real progs ctxs)
-  (define repr (context-repr (car ctxs)))
   (define fn (make-search-func '(TRUE) progs ctxs))
+  (define bad-pt 
+    (for/list ([ctx* (in-list ctxs)])
+      ((representation-bf->repr (context-repr ctx*)) +nan.bf)))
   (define (<eval-prog-real> . pt)
     (define-values (result exs) (ival-eval fn ctxs pt))
-    (match exs
-      [(? list?)
-       exs]
-      [#f
-       (for/list ([ctx* ctxs])
-         ((representation-bf->repr (context-repr ctx*)) +nan.bf))]))
+    (or exs bad-pt))
   <eval-prog-real>)
 

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -14,22 +14,6 @@
 
 (define ground-truth-require-convergence (make-parameter #t))
 
-(define (is-infinite-interval repr interval)
-  (define <-bf (representation-bf->repr repr))
-  (define ->bf (representation-repr->bf repr))
-  ;; HACK: the comparisons to 0.bf is just about posits, where right now -inf.bf
-  ;; rounds to the NaR value, which then represents +inf.bf, which is positive.
-  (define (positive-inf? x)
-    (parameterize ([bf-rounding-mode 'nearest])
-      (and (bigfloat? x) (bf> x 0.bf) (bf= (->bf (<-bf x)) +inf.bf))))
-  (define (negative-inf? x)
-    (parameterize ([bf-rounding-mode 'nearest])
-      (and (bigfloat? x) (bf< x 0.bf) (bf= (->bf (<-bf x)) -inf.bf))))
-  (define ival-positive-infinite (monotonic->ival positive-inf?))
-  (define ival-negative-infinite (comonotonic->ival negative-inf?))
-  (ival-or (ival-positive-infinite interval)
-           (ival-negative-infinite interval)))
-
 (define (is-samplable-interval repr interval)
   (define <-bf (representation-bf->repr repr))
   (define (close-enough? lo hi)

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -67,22 +67,32 @@
     (when (> search-result 0)
       (check-true (<= (vector-ref arr (- search-result 1)) search-for)))))
 
-(define (sample-ival interval repr)
-  (define ->ordinal (compose (representation-repr->ordinal repr) (representation-bf->repr repr)))
-  (define <-ordinal (representation-ordinal->repr repr))
-  (<-ordinal (random-integer (->ordinal (ival-lo interval))
-                             (+ 1 (->ordinal (ival-hi interval))))))
-
 (define (make-hyperrect-sampler hyperrects* reprs)
   (when (null? hyperrects*)
     (raise-herbie-sampling-error "No valid values." #:url "faq.html#no-valid-values"))
   (define hyperrects (list->vector hyperrects*))
+  (define lo-ends
+    (for/vector ([hyperrect hyperrects])
+      (for/list ([interval hyperrect] [repr reprs])
+        ((representation-repr->ordinal repr)
+         ((representation-bf->repr repr)
+          (ival-lo interval))))))
+  (define hi-ends
+    (for/vector ([hyperrect hyperrects])
+      (for/list ([interval hyperrect] [repr reprs])
+        (+ 1 
+           ((representation-repr->ordinal repr)
+            ((representation-bf->repr repr)
+             (ival-hi interval)))))))
   (define weights (partial-sums (vector-map (curryr hyperrect-weight reprs) hyperrects)))
   (define weight-max (vector-ref weights (- (vector-length weights) 1)))
   (λ ()
     (define rand-ordinal (random-integer 0 weight-max))
-    (define hyperrect (vector-ref hyperrects (binary-search weights rand-ordinal)))
-    (map sample-ival hyperrect reprs)))
+    (define idx (binary-search weights rand-ordinal))
+    (define los (vector-ref lo-ends idx))
+    (define his (vector-ref hi-ends idx))
+    (for/list ([lo (in-list los)] [hi (in-list his)] [repr reprs])
+      ((representation-ordinal->repr repr) (random-integer lo hi))))
 
 (module+ test
   (define two-point-hyperrects (list (list (ival (bf 0) (bf 0)) (ival (bf 1) (bf 1)))))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -72,14 +72,16 @@
     (raise-herbie-sampling-error "No valid values." #:url "faq.html#no-valid-values"))
   (define hyperrects (list->vector hyperrects*))
   (define lo-ends
-    (for/vector ([hyperrect hyperrects])
-      (for/list ([interval hyperrect] [repr reprs])
+    (for/vector #:length (vector-length hyperrects)
+                ([hyperrect (in-vector hyperrects)])
+      (for/list ([interval (in-list hyperrect)] [repr (in-list reprs)])
         ((representation-repr->ordinal repr)
          ((representation-bf->repr repr)
           (ival-lo interval))))))
   (define hi-ends
-    (for/vector ([hyperrect hyperrects])
-      (for/list ([interval hyperrect] [repr reprs])
+    (for/vector #:length (vector-length hyperrects)
+                ([hyperrect (in-vector hyperrects)])
+      (for/list ([interval (in-list hyperrect)] [repr (in-list reprs)])
         (+ 1 
            ((representation-repr->ordinal repr)
             ((representation-bf->repr repr)
@@ -91,8 +93,8 @@
     (define idx (binary-search weights rand-ordinal))
     (define los (vector-ref lo-ends idx))
     (define his (vector-ref hi-ends idx))
-    (for/list ([lo (in-list los)] [hi (in-list his)] [repr reprs])
-      ((representation-ordinal->repr repr) (random-integer lo hi))))
+    (for/list ([lo (in-list los)] [hi (in-list his)] [repr (in-list reprs)])
+      ((representation-ordinal->repr repr) (random-integer lo hi)))))
 
 (module+ test
   (define two-point-hyperrects (list (list (ival (bf 0) (bf 0)) (ival (bf 1) (bf 1)))))


### PR DESCRIPTION
To be clear, this PR is optimizing the code that *selects a random input*. This is a small fraction of the sampling phase as a whole—something like 15%. My guess is that this optimization speeds up that 15% by about 2×, basically by precomputing the ordinals for each interval's endpoint instead of recomputing them per-sample.