### PR TITLE
Improve Herbie API endpoint testing

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -7,21 +7,48 @@ const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
 const eval_sample = [[[1], -1.4142135623730951]]
 
+const longRunningJob = `(FPCore (w h dX.u dX.v dY.u dY.v maxAniso)
+                          :precision binary32
+                          (let* ((t_0 (* (floor h) dX.v))
+                                (t_1 (* (floor w) dY.u))
+                                (t_2 (* (floor h) dY.v))
+                                (t_3 (* (floor w) dX.u))
+                                (t_4 (fmax (+ (* t_3 t_3) (* t_0 t_0)) (+ (* t_1 t_1) (* t_2 t_2))))
+                                (t_5 (sqrt t_4))
+                                (t_6 (fabs (- (* t_3 t_2) (* t_0 t_1)))))
+                            (log2
+                            (if (> (/ t_4 t_6) (floor maxAniso))
+                              (/ t_5 (floor maxAniso))
+                              (/ t_6 t_5)))))`
+
 // improve-start endpoint
 // TODO
 
 // improve endpoint
 // TODO
 
+/*
+INPROGRESS - ZE
 // Check status endpoint
-// TODO
+const idk = await fetch('http://127.0.0.1:8000/api/improve', { method: 'POST', body: JSON.stringify({ formula: longRunningJob, seed: 5 }) })
+// console.log(await idk)
+const jobID = `idk-yet`
+const checkStatus = await fetch(
+  `http://127.0.0.1:8000/check-status?${jobID}`,
+  { method: 'GET' })
+// console.log(checkStatus)
+*/
 
 // up endpoint
-// TODO
+const up = await fetch(
+  'http://127.0.0.1:8000/up',
+  { method: 'GET' })
+
+assert.equal('Up', up.statusText)
+// TODO how do I test down state?
 
 // Sample endpoint
-
-const sample = (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
+const sample = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
 
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)
@@ -35,9 +62,13 @@ assert.deepEqual(points[1], points2[1], `request with seed should always return 
 
 // Analyze endpoint
 
-const errors = (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
-  14.97651307489794
-], 0.12711304680349078]] }) })).json()).points  // HACK tiny sample
+const errors = (await (await fetch('http://127.0.0.1:8000/api/analyze', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: [[[
+      14.97651307489794
+    ], 0.12711304680349078]]
+  })
+})).json()).points  // HACK tiny sample
 
 assert.deepEqual(errors, [[[14.97651307489794], "2.3"]], `error shouldn't change;\n request was (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: ${FPCoreFormula}, sample: [[[
   14.97651307489794
@@ -45,41 +76,61 @@ assert.deepEqual(errors, [[[14.97651307489794], "2.3"]], `error shouldn't change
 
 // Local error endpoint
 
-const localError = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: sample2.points }) })).json())
+const localError = (await (await fetch('http://127.0.0.1:8000/api/localerror', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: sample2.points
+  })
+})).json())
 
 assert.equal(localError.tree['avg-error'] > 0, true)
 
 // Alternatives endpoint
 
-const alternatives = (await (await fetch('http://127.0.0.1:8000/api/alternatives', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
-  14.97651307489794
-], 0.12711304680349078]] }) })).json())  // HACK tiny sample
+const alternatives = (await (await fetch('http://127.0.0.1:8000/api/alternatives', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: [[[
+      14.97651307489794
+    ], 0.12711304680349078]]
+  })
+})).json())  // HACK tiny sample
 
 assert.equal(Array.isArray(alternatives.alternatives), true)
 
 // Exacts endpoint
 
-const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
+const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula2, sample: eval_sample
+  })
+})).json()).points
 
 assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
 
 // Calculate endpoint
 
-const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
+const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula2, sample: eval_sample
+  })
+})).json()).points
 
 assert.deepEqual(calculate, [[[1], -1.4142135623730951]])
 
 // Cost endpoint
 
-const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json())
+const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula2, sample: eval_sample
+  })
+})).json())
 assert.equal(cost.cost > 0, true)
 
 // MathJS endpoint
 
-const mathjs = (await (await fetch('http://127.0.0.1:8000/api/mathjs', { 
-	method: 'POST', 
-	body: JSON.stringify({ formula: FPCoreFormula})
-      })).json()).mathjs
+const mathjs = (await (await fetch('http://127.0.0.1:8000/api/mathjs', {
+  method: 'POST',
+  body: JSON.stringify({ formula: FPCoreFormula })
+})).json()).mathjs
 
 assert.equal(mathjs, "sqrt(x + 1.0) - sqrt(x)")
 
@@ -88,30 +139,38 @@ assert.equal(mathjs, "sqrt(x + 1.0) - sqrt(x)")
 const languageList = ["python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"]
 const actualExpressions = []
 const expectedExpressions = [
-    'def expr(x):\n\treturn math.sqrt((x + 1.0)) - math.sqrt(x)\n', // python
-    'double expr(double x) {\n\treturn sqrt((x + 1.0)) - sqrt(x);\n}\n', // c
-    'real(8) function expr(x)\n    real(8), intent (in) :: x\n    expr = sqrt((x + 1.0d0)) - sqrt(x)\nend function\n', // fortran
-    'public static double expr(double x) {\n\treturn Math.sqrt((x + 1.0)) - Math.sqrt(x);\n}\n', // java
-    'function expr(x)\n\treturn Float64(sqrt(Float64(x + 1.0)) - sqrt(x))\nend\n', // julia
-    'function tmp = expr(x)\n\ttmp = sqrt((x + 1.0)) - sqrt(x);\nend\n', // matlab
-    'expr[x_] := N[(N[Sqrt[N[(x + 1), $MachinePrecision]], $MachinePrecision] - N[Sqrt[x], $MachinePrecision]), $MachinePrecision]\n', // wls
-    '\\mathsf{expr}\\left(x\\right) = \\sqrt{x + 1} - \\sqrt{x}\n', // tex
-    'function expr(x) {\n\treturn Math.sqrt((x + 1.0)) - Math.sqrt(x);\n}\n' // js
+  'def expr(x):\n\treturn math.sqrt((x + 1.0)) - math.sqrt(x)\n', // python
+  'double expr(double x) {\n\treturn sqrt((x + 1.0)) - sqrt(x);\n}\n', // c
+  'real(8) function expr(x)\n    real(8), intent (in) :: x\n    expr = sqrt((x + 1.0d0)) - sqrt(x)\nend function\n', // fortran
+  'public static double expr(double x) {\n\treturn Math.sqrt((x + 1.0)) - Math.sqrt(x);\n}\n', // java
+  'function expr(x)\n\treturn Float64(sqrt(Float64(x + 1.0)) - sqrt(x))\nend\n', // julia
+  'function tmp = expr(x)\n\ttmp = sqrt((x + 1.0)) - sqrt(x);\nend\n', // matlab
+  'expr[x_] := N[(N[Sqrt[N[(x + 1), $MachinePrecision]], $MachinePrecision] - N[Sqrt[x], $MachinePrecision]), $MachinePrecision]\n', // wls
+  '\\mathsf{expr}\\left(x\\right) = \\sqrt{x + 1} - \\sqrt{x}\n', // tex
+  'function expr(x) {\n\treturn Math.sqrt((x + 1.0)) - Math.sqrt(x);\n}\n' // js
 ]
 
 for (const language of languageList) {
-    const translatedExpr = 
-        (await (await fetch('http://127.0.0.1:8000/api/translate',
-        { method: 'POST', body: JSON.stringify(
-        { formula: FPCoreFormula, language: language }) })).json())
+  const translatedExpr =
+    (await (await fetch('http://127.0.0.1:8000/api/translate',
+      {
+        method: 'POST', body: JSON.stringify(
+          { formula: FPCoreFormula, language: language })
+      })).json())
 
-    actualExpressions.push(translatedExpr)
+  actualExpressions.push(translatedExpr)
 }
 
 for (let i = 0; i < expectedExpressions.length; i++) {
-    assert.equal(actualExpressions[i].result, expectedExpressions[i])
+  assert.equal(actualExpressions[i].result, expectedExpressions[i])
 }
 
 // Results.json endpoint
 
-// TODO
+const jsonResults = await (await fetch(
+  'http://127.0.0.1:8000/results.json',
+  { method: 'GET' })).json()
+
+// Basic test that checks that there are the two results after the above test.
+// TODO add a way to reset the results.json file?
+assert.equal(jsonResults.tests.length, 1)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -2,27 +2,30 @@ import { strict as assert } from 'node:assert';  // use strict equality everywhe
 
 // Future TODO: before this API becomes set in stone/offered publically, we should change the results of these methods to be just the output data rather than duplicating input values.
 
-const sample = (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1))))', seed: 5 }) })).json())
+const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
+const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
+
+const sample = (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
 
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)
 const points = sample.points
 assert.equal(points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
 
-const sample2 = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1))))', seed: 5 }) })).json())
+const sample2 = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
 const points2 = sample2.points
 
-assert.deepEqual(points[1], points2[1], `request with seed should always return the same value;\nrequest was (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1))))', seed: 5 }) })).json())`)
+assert.deepEqual(points[1], points2[1], `request with seed should always return the same value;\nrequest was (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: ${FPCoreFormula2}, seed: 5 }) })).json())`)
 
-const errors = (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', sample: [[[
+const errors = (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
   14.97651307489794
 ], 0.12711304680349078]] }) })).json()).points  // HACK tiny sample
 
-assert.deepEqual(errors, [[[14.97651307489794], "2.3"]], `error shouldn't change;\n request was (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', sample: [[[
+assert.deepEqual(errors, [[[14.97651307489794], "2.3"]], `error shouldn't change;\n request was (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: ${FPCoreFormula}, sample: [[[
   14.97651307489794
 ], 0.12711304680349078]] }) })).json())`)
 
-const alternatives = (await (await fetch('http://127.0.0.1:8000/api/alternatives', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', sample: [[[
+const alternatives = (await (await fetch('http://127.0.0.1:8000/api/alternatives', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
   14.97651307489794
 ], 0.12711304680349078]] }) })).json())  // HACK tiny sample
 
@@ -30,31 +33,30 @@ assert.equal(Array.isArray(alternatives.alternatives), true)
 
 const mathjs = (await (await fetch('http://127.0.0.1:8000/api/mathjs', { 
 	method: 'POST', 
-	body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'})
+	body: JSON.stringify({ formula: FPCoreFormula})
       })).json()).mathjs
 
 assert.equal(mathjs, "sqrt(x + 1.0) - sqrt(x)")
 
 const eval_sample = [[[1], -1.4142135623730951]]
-const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", sample: eval_sample})})).json()).points
+const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
 
 assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
 
-const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", sample: eval_sample})})).json()).points
+const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
 
 assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
 
-const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", sample: eval_sample})})).json())
+const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json())
 
-const sample3 = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', seed: 5 }) })).json())
+const sample3 = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, seed: 5 }) })).json())
 
-const localerror = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', sample: sample2.points }) })).json())
+const localerror = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: sample2.points }) })).json())
 
 assert.equal(localerror.tree['avg-error'] > 0, true)
 assert.equal(cost.cost > 0, true)
 
 const languageList = ["python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"]
-const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const actualExpressions = []
 const expectedExpressions = [
     'def expr(x):\n\treturn math.sqrt((x + 1.0)) - math.sqrt(x)\n', // python

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -1,9 +1,25 @@
 import { strict as assert } from 'node:assert';  // use strict equality everywhere 
 
-// Future TODO: before this API becomes set in stone/offered publically, we should change the results of these methods to be just the output data rather than duplicating input values.
+// Future TODO: before this API becomes set in stone/offered publicly, we should change the results of these methods to be just the output data rather than duplicating input values.
 
+// Reusable testing data
 const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
+const eval_sample = [[[1], -1.4142135623730951]]
+
+// improve-start endpoint
+// TODO
+
+// improve endpoint
+// TODO
+
+// Check status endpoint
+// TODO
+
+// up endpoint
+// TODO
+
+// Sample endpoint
 
 const sample = (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
 
@@ -17,6 +33,8 @@ const points2 = sample2.points
 
 assert.deepEqual(points[1], points2[1], `request with seed should always return the same value;\nrequest was (await(await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: ${FPCoreFormula2}, seed: 5 }) })).json())`)
 
+// Analyze endpoint
+
 const errors = (await (await fetch('http://127.0.0.1:8000/api/analyze', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
   14.97651307489794
 ], 0.12711304680349078]] }) })).json()).points  // HACK tiny sample
@@ -25,11 +43,38 @@ assert.deepEqual(errors, [[[14.97651307489794], "2.3"]], `error shouldn't change
   14.97651307489794
 ], 0.12711304680349078]] }) })).json())`)
 
+// Local error endpoint
+
+const localError = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: sample2.points }) })).json())
+
+assert.equal(localError.tree['avg-error'] > 0, true)
+
+// Alternatives endpoint
+
 const alternatives = (await (await fetch('http://127.0.0.1:8000/api/alternatives', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: [[[
   14.97651307489794
 ], 0.12711304680349078]] }) })).json())  // HACK tiny sample
 
 assert.equal(Array.isArray(alternatives.alternatives), true)
+
+// Exacts endpoint
+
+const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
+
+assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
+
+// Calculate endpoint
+
+const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
+
+assert.deepEqual(calculate, [[[1], -1.4142135623730951]])
+
+// Cost endpoint
+
+const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json())
+assert.equal(cost.cost > 0, true)
+
+// MathJS endpoint
 
 const mathjs = (await (await fetch('http://127.0.0.1:8000/api/mathjs', { 
 	method: 'POST', 
@@ -38,21 +83,7 @@ const mathjs = (await (await fetch('http://127.0.0.1:8000/api/mathjs', {
 
 assert.equal(mathjs, "sqrt(x + 1.0) - sqrt(x)")
 
-const eval_sample = [[[1], -1.4142135623730951]]
-const exacts = (await (await fetch('http://127.0.0.1:8000/api/exacts', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
-
-assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
-
-const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
-
-assert.deepEqual(calculate, [[[1], -1.4142135623730951]])
-
-const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json())
-
-const localerror = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: sample2.points }) })).json())
-
-assert.equal(localerror.tree['avg-error'] > 0, true)
-assert.equal(cost.cost > 0, true)
+// Translate endpoint
 
 const languageList = ["python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"]
 const actualExpressions = []
@@ -80,3 +111,7 @@ for (const language of languageList) {
 for (let i = 0; i < expectedExpressions.length; i++) {
     assert.equal(actualExpressions[i].result, expectedExpressions[i])
 }
+
+// Results.json endpoint
+
+// TODO

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -45,11 +45,9 @@ assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
 
 const calculate = (await (await fetch('http://127.0.0.1:8000/api/calculate', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json()).points
 
-assert.deepEqual(exacts, [[[1], -1.4142135623730951]])
+assert.deepEqual(calculate, [[[1], -1.4142135623730951]])
 
 const cost = (await (await fetch('http://127.0.0.1:8000/api/cost', {method: 'POST', body: JSON.stringify({formula: FPCoreFormula2, sample: eval_sample})})).json())
-
-const sample3 = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, seed: 5 }) })).json())
 
 const localerror = (await (await fetch('http://127.0.0.1:8000/api/localerror', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula, sample: sample2.points }) })).json())
 


### PR DESCRIPTION
Improving `infra/testApi.mjs` to have a little more organize and robust API testing as the API surface of Herbie grows.

- Deduplicate formulas
- Reorganize the file order by API being tested at that point in the file.
- Add at least one test for each API

Future PR:
- More and better robust testing (open to suggestions)
- Concurrent testing of `improve-start` and `check-status`