### PR TITLE
Prepare for removal of sampling code

### DIFF
--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -81,6 +81,7 @@
 
 (define (rival-apply machine pt)
   (define discs (rival-machine-discs machine))
+  (set-rival-machine-bumps! machine 0)
   (let loop ([iter 0])
     (define exs
       (parameterize ([*sampling-iteration* iter]
@@ -91,7 +92,7 @@
       [err
        (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [(not err?)
-       (for/list ([ex (in-vector exs)] [disc (in-vector discs)])
+       (for/vector #:length (vector-length discs) ([ex (in-vector exs)] [disc (in-vector discs)])
          ; We are promised at this point that (distance (convert lo) (convert hi)) = 0 so use lo
          ([discretization-convert disc] (ival-lo ex)))]
       [(>= iter (*rival-max-iterations*))

--- a/src/ground-truth.rkt
+++ b/src/ground-truth.rkt
@@ -4,19 +4,21 @@
 
 (require "correct-round.rkt")
 
-(provide rival-compile rival-apply rival-analyze
-         (struct-out exn:rival)
-         (struct-out exn:rival:invalid)
-         (struct-out exn:rival:unsamplable)
-         (struct-out discretization)
-         *rival-max-precision* *rival-max-iterations*
-         rival-profile (struct-out execution) *rival-profile-executions*)
+(provide my-rival-compile my-rival-apply my-rival-analyze
+         (struct-out my-discretization)
+         (struct-out my-exn:rival)
+         (struct-out my-exn:rival:invalid)
+         (struct-out my-exn:rival:unsamplable)
+         *my-rival-max-precision*
+         *my-rival-max-iterations*
+         *my-rival-profile-executions*
+         my-rival-profile (struct-out my-execution))
 
 (define ground-truth-require-convergence (make-parameter #t))
 
 (define (is-samplable-interval disc interval)
-  (define convert (discretization-convert disc))
-  (define distance (discretization-distance disc))
+  (define convert (my-discretization-convert disc))
+  (define distance (my-discretization-distance disc))
   (define (close-enough? lo hi)
     (= (distance (convert lo) (convert hi)) 0))
   ((close-enough->ival close-enough?) interval))
@@ -42,21 +44,21 @@
       'unsamplable)
      y)))
 
-(define (rival-compile exprs vars discs)
+(define (my-rival-compile exprs vars discs)
   (compile-specs exprs vars discs))
 
-(struct exn:rival exn:fail ())
-(struct exn:rival:invalid exn:rival (pt))
-(struct exn:rival:unsamplable exn:rival (pt))
+(struct my-exn:rival exn:fail ())
+(struct my-exn:rival:invalid my-exn:rival (pt))
+(struct my-exn:rival:unsamplable my-exn:rival (pt))
 
 (define (ival-any-error? ivals)
   (for/fold ([out (ival-error? (vector-ref ivals 0))])
             ([iv (in-vector ivals 1)])
     (ival-or out (ival-error? iv))))
 
-(struct execution (name number precision time) #:prefab)
+(struct my-execution (name number precision time) #:prefab)
 
-(define (rival-profile machine param)
+(define (my-rival-profile machine param)
   (match param
     ['instructions (vector-length (rival-machine-instructions machine))]
     ['iterations (rival-machine-iteration machine)]
@@ -73,13 +75,13 @@
                       [number (in-vector profile-number 0 profile-ptr)]
                       [precision (in-vector profile-precision 0 profile-ptr)]
                       [time (in-vector profile-time 0 profile-ptr)])
-           (execution instruction number precision time))
+           (my-execution instruction number precision time))
        (set-rival-machine-profile-ptr! machine 0))]))
 
 (define (ival-real x)
   (ival x))
 
-(define (rival-apply machine pt)
+(define (my-rival-apply machine pt)
   (define discs (rival-machine-discs machine))
   (set-rival-machine-bumps! machine 0)
   (let loop ([iter 0])
@@ -90,17 +92,17 @@
     (match-define (ival err err?) (ival-any-error? exs))
     (cond
       [err
-       (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
+       (raise (my-exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [(not err?)
        (for/vector #:length (vector-length discs) ([ex (in-vector exs)] [disc (in-vector discs)])
          ; We are promised at this point that (distance (convert lo) (convert hi)) = 0 so use lo
-         ([discretization-convert disc] (ival-lo ex)))]
+         ([my-discretization-convert disc] (ival-lo ex)))]
       [(>= iter (*rival-max-iterations*))
-       (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
+       (raise (my-exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else
        (loop (+ 1 iter))])))
 
-(define (rival-analyze machine rect)
+(define (my-rival-analyze machine rect)
   (define res
     (parameterize ([*sampling-iteration* 0]
                    [ground-truth-require-convergence #f])

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -159,17 +159,17 @@
     (with-handlers
       ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
        [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])
-      (parameterize ([*rival-max-precision* (*max-mpfr-prec*)]
-                     [*rival-max-iterations* 5])
+      (parameterize ([*my-rival-max-precision* (*max-mpfr-prec*)]
+                     [*my-rival-max-iterations* 5])
         (values 'valid (rest (vector->list (rival-apply machine pt*))))))) ; rest = drop precondition
   (when (> (rival-profile machine 'bumps) 0)
     (warn 'ground-truth "Could not converge on a ground truth"
           #:extra (for/list ([var (in-list (context-vars (car ctxs)))] [val (in-list pt)])
                     (format "~a = ~a" var val))))
   (define executions (rival-profile machine 'executions))
-  (when (>= (vector-length executions) (*rival-profile-executions*))
+  (when (>= (vector-length executions) (*my-rival-profile-executions*))
     (warn 'profile "Rival profile vector overflowed, profile may not be complete"))
-  (define prec-threshold (exact-floor (/ (*rival-max-precision*) 25)))
+  (define prec-threshold (exact-floor (/ (*max-mpfr-prec*) 25)))
   (for ([execution (in-vector executions)])
     (define name (symbol->string (execution-name execution)))
     (define precision (- (execution-precision execution)

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -194,6 +194,7 @@
 ;; Part 3: computing exact values by recomputing at higher precisions
 
 (define (batch-prepare-points fn ctxs sampler)
+  (rival-profile fn 'executions) ; Clear profiling vector
   ;; If we're using the bf fallback, start at the max precision
   (define outcomes (make-hash))
 

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -157,8 +157,8 @@
       ((representation-repr->bf repr) val)))
   (define-values (status value)
     (with-handlers
-      ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
-       [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])
+      ([my-exn:rival:invalid? (lambda (e) (values 'invalid #f))]
+       [my-exn:rival:unsamplable? (lambda (e) (values 'exit #f))])
       (parameterize ([*my-rival-max-precision* (*max-mpfr-prec*)]
                      [*my-rival-max-iterations* 5])
         (values 'valid (rest (vector->list (my-rival-apply machine pt*))))))) ; rest = drop precondition
@@ -171,10 +171,10 @@
     (warn 'profile "Rival profile vector overflowed, profile may not be complete"))
   (define prec-threshold (exact-floor (/ (*max-mpfr-prec*) 25)))
   (for ([execution (in-vector executions)])
-    (define name (symbol->string (execution-name execution)))
-    (define precision (- (execution-precision execution)
-                         (remainder (execution-precision execution) prec-threshold)))
-    (timeline-push!/unsafe 'mixsample (execution-time execution) name precision))
+    (define name (symbol->string (my-execution-name execution)))
+    (define precision (- (my-execution-precision execution)
+                         (remainder (my-execution-precision execution) prec-threshold)))
+    (timeline-push!/unsafe 'mixsample (my-execution-time execution) name precision))
   (timeline-push!/unsafe 'outcomes (- (current-inexact-milliseconds) start)
                          (my-rival-profile machine 'iterations) (~a status) 1)
   (values status value))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -124,11 +124,11 @@
     (cons (λ () (map random-generate reprs)) (hash 'unknown 1.0))]))
 
 (define bool-discretization
-  (discretization identity
+  (my-discretization identity
                   (lambda (x y) (if (eq? x y) 0 1))))
 
 (define (representation->discretization repr)
-  (discretization
+  (my-discretization
    (representation-bf->repr repr)
    (lambda (x y) (- (ulp-difference x y repr) 1))))
 

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -174,7 +174,7 @@
     (define name (symbol->string (execution-name execution)))
     (define precision (- (execution-precision execution)
                          (remainder (execution-precision execution) prec-threshold)))
-    (timeline-push! 'mixsample (execution-time execution) name precision))
+    (timeline-push!/unsafe 'mixsample (execution-time execution) name precision))
   (timeline-push!/unsafe 'outcomes (- (current-inexact-milliseconds) start)
                          (my-rival-profile machine 'iterations) (~a status) 1)
   (values status value))

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -161,7 +161,7 @@
        [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])
       (parameterize ([*rival-max-precision* (*max-mpfr-prec*)]
                      [*rival-max-iterations* 5])
-        (values 'valid (rest (rival-apply machine pt*)))))) ; rest = drop precondition
+        (values 'valid (rest (vector->list (rival-apply machine pt*))))))) ; rest = drop precondition
   (when (> (rival-profile machine 'bumps) 0)
     (warn 'ground-truth "Could not converge on a ground truth"
           #:extra (for/list ([var (in-list (context-vars (car ctxs)))] [val (in-list pt)])

--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -39,7 +39,7 @@
   (define reprs (context-var-reprs ctx))
   (define-values (true* false* other*)
     (for/fold ([true* true] [false* false] [other* '()]) ([rect (in-list other)])
-      (match-define (ival err err?) (rival-analyze ival-fn (list->vector rect)))
+      (match-define (ival err err?) (my-rival-analyze ival-fn (list->vector rect)))
       (when (eq? err 'unsamplable)
         (warn 'ground-truth #:url "faq.html#ground-truth"
               "could not determine a ground truth"


### PR DESCRIPTION
This PR prepares for adding sampling code into Rival, in a few ways:

- It fixes all extant bugs and warnings
- It renames all of Herbie's sampling code identifiers to not conflict.

I've tested this code to work even when the updated Rival code is installed.