### PR TITLE
Added documentation of the /cost API endpoint

### DIFF
--- a/www/doc/2.0/api-endpoints.html
+++ b/www/doc/2.0/api-endpoints.html
@@ -227,5 +227,64 @@
     <h2 id="localerror">/api/local-error</h2>
     <!--TODO--> Forthcoming.
 
+
+    <h2 id="cost">/api/cost</h2>
+
+    <details>
+    <summary>Example inputs & outputs</summary>
+
+    <p>Request:</p>
+
+    <pre>{
+        formula: &lt;FPCore expression&gt;,
+        sample: [point ... ]
+      }</pre>
+
+    <p>Response:</p>
+
+    <pre>{
+        cost: [cost]
+      }</pre>
+
+    <p>Specific Example: sqrt(x+1)-sqrt(x)</p>
+
+    <p>Request:</p>
+
+    <pre>{
+        formula: &lt;(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))&gt;,
+        sample: [ [[1], -1.4142135623730951] ]
+      }</pre>
+
+    <p>Response:</p>
+
+    <pre>{
+        cost: [13120]
+      }</pre>
+
+    <p>Specific Example Simplified: (x+1)-(x)</p>
+
+    <p>Request:</p>
+
+    <pre>{
+        formula: &lt;(FPCore (x) (- (+ x 1 ) x))&gt;,
+        sample: [ [[1], -1.4142135623730951] ]
+      }</pre>
+
+    <p>Response:</p>
+
+    <pre>{
+        cost: [320]
+      }</pre>
+    </details>
+
+    <p>The <code>cost</code> endpoint allows the user to request
+    the evaluation of an expression's overall cost. Cost is 
+    calculated depending on the complexity of operations contained
+    in the expression. </p>
+
+    <p>Given an FPCore expression and a collection of points,
+    returns the cost of the expression. The cost value returned 
+    is calculated internally by Herbie. </p>
+
   </body>
 </html>

--- a/www/doc/2.0/api-endpoints.html
+++ b/www/doc/2.0/api-endpoints.html
@@ -235,46 +235,47 @@
 
     <p>Request:</p>
 
-    <pre>{
-        formula: &lt;FPCore expression&gt;,
-        sample: [point ... ]
-      }</pre>
+  <pre>{
+    formula: &lt;FPCore expression&gt;,
+    sample: [point ... ]
+}</pre>
 
     <p>Response:</p>
 
-    <pre>{
-        cost: [cost]
-      }</pre>
+  <pre>{
+    cost: [cost]
+}</pre>
 
-    <p>Specific Example: sqrt(x+1)-sqrt(x)</p>
+    <p><b>Specific Example: sqrt(x+1)-sqrt(x)</b></p>
 
     <p>Request:</p>
 
-    <pre>{
-        formula: &lt;(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))&gt;,
-        sample: [ [[1], -1.4142135623730951] ]
-      }</pre>
+  <pre>{
+    formula: &lt;(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))&gt;,
+    sample: [ [[1], -1.4142135623730951] ]
+}</pre>
 
     <p>Response:</p>
 
-    <pre>{
-        cost: [13120]
-      }</pre>
+  <pre>{
+    cost: [13120]
+}</pre>
 
-    <p>Specific Example Simplified: (x+1)-(x)</p>
+    <p><b>Lower-Cost Example: (x+1)-(x)</b></p>
 
     <p>Request:</p>
 
-    <pre>{
-        formula: &lt;(FPCore (x) (- (+ x 1 ) x))&gt;,
-        sample: [ [[1], -1.4142135623730951] ]
-      }</pre>
+  <pre>{
+    formula: &lt;(FPCore (x) (- (+ x 1 ) x))&gt;,
+    sample: [ [[1], -1.4142135623730951] ]
+}</pre>
 
     <p>Response:</p>
 
-    <pre>{
-        cost: [320]
-      }</pre>
+  <pre>{
+    cost: [320]
+}</pre>
+
     </details>
 
     <p>The <code>cost</code> endpoint allows the user to request
@@ -284,7 +285,15 @@
 
     <p>Given an FPCore expression and a collection of points,
     returns the cost of the expression. The cost value returned 
-    is calculated internally by Herbie. </p>
+    is calculated internally by Herbie.</p> 
+    
+    <p>The points should be of the same format as the points 
+    generated in the sample endpoint. Refer to /api/sample 
+    for more details. </p>
+
+    <p>Note the sample points are not used in the cost calculation.
+    The contents of the points do not matter as long as they are
+    in the correct format as mentioned above.</p>
 
   </body>
 </html>


### PR DESCRIPTION
Before we had a cost endpoint, but it was not documented. This PR adds documentation regarding inputs and outputs, including types and specific examples. 

Pictures:

![image](https://github.com/herbie-fp/herbie/assets/112049313/d74f18a7-c77c-445f-853a-b23374394d60)
![image](https://github.com/herbie-fp/herbie/assets/112049313/4c6f1a45-4505-46ba-a085-74d8d16a4006)