### PR TITLE
Fix Rival bindings

### DIFF
--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -78,7 +78,7 @@
   (hash-set! out 'unknown (exact->inexact (/ other-weight denom)))
   (for ([(reason rect) (in-dict false)])
     (define weight (exact->inexact (/ (hyperrect-weight rect reprs) denom)))
-    (hash-update! out reason (curry + weight) 0))
+    (hash-update! out (or reason 'invalid) (curry + weight) 0))
   (define total (apply + (hash-values out)))
   (hash-update! out 'precondition (curry + (- 1 total)) 0)
   (make-immutable-hash (hash->list out)))

--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -53,7 +53,7 @@
                 (format "~a = ~a" var val))))
       (cond
        [err
-        (values true* (cons (cons err rect) false*) other*)]
+        (values true* (cons rect false*) other*)]
        [(not err?)
         (values (cons rect true*) false* other*)]
        [else
@@ -72,13 +72,12 @@
   (define reprs (context-var-reprs ctx))
   (define denom (total-weight reprs))
   (define true-weight (apply + (map (curryr hyperrect-weight reprs) true)))
+  (define false-weight (apply + (map (curryr hyperrect-weight reprs) false)))
   (define other-weight (apply + (map (curryr hyperrect-weight reprs) other)))
   (define out (make-hash))
   (hash-set! out 'valid (exact->inexact (/ true-weight denom)))
   (hash-set! out 'unknown (exact->inexact (/ other-weight denom)))
-  (for ([(reason rect) (in-dict false)])
-    (define weight (exact->inexact (/ (hyperrect-weight rect reprs) denom)))
-    (hash-update! out (or reason 'invalid) (curry + weight) 0))
+  (hash-set! out 'invalid (exact->inexact (/ false-weight denom)))
   (define total (apply + (hash-values out)))
   (hash-update! out 'precondition (curry + (- 1 total)) 0)
   (make-immutable-hash (hash->list out)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -442,12 +442,12 @@
 
 (define-ruleset* pow-reduce-fp-safe (exponents simplify fp-safe sound)
   #:type ([a real])
-  [unpow1         (pow a 1)                  a]
-  [pow-base-1     (pow 1 a)                  1])
+  [unpow1         (pow a 1)                  a])
 
 (define-ruleset* pow-reduce-fp-safe-nan (exponents simplify fp-safe-nan sound)
   #:type ([a real])
-  [unpow0         (pow a 0)                  1])
+  [unpow0         (pow a 0)                  1]
+  [pow-base-1     (pow 1 a)                  1])
 
 (define-ruleset* pow-expand-fp-safe (exponents fp-safe sound)
   #:type ([a real])


### PR DESCRIPTION
I updated Rival to no longer provide "explanations" for domain errors; Herbie needs some changes (simplifications) to handle this correctly.