### PR TITLE
Printing data file when Determinism Test fails

### DIFF
--- a/infra/diff.rkt
+++ b/infra/diff.rkt
@@ -28,4 +28,6 @@
       (printf "Matching output expressions\n")]
      [else
       (printf "Output expressions do not match!!\n")
+      (printf " datafile1: ~a\n" df1)
+      (printf " datafile1: ~a\n" df2)
       (exit 1)])))


### PR DESCRIPTION
This is a simple PR that was meant to be added to the previous Report one.

Its main goal is to print the data file when the Determinism test fails.

Despite trying to recreate it locally, the tests don’t fail, but seemingly fails in the CI tests sometimes. This would better help us understand the source of the error.