### PR TITLE
Move Sandbox.rkt Globals to Config.rkt

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -124,6 +124,12 @@
 ;; Plugins loaded locally rather than through Racket.
 (define *loose-plugins* (make-parameter '()))
 
+;; Sets the number of total points for Herbie to sample.
+(define *reeval-pts* (make-parameter 8000))
+
+;; Time out for a given run. 2.5 minutes currently.
+(define *timeout* (make-parameter (* 1000 60 5/2)))
+
 ;;; About Herbie:
 
 (define (run-command cmd)

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -36,9 +36,6 @@
 (struct improve-result (preprocess pctxs start target end bogosity))
 (struct alt-analysis (alt train-errors test-errors))
 
-(define *reeval-pts* (make-parameter 8000))
-(define *timeout* (make-parameter (* 1000 60 5/2)))
-
 ;; true if Racket CS <= 8.2
 (define cs-places-workaround?
   (let ([major (string->number (substring (version) 0 1))]

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -244,9 +244,7 @@
              (define test (parse-test formula))
              (eprintf "Sampling job started on ~a..." formula)
              (define result (run-herbie 'sample test #:seed seed #:profile? #f #:timeline-disabled? #t))
-             (define pctx (job-result-backend result))
-             (define result-hashtable (hasheq 'points (pcontext->json pctx (context-repr (test-context test)))))
-             (hash-set! *completed-jobs* hash result-hashtable)
+             (hash-set! *completed-jobs* hash result)
              (eprintf " complete\n")
              (hash-remove! *jobs* hash)
             (semaphore-post sema)])
@@ -397,7 +395,11 @@
       ;; Is this ok because we are multithreaded now?
       (set-seed! seed)
       (semaphore-wait (run-sample hash formula))
-      (hash-ref *completed-jobs* hash))))
+      (define result (hash-ref *completed-jobs* hash))
+      (define pctx (job-result-backend result))
+      (define test (parse-test formula))
+      (hasheq 'points (pcontext->json pctx 
+       (context-repr (test-context test)))))))
 
 (define analyze-endpoint
   (post-with-json-response

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -389,10 +389,7 @@
       (define formula-str (hash-ref post-data 'formula))
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define _hash (sha1 (open-input-string formula-str)))
-      ;; Hmm how should I pass seed?
-      ;; is it ok to use the seed set in the thread?
       (define _seed (hash-ref post-data 'seed))
-      ;; Is this ok because we are multithreaded now?
       (semaphore-wait (run-sample _hash formula _seed))
       (define result (hash-ref *completed-jobs* _hash))
       (define pctx (job-result-backend result))


### PR DESCRIPTION
This PR just moves the globals from Sandbox.rkt to Config.rkt to consolidate globals into one place.