### PR TITLE
Only provide two options from simplify (initial & simplest)

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -379,8 +379,7 @@
         (for/list ([id node-ids] [expr (egraph-query-exprs input)])
           (egraph-get-variants egg-graph id expr ctx))
         (for/list ([id node-ids])
-          (for/list ([iter (in-range (length iter-data))])
-            (egraph-get-simplest egg-graph id iter ctx)))))
+          (egraph-get-simplest egg-graph id (- (length iter-data) 1) ctx))))
   
   (define proofs
     (for/list ([proof-input (in-list proof-inputs)])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -20,7 +20,7 @@
 
   (define out
     (for/list ([result results] [expr (egraph-query-exprs input)])
-      (remove-duplicates (cons expr result))))
+      (remove-duplicates (cons expr (list result)))))
   (timeline-push! 'outputs (map ~a (apply append out)))
     
   out)


### PR DESCRIPTION
This PR basically undoes commit [4e4cda15](https://github.com/herbie-fp/herbie/commit/4e4cda15dedee719eb55596097c9e4bbbecd7cc7) (possibly #485). Basically, right now, simplify returns a list of outputs, one per iter. This is wasteful for a few reasons:

- We need to parse each output, which takes a while and allocates memory
- We also need to convert each output from egg IR to Herbie IR
- We mostly don't use these intermediate, half-simplified expressions

As soundness of simplify has improved, I think we can probably remove this, making Herbie faster.