### PR TITLE
Clean up `localize`

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -7,6 +7,7 @@
 (define all-flags
   #hash([precision . (double fallback)]
         [setup . (simplify search)]
+        [localize . (costs errors)]
         [generate . (rr taylor simplify better-rr proofs)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
@@ -14,6 +15,7 @@
 (define default-flags
   #hash([precision . ()]
         [setup . (simplify search)]
+        [localize . (costs errors)]
         [generate . (rr taylor simplify proofs)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -54,7 +54,7 @@
         expr<? #:key cdr)
        > #:key (compose errors-score car))))
 
-  (define localize-costs
+  (define localize-costss
     (for/list ([subexprs (in-list subexprss)] [simplifieds (in-list simplifiedss)])
       (sort 
        (for/list ([subexpr (in-list subexprs)]
@@ -64,7 +64,7 @@
                   (expr->cost (last simplified) (repr-of subexpr ctx)))
                subexpr))
        > #:key car)))
-  (values localize-errss localize-costs))
+  (values localize-errss localize-costss))
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors exprs ctx)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -5,7 +5,8 @@
          "../syntax/syntax.rkt" "../alternative.rkt" "../platform.rkt" 
          "simplify.rkt" "egg-herbie.rkt" "../syntax/rules.rkt")
 
-(provide batch-localize-both local-error-as-tree compute-local-errors
+(provide batch-localize-costs batch-localize-errors
+         local-error-as-tree compute-local-errors
          all-subexpressions)
 
 (define (all-subexpressions expr)
@@ -34,25 +35,15 @@
     [('() '())
      '()]))
 
-(define (batch-localize-both exprs ctx)
+(define (batch-localize-costs exprs ctx)
   (define subexprss (map all-subexpressions exprs))
   (define expr->cost  (platform-cost-proc (*active-platform*)))
-
+  
   (define simplifiedss
     (regroup-nested
      subexprss
-     (simplify-batch (make-egg-query (apply append subexprss) (*simplify-rules*)))))
-
-  (define errss (compute-local-errors exprs ctx))
-  (define localize-errss
-    (for/list ([expr (in-list exprs)] [errs (in-list errss)])
-      (sort
-       (sort
-        (for/list ([(subexpr err) (in-hash errs)]
-                   #:when (list? subexpr))
-          (cons err subexpr))
-        expr<? #:key cdr)
-       > #:key (compose errors-score car))))
+     (map last
+          (simplify-batch (make-egg-query (apply append subexprss) (*simplify-rules*))))))
 
   (define localize-costss
     (for/list ([subexprs (in-list subexprss)] [simplifieds (in-list simplifiedss)])
@@ -61,16 +52,27 @@
                   [simplified (in-list simplifieds)]
                   #:when (list? subexpr))
          (cons (- (expr->cost subexpr (repr-of subexpr ctx))
-                  (expr->cost (last simplified) (repr-of subexpr ctx)))
+                  (expr->cost simplified (repr-of subexpr ctx)))
                subexpr))
        > #:key car)))
-  (values localize-errss localize-costss))
+
+  (values simplifiedss localize-costss))
+
+(define (batch-localize-errors exprs ctx)
+  (define subexprss (map all-subexpressions exprs))
+  (define errss (compute-local-errors subexprss ctx))
+
+  (for/list ([expr (in-list exprs)] [errs (in-list errss)])
+    (sort
+     (sort
+      (for/list ([(subexpr err) (in-hash errs)]
+                 #:when (list? subexpr))
+        (cons err subexpr))
+      expr<? #:key cdr)
+     > #:key (compose errors-score car))))
 
 ; Compute local error or each sampled point at each node in `prog`.
-(define (compute-local-errors exprs ctx)
-  (define subexprss
-    (for/list ([expr (in-list exprs)])
-      (all-subexpressions expr)))
+(define (compute-local-errors subexprss ctx)
   (define spec-list
     (for*/list ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
       (prog->spec subexpr)))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -56,7 +56,7 @@
                subexpr))
        > #:key car)))
 
-  (values simplifiedss localize-costss))
+  localize-costss)
 
 (define (batch-localize-errors exprs ctx)
   (define subexprss (map all-subexpressions exprs))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -115,7 +115,7 @@
 ;; and returns the error information as an S-expr in the
 ;; same shape as `prog`
 (define (local-error-as-tree expr ctx)
-  (define errs (first (compute-local-errors (list expr) ctx)))
+  (define errs (first (compute-local-errors (list (all-subexpressions expr)) ctx)))
   (let loop ([expr expr])
     (match expr
       [(list op args ...) (cons (hash-ref errs expr) (map loop args))]

--- a/src/error-table.rkt
+++ b/src/error-table.rkt
@@ -9,7 +9,7 @@
 (define (actual-errors expr pcontext)
   (match-define (cons subexprs pt-errorss)
     (flip-lists
-     (hash->list (first (compute-local-errors (list expr)
+     (hash->list (first (compute-local-errors (list (all-subexpressions expr))
                                        (*context*))))))
 
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -201,11 +201,13 @@
 (define (localize!)
   (unless (^next-alts^)
     (raise-user-error 'localize! "No alt chosen. Run (choose-alts!) or (choose-alt! n) to choose one"))
-  (timeline-event! 'localize)
   (define repr (context-repr (*context*)))
-  (define num-exprs (length (^next-alts^)))
-  (define-values (loc-errss loc-costss)
-     (batch-localize-both (map alt-expr (^next-alts^)) (*context*)))
+  (timeline-event! 'simplify)
+  (define-values (_ loc-costss)
+    (batch-localize-costs (map alt-expr (^next-alts^)) (*context*)))
+  (timeline-event! 'localize)
+  (define loc-errss
+    (batch-localize-errors (map alt-expr (^next-alts^)) (*context*)))
 
   ; high-error locations
   (^locs^

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -201,36 +201,42 @@
 (define (localize!)
   (unless (^next-alts^)
     (raise-user-error 'localize! "No alt chosen. Run (choose-alts!) or (choose-alt! n) to choose one"))
-  (define repr (context-repr (*context*)))
+
   (timeline-event! 'simplify)
-  (define-values (_ loc-costss)
-    (batch-localize-costs (map alt-expr (^next-alts^)) (*context*)))
+  (define exprs (map alt-expr (^next-alts^)))
+  (define localized-exprs empty)
+  (define repr (context-repr (*context*)))
+
+  (when (flag-set? 'localize 'costs)
+    (define loc-costss (batch-localize-costs exprs (*context*)))
+    (define cost-localized
+      (for/list ([loc-costs (in-list loc-costss)]
+                 #:when true
+                 [(cost-diff expr) (in-dict loc-costs)]
+                 [i (in-range (*localize-expressions-limit*))])
+        (timeline-push! 'locations (~a expr) "cost-diff" cost-diff
+                        (not (patch-table-has-expr? expr))
+                        (~a (representation-name repr)))
+        expr))
+    (set! localized-exprs (remove-duplicates (append localized-exprs cost-localized))))
+
   (timeline-event! 'localize)
-  (define loc-errss
-    (batch-localize-errors (map alt-expr (^next-alts^)) (*context*)))
+  (when (flag-set? 'localize 'errors)
+    (define loc-errss (batch-localize-errors exprs (*context*)))
+    ;;Timeline will push duplicates
+    (define error-localized
+      (for/list ([loc-errs (in-list loc-errss)]
+                 #:when true
+                 [(err expr) (in-dict loc-errs)]
+                 [i (in-range (*localize-expressions-limit*))])
+        (timeline-push! 'locations (~a expr) "accuracy" (errors-score err)
+                        (not (patch-table-has-expr? expr))
+                        (~a (representation-name repr)))
+        expr))
+    (set! localized-exprs (remove-duplicates (append localized-exprs error-localized))))
 
-  ; high-error locations
-  (^locs^
-    (remove-duplicates 
-      (append 
-       (for/list ([loc-errs (in-list loc-errss)]
-                  #:when true
-                  [(err expr) (in-dict loc-errs)]
-                  [i (in-range (*localize-expressions-limit*))])
-         (timeline-push! 'locations (~a expr) "accuracy" (errors-score err)
-                         (not (patch-table-has-expr? expr)) (~a (representation-name repr)))
-         expr)
-        ;;Timeline will push duplicates
-        (for/list ([loc-costs (in-list loc-costss)]
-                   #:when true
-                   [(cost-diff expr) (in-dict loc-costs)]
-                   [i (in-range (*localize-expressions-limit*))])
-          (timeline-push! 'locations (~a expr) "cost-diff" cost-diff
-                          (not (patch-table-has-expr? expr)) (~a (representation-name repr)))
-          expr))))
-
-  (^lowlocs^
-  '())
+  (^locs^ localized-exprs)
+  (^lowlocs^ '())
   (void))
 
 


### PR DESCRIPTION
This re-splits `batch-localize-cost` and `batch-localize-error`, adds a timeline break between them (`-costs` is now a `simplify` phase, which I think is fair), and makes them each togglable with flags.