### PR TITLE
Fix url for generate-report

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -70,7 +70,7 @@
 (define (generate-report req)
   (define data
     (for/list ([(k v) (in-hash *completed-jobs*)])
-      (get-table-data v (format "~a.~a" hash *herbie-commit*))))
+      (get-table-data v (format "~a.~a" k *herbie-commit*))))
   (define info (make-report-info data #:seed (get-seed) #:note (if (*demo?*) "Web demo results" "Herbie results")))
   (response 200 #"OK" (current-seconds) #"text"
             (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))


### PR DESCRIPTION
This PR fixes a subtle bug in `generate-report` where it is currently generating URL's like the following. 
`#<procedure:hash>.3d2f9b2771597ba020e32683e23e5e8fb9fe5752` 

where it should be generating something like. 
`6a7e2826cc8869174e6755073c26ecbd069c8ff6.3d2f9b2771597ba020e32683e23e5e8fb9fe5752`