### PR TITLE
Quick fix `render-fpcore`

### DIFF
--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -302,7 +302,7 @@
          #f
          (format "  :herbie-expected ~a" (test-expected test)))
      (and (test-output test)
-          (> (length (test-output test)) 0)
+          (not (null? (test-output test)))
           (format "\n~a"
                   (string-join
                    (map

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -302,7 +302,7 @@
          #f
          (format "  :herbie-expected ~a" (test-expected test)))
      (and (test-output test)
-          (> (length (test-output test) 0))
+          (> (length (test-output test)) 0)
           (format "\n~a"
                   (string-join
                    (map

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -301,15 +301,14 @@
      (if (equal? (test-expected test) #t)
          #f
          (format "  :herbie-expected ~a" (test-expected test)))
-     (if (not (null? (test-output test)))
-        ;; Extra newlines for clarity. Also joined formatted expressions with newlines
-        (format "\n~a"
-          (string-join
-            (map
-              (lambda (exp) (format "  :alt\n  ~a\n" (car exp)))
-              (test-output test))
-            "\n"))
-         #f)
+     (and (test-output test)
+          (> (length (test-output test) 0))
+          (format "\n~a"
+                  (string-join
+                   (map
+                    (lambda (exp) (format "  :alt\n  ~a\n" (car exp)))
+                    (test-output test))
+                   "\n")))
      (format "  ~a)" (prog->fpcore (test-input test) output-repr))))
    "\n"))
 


### PR DESCRIPTION
Quick fix for a bug in `render-fpcore` which breaks the cost script.