### PR TITLE
Fix job-id collision

### DIFF
--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -37,7 +37,7 @@
           (override-test-precision the-test (*precision*))
           the-test))
     (define result (run-herbie 'improve the-test* #:seed seed))
-    (match-define (job-result test status time timeline warnings backend) result)
+    (match-define (job-result _ test status time timeline warnings backend) result)
     (match status
       ['success
        (match-define 

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -50,7 +50,7 @@
    [_ #f]))
 
 (define (make-graph result out output? fpcore? profile?)
-  (match-define (job-result test _ time _ warnings backend) result)
+  (match-define (job-result _ test _ time _ warnings backend) result)
   (define vars (test-vars test))
   (define repr (test-output-repr test))
   (define repr-bits (representation-total-bits repr))

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -45,7 +45,7 @@
      (make-points-json result out ctx)]))
 
 (define (get-interactive-js result ctx)
-  (match-define (job-result _ _ _ _ _ 
+  (match-define (job-result _ _ _ _ _ _
                  (improve-result _ _ start _ end _)) result)
   (define start-expr (alt-expr (alt-analysis-alt start)))
   (define end-expr (alt-expr (alt-analysis-alt (car end))))
@@ -69,7 +69,7 @@
   (string->number (real->decimal-string (ulps->bits x) 1)))
 
 (define (make-points-json result out repr)
-  (match-define (job-result test _ _ _ _ 
+  (match-define (job-result _ test _ _ _ _ 
                  (improve-result _ pctxs start targets end _) ) result)
   (define repr (test-output-repr test))
   (define start-errors (alt-analysis-test-errors start))

--- a/src/web/traceback.rkt
+++ b/src/web/traceback.rkt
@@ -7,7 +7,7 @@
 
 (define (make-traceback result out profile?)
   ;; Called with timeout or failure results
-  (match-define (job-result test status time timeline warnings backend) result)
+  (match-define (job-result command test status time timeline warnings backend) result)
   (define exn (if (eq? status 'failure) backend 'timeout))
 
   (fprintf out "<!doctype html>\n")


### PR DESCRIPTION
This PR re-merges changes from #825 that were missed from chained merges.
Also fixes bug for jobs with the same `hash`/`job-id` but different commands used.