### PR TITLE
Split the explanations function

### DIFF
--- a/src/.#explain.rkt
+++ b/src/.#explain.rkt
@@ -1,0 +1,1 @@
+bhargavkk@Bhargavs-Laptop.local.73424

--- a/src/.#explain.rkt
+++ b/src/.#explain.rkt
@@ -1,1 +1,0 @@
-bhargavkk@Bhargavs-Laptop.local.73424

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -73,9 +73,7 @@
                   (expr->cost simplified (repr-of subexpr ctx)))
                subexpr))
        > #:key car)))
-
   localize-costss)
-
 
 (define (batch-localize-errors exprs ctx)
   (define subexprss (map all-subexpressions exprs))

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -84,8 +84,7 @@
 
 (define (predict-errors ctx pctx
                         subexprs-list repr-hash subexprs-fn)
-
-(define error-count-hash
+  (define error-count-hash
     (make-hash (map (lambda (x) (cons x '())) subexprs-list)))
   (define uflow-hash (make-hash))
   (define oflow-hash (make-hash)) 

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -82,27 +82,10 @@
                         (eval-progs-real spec-list ctx-list)))
   (values subexprs-list repr-hash subexprs-fn))
 
-(define (predicted-errors expr ctx pctx)
-  
-  ;; (define subexprs
-  ;;   (all-subexpressions-rev expr (context-repr ctx)))
-  ;; (define subexprs-list (map car subexprs))
-  ;; (define spec-list (map prog->spec subexprs-list))
-  ;; (define ctx-list
-  ;;   (for/list ([subexpr (in-list subexprs)])
-  ;;     (struct-copy context ctx [repr (repr-of (car subexpr) ctx)])))
+(define (predict-errors ctx pctx
+                        subexprs-list repr-hash subexprs-fn)
 
-  ;; (define repr-hash
-  ;;   (make-immutable-hash (map cons
-  ;;                             subexprs-list
-  ;;                             (map context-repr ctx-list))))
-
-  ;; (define subexprs-fn (parameterize ([*max-mpfr-prec* 128])
-  ;;                       (eval-progs-real spec-list ctx-list)))
-
-  (define-values (subexprs-list repr-hash subexprs-fn) (compile-expr expr ctx pctx))
-  
-  (define error-count-hash
+(define error-count-hash
     (make-hash (map (lambda (x) (cons x '())) subexprs-list)))
   (define uflow-hash (make-hash))
   (define oflow-hash (make-hash)) 
@@ -622,6 +605,23 @@
            
            [else #f])]
         [_ #f])))
+  (values error-count-hash
+          expls->points
+          maybe-expls->points
+          oflow-hash
+          uflow-hash))
+
+(define (predicted-errors expr ctx pctx)
+  
+  (define-values (subexprs-list repr-hash subexprs-fn) (compile-expr expr ctx))
+  
+  (define-values (error-count-hash
+                  expls->points
+                  maybe-expls->points
+                  oflow-hash
+                  uflow-hash)
+    (predict-errors ctx pctx
+                    subexprs-list repr-hash subexprs-fn))
 
   (define tcount-hash (actual-errors expr pctx))
 

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -60,14 +60,13 @@
         'u/u 'u/n 'o/o 'n/o
         'o*u 'u*o 'n*u
         'cancellation))
+(define cond-thres (bf 100))
+(define maybe-cond-thres (bf 32))
 
-(define (predicted-errors expr ctx pctx)
-  (define cond-thres (bf 100))
-  (define maybe-cond-thres (bf 32))
-
-  
+(define (compile-expr expr ctx)
   (define subexprs
     (all-subexpressions-rev expr (context-repr ctx)))
+
   (define subexprs-list (map car subexprs))
   (define spec-list (map prog->spec subexprs-list))
   (define ctx-list
@@ -80,7 +79,28 @@
                               (map context-repr ctx-list))))
 
   (define subexprs-fn (parameterize ([*max-mpfr-prec* 128])
-                        (eval-progs-real spec-list ctx-list))) 
+                        (eval-progs-real spec-list ctx-list)))
+  (values subexprs-list repr-hash subexprs-fn))
+
+(define (predicted-errors expr ctx pctx)
+  
+  ;; (define subexprs
+  ;;   (all-subexpressions-rev expr (context-repr ctx)))
+  ;; (define subexprs-list (map car subexprs))
+  ;; (define spec-list (map prog->spec subexprs-list))
+  ;; (define ctx-list
+  ;;   (for/list ([subexpr (in-list subexprs)])
+  ;;     (struct-copy context ctx [repr (repr-of (car subexpr) ctx)])))
+
+  ;; (define repr-hash
+  ;;   (make-immutable-hash (map cons
+  ;;                             subexprs-list
+  ;;                             (map context-repr ctx-list))))
+
+  ;; (define subexprs-fn (parameterize ([*max-mpfr-prec* 128])
+  ;;                       (eval-progs-real spec-list ctx-list)))
+
+  (define-values (subexprs-list repr-hash subexprs-fn) (compile-expr expr ctx pctx))
   
   (define error-count-hash
     (make-hash (map (lambda (x) (cons x '())) subexprs-list)))

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -621,7 +621,7 @@
 
   (define tcount-hash (actual-errors expr pctx))
 
-  (define repr (repr-of expr context))
+  (define repr (repr-of expr (*context*)))
   (define (values->json vs repr)
     (map (lambda (value) (value->json value repr)) vs))
   

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -147,6 +147,9 @@
         (hash-set! flow-hash subexpr new-parent-set))
 
       (match subexpr
+        [(list _ x-ex y-ex z-ex)
+         (update-flow-hash oflow-hash bfinfinite? x-ex y-ex z-ex)
+         (update-flow-hash uflow-hash bfzero? x-ex y-ex z-ex)]
         [(list _ x-ex y-ex)
          (update-flow-hash oflow-hash bfinfinite? x-ex y-ex)
          (update-flow-hash uflow-hash bfzero? x-ex y-ex)]

--- a/src/explain.rkt
+++ b/src/explain.rkt
@@ -5,7 +5,7 @@
          "ground-truth.rkt" "syntax/sugar.rkt" "alternative.rkt" "programs.rkt"
          "float.rkt" "config.rkt")
 
-(provide predicted-errors)
+(provide explain)
 
 (define *top-3* (make-parameter #f))
 
@@ -730,7 +730,7 @@
           total-confusion-matrix
           freqs))
 
-(define (predicted-errors expr ctx pctx)
+(define (explain expr ctx pctx)
   (define-values (subexprs-list repr-hash subexprs-fn) (compile-expr expr ctx))
   
   (define-values (error-count-hash

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -364,7 +364,7 @@
   (define expr (alt-expr (car simplified)))
 
   (define-values (fperrors explanations-table confusion-matrix maybe-confusion-matrix total-confusion-matrix freqs)
-    (predicted-errors expr context pcontext))
+    (explain expr context pcontext))
 
   (for ([fperror (in-list fperrors)])
     (match-define (list expr truth opreds oex upreds uex) fperror)


### PR DESCRIPTION
This pull requests splits the main explanation function into three sub-functions with the eventual goal of exposing the explanation functionality as an endpoint for external use independent to other parts of Herbie(like Odyssey).