### PR TITLE
Alternative `if` cost method

### DIFF
--- a/src/compiler.rkt
+++ b/src/compiler.rkt
@@ -48,7 +48,7 @@
          (vector-ref regs b)
          (vector-ref regs c))]
     [(list op args ...)
-     (apply op (map (curryr vector-ref regs) args))]))
+     (apply op (map (lambda (arg) (vector-ref regs arg)) args))]))
 
 (define (if-proc c a b)
   (if c a b))

--- a/src/platform.rkt
+++ b/src/platform.rkt
@@ -31,6 +31,7 @@
     ; Cost model
     [platform-impl-cost (-> platform? any/c any/c)]
     [platform-repr-cost (-> platform? any/c any/c)]
+    [platform-node-cost-proc (-> platform? procedure?)]
     [platform-cost-proc (-> platform? procedure?)]))
 
 (module+ internals
@@ -210,6 +211,13 @@
 (define (make-platform-info)
   (platform-info #f #f #f '() '()))
 
+;; Parse if cost syntax
+(define (platform/parse-if-cost stx)
+  (syntax-case stx (max sum)
+    [(max x) #'(list 'max x)]
+    [(sum x) #'(list 'sum x)]
+    [x #'(list 'max x)]))
+
 ;; Parse conversion signatures into a list of implementation table
 (define (platform/parse-convs oops! default-cost default-cost-id conv-sigs)
   (for/fold ([impls '()]) ([conv (in-list conv-sigs)])
@@ -277,7 +285,9 @@
 ;;   (platform
 ;;     #:conversions ([binary64 binary32] ...)  ; conversions
 ;;     #:default-cost 1                         ; default cost per impl
-;;     #:if-cost 1                              ; cost of an implementation
+;;     #:if-cost 1                              ; cost of an if branch (using max strategy)
+;;     #:if-cost (max 1)                        ; cost of an if branch (using max strategy)
+;;     #:if-cost (sum 1)                        ; cost of an if branch (using sum strategy)
 ;;     [(bool) (TRUE FALSE)]                    ; constant (0-ary functions)
 ;;     [(bool bool) (not)]                      ; 1-ary function: bool -> bool
 ;;     [(bool bool bool) (and or)]              ; 2-ary function: bool -> bool -> bool
@@ -322,7 +332,7 @@
          [(#:if-cost cost rest ...)
           (loop #'(rest ...)
                 (struct-copy platform-info info
-                  [if-cost #'cost]))]
+                  [if-cost (platform/parse-if-cost #'cost)]))]
          [(#:if-cost)
           (oops! "expected value after keyword `#:if-cost`" stx)]
          [(#:conversions (cs ...) rest ...)
@@ -395,22 +405,23 @@
 
 ;; Merger for costs.
 (define (merge-cost pform-costs key #:optional? [optional? #f])
-  (define costs
-    (for/list ([pform-cost (in-list pform-costs)])
-      (hash-ref pform-cost key #f)))
-  (match (remove-duplicates (filter identity costs))
-    [(list c1 c2 cs ...)
-     (error 'merge-costs
-            "mismatch when combining cost model ~a ~a"
-            key (list* c1 c2 cs))]
-    [(list c1)
-     c1]
-    [(list)
-     (unless optional?
-       (error 'merge-costs
-              "cannot find cost for implementation ~a"
-              key))
-     #f]))
+  (define costs (map (lambda (h) (hash-ref h key #f)) pform-costs))
+  (match-define (list c0 cs ...) costs)
+  (define cost
+    (for/fold ([c0 c0]) ([c1 (in-list cs)])
+      (match* (c0 c1)
+        [(#f _) c1]
+        [(_ #f) c0]
+        [(c c) c]
+        [(_ _)
+         (error 'merge-costs
+                "mismatch when combining cost model ~a ~a"
+                key costs)])))
+  (unless (or cost optional?)
+    (error 'merge-costs
+           "cannot find cost for implementation ~a"
+           key))
+  cost)
 
 ;; Set operations on platforms.
 (define ((make-set-operation merge-impls) p1 . ps)
@@ -746,20 +757,47 @@
             (lambda ()
               (error 'platform-repr-cost "no cost for repr ~a" repr))))
 
+; Cost model of a single node by a platform.
+; Returns a procedure that must be called with the costs of the children.
+(define (platform-node-cost-proc pform)
+  (λ (expr repr)
+    (match expr
+      [(? literal?) (lambda () (platform-repr-cost pform repr))]
+      [(? symbol?) (lambda () (platform-repr-cost pform repr))]
+      [(list 'if _ _ _)
+       (define if-cost (platform-impl-cost pform 'if))
+       (lambda (cond-cost ift-cost iff-cost)
+         (match if-cost
+           [`(max ,n) (+ n cond-cost (max ift-cost iff-cost))]
+           [`(sum ,n) (+ n cond-cost ift-cost iff-cost)]))]
+      [(list impl args ...)
+       (define impl-cost (platform-impl-cost pform impl))
+       (lambda itype-costs
+         (unless (= (length itype-costs) (length args))
+           (error 'platform-node-cost-proc
+                  "arity mismatch, expected ~a arguments"
+                  (length args)))
+         (apply + impl-cost itype-costs))])))
+
 ; Cost model parameterized by a platform.
 (define (platform-cost-proc pform)
+  (define bool-repr (get-representation 'bool))
+  (define node-cost-proc (platform-node-cost-proc pform))
   (λ (expr repr)
     (let loop ([expr expr] [repr repr])
       (match expr
+        [(? literal?) ((node-cost-proc expr repr))]
+        [(? symbol?) ((node-cost-proc expr repr))]
         [(list 'if cond ift iff)
-         (+ (platform-impl-cost pform 'if)
-            (loop cond (get-representation 'bool))
-            (max (loop ift repr) (loop iff repr)))]
+         (define cost-proc (node-cost-proc expr repr))
+         (cost-proc (loop cond bool-repr)
+                    (loop ift repr)
+                    (loop iff repr))]
         [(list impl args ...)
+         (define cost-proc (node-cost-proc expr repr))
          (define itypes (impl-info impl 'itype))
-         (apply + (platform-impl-cost pform impl) (map loop args itypes))]
-        [_
-         (platform-repr-cost pform repr)]))))
+         (apply cost-proc (map loop args itypes))]))))
+
 
 (define (extract-platform-name annotation)
   (match-define (list '! props ...) annotation)

--- a/src/platforms/avx.rkt
+++ b/src/platforms/avx.rkt
@@ -10,7 +10,7 @@
   (with-terminal-cost ([bool move-cost])
     (platform
      #:default-cost move-cost
-     #:if-cost move-cost
+     #:if-cost (sum move-cost)
      [(bool) (TRUE FALSE)]
      [(bool bool) not]
      [(bool bool bool) (and or)])))

--- a/src/preprocess.rkt
+++ b/src/preprocess.rkt
@@ -13,6 +13,11 @@
     (get-parametric-operator 'fabs repr)
     #t))
 
+(define (has-copysign-impl? repr)
+  (with-handlers ([exn:fail:user:herbie? (const #f)])
+    (get-parametric-operator 'copysign repr repr)
+    #t))
+
 ;; The even identities: f(x) = f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
 (define (make-even-identities spec ctx)
@@ -28,7 +33,8 @@
   (reap [sow]
     (for ([var (in-list (context-vars ctx))]
           [repr (in-list (context-var-reprs ctx))])
-      (when (has-fabs-neg-impls? repr)
+      (when (and (has-fabs-neg-impls? repr)
+                 (has-copysign-impl? repr))
         (sow (replace-vars `((,var . (neg ,var))) `(neg ,spec)))))))
 
 ;; Swap identities: f(a, b) = f(b, a)


### PR DESCRIPTION
This PR allows platforms to specify an alternative `if` cost: the cost of an `if` is the sum of the condition, if-true, and if-false branches, plus some constant value. This is likely useful for vectorized code.