### PR TITLE
Hide `rival-machine` implementation details from the rest of Herbie

### DIFF
--- a/src/correct-round.rkt
+++ b/src/correct-round.rkt
@@ -209,6 +209,8 @@
 
         [(list 'cast x)  (list identity x)]
 
+        [(list 'assert x)  (list ival-assert x)]
+
         [(list op args ...)
          (error 'compile-specs "Unknown operator ~a" op)])))
 

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -10,7 +10,6 @@
          (struct-out exn:rival:unsamplable)
          rival-profile-iterations-taken
          (struct-out discretization))
-(provide (struct-out rival-machine)) ; This is temporary and we want to get rid of it
 
 (define ground-truth-require-convergence (make-parameter #t))
 


### PR DESCRIPTION
This PR continues the project of separating the sampling code from Herbie by making the `rival-machine` struct private.

The mechanism is pretty simple; the compiler now supports `assert` so instead of feeding in the precondition as `foo` we now feed it in as `(assert foo)`. If the precondition is ever false, then evaluating it will now error, which will make the point exit early as `invalid`.