### PR TITLE
Move sanbox.rkt globals to config.rkt

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -124,6 +124,12 @@
 ;; Plugins loaded locally rather than through Racket.
 (define *loose-plugins* (make-parameter '()))
 
+;; Sets the number of total points for Herbie to sample.
+(define *reeval-pts* (make-parameter 8000))
+
+;; Time out for a given run. 2.5 minutes currently.
+(define *timeout* (make-parameter (* 1000 60 5/2)))
+
 ;;; About Herbie:
 
 (define (run-command cmd)

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -36,9 +36,6 @@
 (struct improve-result (preprocess pctxs start target end bogosity))
 (struct alt-analysis (alt train-errors test-errors))
 
-(define *reeval-pts* (make-parameter 8000))
-(define *timeout* (make-parameter (* 1000 60 5/2)))
-
 ;; true if Racket CS <= 8.2
 (define cs-places-workaround?
   (let ([major (string->number (substring (version) 0 1))]


### PR DESCRIPTION
This PR just moves the globals from Sandbox.rkt to Config.rkt to consolidate globals into one place.