### PR TITLE
Better hashes for threads/jobs

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -541,23 +541,24 @@
       (define test (parse-test formula))
       (define expr (prog->fpcore (test-input test) (test-output-repr test)))
       ;; TODO: potentially unsafe if resugaring changes the AST
-      (define tree
-      (let loop ([expr expr] [err local-error])
-        (match expr
-          [(list op args ...)
-          ;; err => (List (listof Integer) List ...)
-          (hasheq
-            'e (~a op)
-            'avg-error (format-bits (errors-score (first err)))
-            'children (map loop args (rest err)))]
-          [_
-          ;; err => (List (listof Integer))
-          (hasheq
-            'e (~a expr)
-            'avg-error (format-bits (errors-score (first err)))
-            'children '())])))
+      (define ast (local-error->fpcore expr local-error))
+      (hasheq 'tree ast))))
 
-      (hasheq 'tree tree))))
+(define (local-error->fpcore expr local-error)
+  (let loop ([expr expr] [err local-error])
+    (match expr
+      [(list op args ...)
+      ;; err => (List (listof Integer) List ...)
+      (hasheq
+        'e (~a op)
+        'avg-error (format-bits (errors-score (first err)))
+        'children (map loop args (rest err)))]
+      [_
+      ;; err => (List (listof Integer))
+      (hasheq
+        'e (~a expr)
+        'avg-error (format-bits (errors-score (first err)))
+        'children '())])))
 
 (define (run-alternatives hash formula seed sample)
   (hash-set! *jobs* hash (*timeline*))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -322,8 +322,7 @@
           (eprintf "Evaluation job started on ~a..." formula)
           (define result (run-herbie 'evaluate test #:seed seed 
           #:pcontext pcontext #:profile? #f #:timeline-disabled? #t))
-          (define approx (job-result-backend result))
-          (hash-set! *completed-jobs* hash (hasheq 'points approx))
+          (hash-set! *completed-jobs* hash result)
           (eprintf " complete\n")
           (hash-remove! *jobs* hash)
           (semaphore-post sema)]
@@ -538,7 +537,9 @@
       (define hash (sha1 (open-input-string 
        (string-append (symbol->string 'evaluate) formula-str))))
       (semaphore-wait (run-evaluate hash formula seed sample))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define approx (job-result-backend result))
+      (hasheq 'points approx))))
 
 (define (run-local-error hash formula seed sample)
   (hash-set! *jobs* hash (*timeline*))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -311,8 +311,7 @@
           (eprintf "Ground truth job started on ~a..." formula)
           (define result (run-herbie 'exacts test #:seed seed 
           #:pcontext pcontext #:profile? #f #:timeline-disabled? #t))
-          (define exacts (job-result-backend result))
-          (hash-set! *completed-jobs* hash (hasheq 'points exacts))
+          (hash-set! *completed-jobs* hash result)
           (eprintf " complete\n")
           (hash-remove! *jobs* hash)
           (semaphore-post sema)]
@@ -519,7 +518,9 @@
       (define hash (sha1 (open-input-string 
        (string-append (symbol->string 'exacts) formula-str))))
       (semaphore-wait (run-exacts hash formula seed sample))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define exacts (job-result-backend result))
+      (hasheq 'points exacts))))
 
 (define (run-evaluate hash formula seed sample)
   (hash-set! *jobs* hash (*timeline*))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -262,7 +262,6 @@
           (semaphore-post sema)]
          [(list 'local-error hash formula sema seed sample)
           (define test (parse-test formula))
-          (define expr (prog->fpcore (test-input test) (test-output-repr test)))
           (define pcontext (json->pcontext sample (test-context test)))
           (eprintf "Local error job started on ~a..." formula)
           (define result (run-herbie 'local-error test #:seed seed 
@@ -273,8 +272,6 @@
           (semaphore-post sema)]
          [(list 'alternatives hash formula sema seed sample)
           (define test (parse-test formula))
-          (define vars (test-vars test))
-          (define repr (test-output-repr test))
           (eprintf "Alternatives job started on ~a..." formula)  
           (define pcontext (json->pcontext sample (test-context test)))
           (define result (run-herbie 'alternatives test #:seed seed 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -258,8 +258,7 @@
           (define result (run-herbie 'errors test
           #:seed seed #:pcontext pcontext
           #:profile? #f #:timeline-disabled? #t))
-          (define errs (job-result-backend result))
-          (hash-set! *completed-jobs* hash (hasheq 'points errs))
+          (hash-set! *completed-jobs* hash result)
           (eprintf " complete\n")
           (hash-remove! *jobs* hash)
           (semaphore-post sema)]
@@ -480,7 +479,9 @@
       (define hash (sha1 (open-input-string 
        (string-append (symbol->string 'errors) formula-str))))
       (semaphore-wait (run-analyze hash formula seed pcontext sample))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define errs (job-result-backend result))
+      (hasheq 'points errs))))
 
 (define (run-exacts hash formula seed sample)
   (hash-set! *jobs* hash (*timeline*))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -452,7 +452,8 @@
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
        (parse-test formula)
-       (define hash (sha1 (open-input-string formula-str)))
+       (define hash (sha1 (open-input-string 
+        (string-append (symbol->string 'improve) formula-str))))
        (body hash formula))]
     [_
      (response/error "Demo Error"
@@ -518,7 +519,8 @@
       (define formula-str (hash-ref post-data 'formula))
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define seed (hash-ref post-data 'seed))
-      (define hash (sha1 (open-input-string formula-str)))
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'sample) formula-str))))
       (semaphore-wait (run-sample hash formula seed))
       (hash-ref *completed-jobs* hash))))
 
@@ -537,7 +539,8 @@
       (define seed (hash-ref post-data 'seed #f))
       (define test (parse-test formula))
       (define pcontext (json->pcontext sample (test-context test)))
-      (define hash (sha1 (open-input-string formula-str)))
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'errors) formula-str))))
       (semaphore-wait (run-analyze hash formula seed pcontext sample))
       (hash-ref *completed-jobs* hash))))
 
@@ -555,7 +558,8 @@
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define sample (hash-ref post-data 'sample))
       (define seed (hash-ref post-data 'seed #f))
-      (define hash (sha1 (open-input-string formula-str)))
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'exacts) formula-str))))
       (semaphore-wait (run-exacts hash formula seed sample))
       (hash-ref *completed-jobs* hash))))
 
@@ -572,7 +576,8 @@
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define sample (hash-ref post-data 'sample))
       (define seed (hash-ref post-data 'seed #f))
-      (define hash (sha1 (open-input-string formula-str)))
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'evaluate) formula-str))))
       (semaphore-wait (run-evaluate hash formula seed sample))
       (hash-ref *completed-jobs* hash))))
 
@@ -589,9 +594,8 @@
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define sample (hash-ref post-data 'sample))
       (define seed (hash-ref post-data 'seed #f))
-      ;; Should this hash the type of command as well?
-      ;; Conflict if job for local-error and errors of the same formual.
-      (define hash (sha1 (open-input-string formula-str)))
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'local-error) formula-str))))
       (semaphore-wait (run-local-error hash formula seed sample))
       (hash-ref *completed-jobs* hash))))
 
@@ -607,7 +611,9 @@
       (define formula-str (hash-ref post-data 'formula))
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define sample (hash-ref post-data 'sample))
-      (define seed (hash-ref post-data 'seed #f))    
+      (define seed (hash-ref post-data 'seed #f))   
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'alternatives) formula-str)))) 
       (semaphore-wait (run-alternatives hash formula seed sample))
       (hash-ref *completed-jobs* hash))))
 
@@ -633,7 +639,9 @@
     (lambda (post-data)
       (define formula-str (hash-ref post-data 'formula))
       (define formula (read-syntax 'web (open-input-string formula-str)))
-      (define seed (hash-ref post-data 'seed #f))    
+      (define seed (hash-ref post-data 'seed #f))   
+      (define hash (sha1 (open-input-string 
+       (string-append (symbol->string 'cost) formula-str))))  
       (semaphore-wait (run-cost hash formula))
       (hash-ref *completed-jobs* hash))))
 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -332,8 +332,7 @@
           (eprintf "Computing cost of ~a..." formula)
           (define result (run-herbie 'cost test 
           #:profile? #f #:timeline-disabled? #t))
-          (define cost (job-result-backend result))
-          (hash-set! *completed-jobs* hash (hasheq 'cost cost))
+          (hash-set! *completed-jobs* hash result)
           (eprintf " complete\n")
           (hash-remove! *jobs* hash)
           (semaphore-post sema)])
@@ -643,7 +642,9 @@
       (define hash (sha1 (open-input-string 
        (string-append (symbol->string 'cost) formula-str))))  
       (semaphore-wait (run-cost hash formula))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define cost (job-result-backend result))
+      (hasheq 'cost cost))))
 
 (define (run-demo #:quiet [quiet? #f] #:output output #:demo? demo? #:prefix prefix #:log log #:port port #:public? public)
   (*demo?* demo?)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -245,9 +245,7 @@
           (eprintf "Sampling job started on ~a..." formula)
           (define result (run-herbie 'sample test #:seed seed 
           #:profile? #f #:timeline-disabled? #t))
-          (define pctx (job-result-backend result))
-          (define result-hashtable (hasheq 'points (pcontext->json pctx (context-repr (test-context test)))))
-          (hash-set! *completed-jobs* hash result-hashtable)
+          (hash-set! *completed-jobs* hash result)
           (eprintf " complete\n")
           (hash-remove! *jobs* hash)
           (semaphore-post sema)]
@@ -459,7 +457,11 @@
       (define hash (sha1 (open-input-string 
        (string-append (symbol->string 'sample) formula-str))))
       (semaphore-wait (run-sample hash formula seed))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define pctx (job-result-backend result))
+      (define test (parse-test formula))
+      (hasheq 'points (pcontext->json pctx 
+       (context-repr (test-context test)))))))
 
 (define (run-analyze hash formula seed pcontext sample)
   (hash-set! *jobs* hash (*timeline*))


### PR DESCRIPTION
This PR includes the command symbol into the hash to help differentiate between a `'improve` job and an `'errors` job with the same formula.

Also a touch up to Indentation.