### PR TITLE
Track memory usage per-phase

### DIFF
--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -35,14 +35,17 @@
     (hash-update! (car (unbox (*timeline*))) *timeline-active-key*
                   (curry append *timeline-active-value*) '())
     (set! *timeline-active-key* #f))
-  
+
   (unless (*timeline-disabled*)
     (when (pair? (unbox (*timeline*)))
       (for ([key (in-list always-compact)]
             #:when (hash-has-key? (car (unbox (*timeline*))) key))
         (timeline-compact! key)))
+    (define live-memory (current-memory-use #f))
+    (define alloc-memory (current-memory-use 'cumulative))
     (define b (make-hasheq (list (cons 'type (~a type))
-                                 (cons 'time (current-inexact-milliseconds)))))
+                                 (cons 'time (current-inexact-milliseconds))
+                                 (cons 'memory (list (list live-memory alloc-memory))))))
     (set-box! (*timeline*) (cons b (unbox (*timeline*))))))
 
 (define (timeline-push! key . values)
@@ -100,6 +103,9 @@
 (define (timeline-load! value)
   (*timeline* value))
 
+(define (diff-memory-records v1 v2)
+  (list (list (- (caar v1) (caar v2)) (- (cadar v1) (cadar v2)))))
+
 (define (timeline-extract)
   (when *timeline-1st-timer* (*timeline-1st-timer*))
   (when *timeline-2nd-timer* (*timeline-2nd-timer*))
@@ -108,11 +114,15 @@
                   (curry append *timeline-active-value*) '())
     (set! *timeline-active-key* #f))
   (for ([end! (set->list *timeline-timers*)]) (end!))
-  (define end (hasheq 'time (current-inexact-milliseconds)))
+  (define end
+    (hasheq 'time (current-inexact-milliseconds)
+            'memory (list (list (current-memory-use #f)
+                                (current-memory-use 'cumulative)))))
   (reverse
    (for/list ([evt (unbox (*timeline*))] [next (cons end (unbox (*timeline*)))])
      (define evt* (hash-copy evt))
      (hash-update! evt* 'time (λ (v) (- (hash-ref next 'time) v)))
+     (hash-update! evt* 'memory (λ (v) (diff-memory-records (hash-ref next 'memory) v)))
      evt*)))
 
 (define (timeline-relink link timeline)
@@ -173,6 +183,7 @@
 (define-timeline type #:custom (λ (a b) a))
 (define-timeline time #:custom +)
 
+(define-timeline memory [live +] [alloc +])
 (define-timeline method [method])
 (define-timeline mixsample [time +] [function false] [precision false])
 (define-timeline rules [rule false] [count +])

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -55,6 +55,7 @@
             (span ([class "time"])
                   ,(format-time time) " (" ,(format-percent time total-time) ")"))
         (dl
+         ,@(dict-call curr render-phase-memory 'memory)
          ,@(dict-call curr render-phase-algorithm 'method)
          ,@(dict-call curr render-phase-locations 'locations)
          ,@(dict-call curr render-phase-accuracy 'accuracy 'oracle 'baseline 'name 'link 'repr)
@@ -299,6 +300,12 @@
               (td ,(~r (apply + (map (curryr altnum 0) '(new fresh picked done))) #:group-sep " "))
               (td ,(~r (apply + (map (curryr altnum 1) '(new fresh picked done))) #:group-sep " "))
               (td ,(~r (apply + (map altnum '(new fresh picked done))) #:group-sep " "))))))))
+
+(define (render-phase-memory mem)
+  (match-define (list live alloc) (car mem))
+  `((dt "Memory")
+    (dd ,(~r (/ live (expt 2 20)) #:group-sep " " #:precision '(= 1)) "MiB live, "
+        ,(~r (/ alloc (expt 2 20)) #:group-sep " " #:precision '(= 1)) "MiB allocated")))
 
 (define (render-phase-error min-error-table)
   (match-define (list min-error repr-name) (car min-error-table))


### PR DESCRIPTION
This PR tracks live and allocated memory at the end of each phase, and shows the results in the timeline:

![image](https://github.com/herbie-fp/herbie/assets/30707/041c8f47-073b-446f-bfda-56a9a1f067ef)

The hope is that, if we lower memory usage, we'll have fewer garbage collections, which will lead both to faster code and also to fewer synchronizations in multithreaded code so more parallelism.