### PR TITLE
Job server public API introduction.

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -13,13 +13,15 @@
          "../syntax/sugar.rkt" "../alternative.rkt" "../points.rkt"
          "../programs.rkt" "../sandbox.rkt" "../float.rkt")
 (require "../datafile.rkt" "pages.rkt" "make-report.rkt"
-         "common.rkt" "core2mathjs.rkt" "history.rkt" "plot.rkt")
+         "common.rkt" "core2mathjs.rkt" "history.rkt" "plot.rkt" "server.rkt")
 (require (submod "../timeline.rkt" debug))
 
 (provide run-demo)
 
 (define *demo-prefix* (make-parameter "/"))
 (define *demo-log* (make-parameter false))
+(define *demo?* (make-parameter false))
+(define *demo-output* (make-parameter false))
 
 (define (add-prefix url)
   (string-replace (string-append (*demo-prefix*) url) "//" "/"))
@@ -54,152 +56,6 @@
    [((hash-arg) (string-arg)) generate-page]
    [("results.json") generate-report]))
 
-#| 
-Job Server Public API section
-
-This section just servers as a place for us to create the API's but give a
-|#
-
-;; Job object, What herbie excepts as input for a new job.
-
-;; TODO rename to herbie-command
-(struct herbie-command 
- (command formula seed pcontext profile? timeline-disabled?) #:transparent)
-
-;; Creates a command object to be passed to start-job server.
-;; TODO contract?
-(define (create-job command formula 
-                    #:seed [seed #f] 
-                    #:pcontext [pcontext #f]
-                    #:profile? [profile? #f]
-                    #:timeline-disabled? [timeline-disabled? #f])
-  (herbie-command command formula seed pcontext profile? timeline-disabled?))
-
-;; Starts a job for a given command object
-(define (start-job command)
-  (start-work command))
-#| 
-Not ready for this API yet as i'm not sure how syncing with this abstraction will work. I could try using semaphores as the current server does.
-|#
-(define (wait-for-job job-id)
-  #| Where should we store job ids
-  How does access control in Racket work?
-  |#
-  (eprintf "Waiting for job\n")
-  (define sema (hash-ref *job-semma* job-id))
-  (semaphore-wait sema)
-  (hash-remove! *job-semma* job-id)
-  (hash-ref *completed-jobs* job-id))
-
-(define (is-job-finished job-id)
-#| Not really sure what this should return yet. s|#
- (hash-ref *job-status* job-id #f))
-
-(define (job-count)
- (hash-count *job-status*))
-
-(define (start-job-server config global-demo global-output)
- (set! *demo?* global-demo)
- (set! *demo-output* global-output)
- (thread-send *worker-thread* config))
-(define (is-server-up)
- (thread-running? *worker-thread*))
-
-; Helers to isolated *completed-jobs*
-(define (helper what-ever) 
- (hash-has-key? *completed-jobs* what-ever))
-(define (helper2 what-ever) 
- (hash-ref *completed-jobs* what-ever))
-(define (helper3)
-  (in-hash *completed-jobs*))
-
-(define (compute-job-id job-info)
- (sha1 (open-input-string (~s job-info))))
-
-; public but not sure how to make private yet
-(define *demo?* (make-parameter false))
-(define *demo-output* (make-parameter false))
-;; Private 
-; globals
-; TODO I'm sure these can encapslated some how.
-(define *completed-jobs* (make-hash))
-(define *job-status* (make-hash))
-(define *job-semma* (make-hash))
-
-;; Helpers 
-; Handles semaphore and async part of a job
-(struct work (id job sema))
-
-; Encapsulates semaphores and async part of jobs.
-(define (start-work job)
- (define job-id (compute-job-id job))
- (hash-set! *job-status* job-id (*timeline*))
- (define sema (make-semaphore))
- (hash-set! *job-semma* job-id sema)
- (thread-send *worker-thread* (work job-id job sema))
- job-id)
-
-(define *worker-thread*
- (thread
-  (λ ()
-    (let loop ([seed #f])
-      (match (thread-receive)
-        [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
-                timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
-        (set! seed vec)
-        (*flags* flag-table)
-        (*num-iterations* iterations)
-        (*num-points* points)
-        (*timeout* timeout)
-        (*demo-output* output)
-        (*reeval-pts* reeval)
-        (*demo?* demo?)]
-        [job-info (run-job job-info)])
-      (loop seed)))))
-
-(define (run-job job-info)
- (match-define (work job-id info sema) job-info)
- (define path (format "~a.~a" job-id *herbie-commit*))
- (cond ;; Check caches if job as already been completed
-  ; [(hash-has-key? *completed-jobs* job-id)
-  ;  (semaphore-post sema)]
-  ; [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
-  ;  (semaphore-post sema)]
-  [else (wrapper-run-herbie info job-id)
-   (hash-remove! *job-status* job-id)
-   (semaphore-post sema)])
- (hash-remove! *job-semma* job-id))
-
-(define (wrapper-run-herbie cmd job-id)
-  (print-job-message (herbie-command-command cmd) job-id (syntax->datum (herbie-command-formula cmd)))
-  (define result (run-herbie 
-   (herbie-command-command cmd)
-   (parse-test (herbie-command-formula cmd))
-   #:seed (herbie-command-seed cmd)
-   #:pcontext (herbie-command-pcontext cmd)
-   #:profile? (herbie-command-profile? cmd)
-   #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
-  (hash-set! *completed-jobs* job-id result)
-  (eprintf "Job ~a complete\n" job-id))
-
-(define (print-job-message command job-id job-str)
-  (define job-label
-    (match command 
-      ['alternatives "Alternatives"]
-      ['evaluate "Evaluation"]
-      ['cost "Computing"]
-      ['errors "Analyze"]
-      ['exacts "Ground truth"]
-      ['improve "Improve"]
-      ['local-error "Local error"]
-      ['sample "Sampling"]
-      [_ (error 'compute-result "unknown command ~a" command)]))
-  (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label (symbol->string command) job-id job-str))
-
-(define (job-done? job-id)
-  (hash-has-key? *completed-jobs* job-id))
-
-;; End Job Server section
 
 ;; TODO figure out what to do with *demo-output*
 (define (already-computed? job-id)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -30,10 +30,10 @@
   (λ (x)
     (and (not (*demo-output*))
          (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
-           (and m (helper (second m))))))
+           (and m (completed-job? (second m))))))
   (λ (x)
     (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
-      (helper2 (if m (second m) x)))))
+      (remove-me (if m (second m) x)))))
 
 (define-bidi-match-expander hash-arg hash-arg/m hash-arg/m)
 
@@ -82,7 +82,7 @@
 
 (define (generate-report req)
   (define data
-    (for/list ([(k v) (helper3)]
+    (for/list ([(k v) (remove-me2)]
       #:when (equal? (job-result-command v) 'improve))
        (get-table-data v (format "~a.~a" k *herbie-commit*))))
   (define info (make-report-info data #:seed (get-seed) #:note (if (*demo?*) "Web demo results" "Herbie results")))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -98,7 +98,9 @@ Not ready for this API yet as i'm not sure how syncing with this abstraction wil
 (define (job-count)
  (hash-count *job-status*))
 
-(define (start-job-server config)
+(define (start-job-server config global-demo global-output)
+ (set! *demo?* global-demo)
+ (set! *demo-output* global-output)
  (thread-send *worker-thread* config))
 (define (is-server-up)
  (thread-running? *worker-thread*))
@@ -115,8 +117,8 @@ Not ready for this API yet as i'm not sure how syncing with this abstraction wil
  (sha1 (open-input-string (~s job-info))))
 
 ; public but not sure how to make private yet
-(define *demo-output* (make-parameter false))
 (define *demo?* (make-parameter false))
+(define *demo-output* (make-parameter false))
 ;; Private 
 ; globals
 ; TODO I'm sure these can encapslated some how.
@@ -159,10 +161,10 @@ Not ready for this API yet as i'm not sure how syncing with this abstraction wil
  (match-define (work job-id info sema) job-info)
  (define path (format "~a.~a" job-id *herbie-commit*))
  (cond ;; Check caches if job as already been completed
-  [(hash-has-key? *completed-jobs* job-id)
-   (semaphore-post sema)]
-  [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
-   (semaphore-post sema)]
+  ; [(hash-has-key? *completed-jobs* job-id)
+  ;  (semaphore-post sema)]
+  ; [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
+  ;  (semaphore-post sema)]
   [else (wrapper-run-herbie info job-id)
    (hash-remove! *job-status* job-id)
    (semaphore-post sema)])
@@ -674,7 +676,7 @@ Not ready for this API yet as i'm not sure how syncing with this abstraction wil
   (define config
     `(init rand ,(get-seed) flags ,(*flags*) num-iters ,(*num-iterations*) points ,(*num-points*)
            timeout ,(*timeout*) output-dir ,(*demo-output*) reeval ,(*reeval-pts*) demo? ,(*demo?*)))
-  (start-job-server config)
+  (start-job-server config *demo?* *demo-output* )
 
   (eprintf "Herbie ~a with seed ~a\n" *herbie-version* (get-seed))
   (eprintf "Find help on https://herbie.uwplse.org/, exit with Ctrl-C\n")

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -9,12 +9,10 @@
          web-server/managers/none)
 
 (require "../common.rkt" "../config.rkt" "../syntax/read.rkt" "../errors.rkt")
-(require "../syntax/syntax-check.rkt" "../syntax/type-check.rkt" "../syntax/types.rkt"
-         "../syntax/sugar.rkt" "../alternative.rkt" "../points.rkt"
-         "../programs.rkt" "../sandbox.rkt" "../float.rkt")
+(require "../syntax/types.rkt"
+         "../syntax/sugar.rkt" "../alternative.rkt" "../points.rkt" "../sandbox.rkt" "../float.rkt")
 (require "../datafile.rkt" "pages.rkt" "make-report.rkt"
          "common.rkt" "core2mathjs.rkt" "history.rkt" "plot.rkt" "server.rkt")
-(require (submod "../timeline.rkt" debug))
 
 (provide run-demo)
 

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -18,14 +18,13 @@
 
 (provide run-demo)
 
-(define *demo?* (make-parameter false))
 (define *demo-prefix* (make-parameter "/"))
-(define *demo-output* (make-parameter false))
 (define *demo-log* (make-parameter false))
 
 (define (add-prefix url)
   (string-replace (string-append (*demo-prefix*) url) "//" "/"))
 
+; TODO replace (hash-has-key? *completed-jobs* ..
 (define-coercion-match-expander hash-arg/m
   (λ (x)
     (and (not (*demo-output*))
@@ -56,6 +55,148 @@
    [((hash-arg) (string-arg)) generate-page]
    [("results.json") generate-report]))
 
+#| 
+Job Server Public API section
+
+This section just servers as a place for us to create the API's but give a
+|#
+
+;; Job object, What herbie excepts as input for a new job.
+
+;; TODO rename to herbie-command
+(struct run-herbie-command 
+ (command formula seed pcontext profile? timeline-disabled?) #:transparent)
+
+;; Creates a command object to be passed to start-job server.
+;; TODO contract?
+(define (create-job command formula 
+                    #:seed [seed #f] 
+                    #:pcontext [pcontext #f]
+                    #:profile? [profile? #f]
+                    #:timeline-disabled? [timeline-disabled? #f])
+  (run-herbie-command command formula seed pcontext profile? timeline-disabled?))
+
+;; Starts a job for a given command object
+(define (start-job command)
+  (start-work command))
+#| 
+Not ready for this API yet as i'm not sure how syncing with this abstraction will work. I could try using semaphores as the current server does.
+|#
+(define (wait-for-job job-id)
+  #| Where should we store job ids
+  How does access control in Racket work?
+  |#
+  (eprintf "Waiting for job\n")
+  (define sema (hash-ref *job-semma* job-id))
+  (semaphore-wait sema)
+  (hash-remove! *job-semma* job-id)
+  (hash-ref *completed-jobs* job-id))
+
+(define (get-finnished-jobs)
+ (in-hash *completed-jobs*))
+
+(define (is-job-finished job-id)
+#| Not really sure what this should return yet. s|#
+ (hash-ref *job-status* job-id #f))
+
+(define (job-count)
+ (hash-count *job-status*))
+
+(define (start-job-server config)
+ (thread-send *worker-thread* config))
+(define (is-server-up)
+ (thread-running? *worker-thread*))
+
+(define (compute-job-id job-info)
+ (sha1 (open-input-string (~s job-info))))
+
+; public but not sure how to make private yet
+(define *demo-output* (make-parameter false))
+(define *demo?* (make-parameter false))
+;; Private 
+; globals
+; TODO I'm sure these can encapslated some how.
+(define *completed-jobs* (make-hash))
+(define *job-status* (make-hash))
+(define *job-semma* (make-hash))
+
+;; Helpers 
+; Handles semaphore and async part of a job
+(struct work (id job sema))
+
+; Encapsulates semaphores and async part of jobs.
+(define (start-work job)
+ (define job-id (compute-job-id job))
+ (hash-set! *job-status* job-id (*timeline*))
+ (define sema (make-semaphore))
+ (hash-set! *job-semma* job-id sema)
+ (thread-send *worker-thread* (work job-id job sema))
+ job-id)
+
+(define *worker-thread*
+ (thread
+  (λ ()
+    (let loop ([seed #f])
+      (match (thread-receive)
+        [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
+                timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
+        (set! seed vec)
+        (*flags* flag-table)
+        (*num-iterations* iterations)
+        (*num-points* points)
+        (*timeout* timeout)
+        (*demo-output* output)
+        (*reeval-pts* reeval)
+        (*demo?* demo?)]
+        [job-info (run-job job-info)])
+      (loop seed)))))
+
+(define (run-job job-info)
+ (match-define (work job-id info sema) job-info)
+ (define path (format "~a.~a" job-id *herbie-commit*))
+ (cond ;; Check caches if job as already been completed
+  [(hash-has-key? *completed-jobs* job-id)
+   (semaphore-post sema)]
+  [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
+   (semaphore-post sema)]
+  [else (wrapper-run-herbie info job-id)
+   (hash-remove! *job-status* job-id)
+   (semaphore-post sema)])
+ (hash-remove! *job-semma* job-id))
+
+(define (wrapper-run-herbie cmd job-id)
+  (print-job-message (run-herbie-command-command cmd) job-id (syntax->datum (run-herbie-command-formula cmd)))
+  (define result (run-herbie 
+   (run-herbie-command-command cmd)
+   (parse-test (run-herbie-command-formula cmd))
+   #:seed (run-herbie-command-seed cmd)
+   #:pcontext (run-herbie-command-pcontext cmd)
+   #:profile? (run-herbie-command-profile? cmd)
+   #:timeline-disabled? (run-herbie-command-timeline-disabled? cmd)))
+  (hash-set! *completed-jobs* job-id result)
+  (eprintf "Job ~a complete\n" job-id))
+
+(define (print-job-message command job-id job-str)
+  (define job-label
+    (match command 
+      ['alternatives "Alternatives"]
+      ['evaluate "Evaluation"]
+      ['cost "Computing"]
+      ['errors "Analyze"]
+      ['exacts "Ground truth"]
+      ['improve "Improve"]
+      ['local-error "Local error"]
+      ['sample "Sampling"]
+      [_ (error 'compute-result "unknown command ~a" command)]))
+  (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label (symbol->string command) job-id job-str))
+
+(define (already-computed? job-id)
+  (or (hash-has-key? *completed-jobs* job-id)
+      (and (*demo-output*)
+           (directory-exists? (build-path (*demo-output*) (format "~a.~a" job-id *herbie-commit*))))))
+
+;; End Job Server section
+
 (define (generate-page req results page)
   (match-define result results)
   (define path (string-split (url->string (request-uri req)) "/"))
@@ -73,7 +214,7 @@
                       (build-path (*demo-output*) "results.json")
                       (build-path (*demo-output*) "index.html")))
     (response 200 #"OK" (current-seconds) #"text"
-              (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+              (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
               (λ (out)
                 (with-handlers ([exn:fail? (page-error-handler result page out)])
                 (make-page page out result (*demo-output*) #f))))]
@@ -82,12 +223,13 @@
 
 (define (generate-report req)
   (define data
+    ; TODO replace with (in-hash *completed-jobs*)
     (for/list ([(k v) (in-hash *completed-jobs*)]
       #:when (equal? (job-result-command v) 'improve))
        (get-table-data v (format "~a.~a" k *herbie-commit*))))
   (define info (make-report-info data #:seed (get-seed) #:note (if (*demo?*) "Web demo results" "Herbie results")))
   (response 200 #"OK" (current-seconds) #"text"
-            (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+            (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
             (λ (out) (write-datafile out info))))
 
 (define url (compose add-prefix url*))
@@ -127,7 +269,7 @@
     (make-directory (*demo-output*)))
 
   (response/xexpr
-   #:headers (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+   #:headers (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
    (herbie-page
     #:title (if (*demo?*) "Herbie web demo" "Herbie")
     #:show-title (*demo?*)
@@ -139,7 +281,7 @@
        (a ([id "use-fpcore"]) "Use FPCore")
        )
     (cond
-      [(thread-running? *worker-thread*)
+      [(is-server-up)
        `(form ([action ,(url improve)] [method "post"] [id "formula"]
                [data-progress ,(url improve-start)])
           (textarea ([name "formula"] [autofocus "true"]
@@ -169,7 +311,7 @@
 
     (if (*demo?*)
         `(p "To handle the high volume of requests, web requests are queued; "
-            "there are " (span ([id "num-jobs"]) ,(~a (hash-count *jobs*))) " jobs in the queue right now. "
+            "there are " (span ([id "num-jobs"]) ,(~a (job-count))) " jobs in the queue right now. "
             "Web demo requests may also time out and cap the number of improvement iterations. "
             "To avoid these limitations, " (a ([href "/doc/latest/installing.html"]) "install Herbie")
             " on your own computer.")
@@ -207,81 +349,6 @@
            [else
             `("all formulas submitted here are " (a ([href "./index.html"]) "logged") ".")])))))
 
-(define *completed-jobs* (make-hash))
-(define *jobs* (make-hash))
-
-(define *worker-thread*
-  (thread
-   (λ ()
-     (let loop ([seed #f])
-       (match (thread-receive)
-         [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
-                 timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
-          (set! seed vec)
-          (*flags* flag-table)
-          (*num-iterations* iterations)
-          (*num-points* points)
-          (*timeout* timeout)
-          (*demo-output* output)
-          (*reeval-pts* reeval)
-          (*demo?* demo?)]
-         [job-info (run-job job-info)])
-       (loop seed)))))
-
-(struct run-herbie-command 
- (command formula seed pcontext profile? timeline-disabled?) #:transparent)
-
-(define (wrapper-run-herbie cmd job-id)
-  (print-job-message (run-herbie-command-command cmd) job-id (syntax->datum (run-herbie-command-formula cmd)))
-  (define result (run-herbie 
-   (run-herbie-command-command cmd)
-   (parse-test (run-herbie-command-formula cmd))
-   #:seed (run-herbie-command-seed cmd)
-   #:pcontext (run-herbie-command-pcontext cmd)
-   #:profile? (run-herbie-command-profile? cmd)
-   #:timeline-disabled? (run-herbie-command-timeline-disabled? cmd)))
-  (hash-set! *completed-jobs* job-id result)
-  (eprintf "Job ~a complete\n" job-id))
-
-(define (run-job job-info)
- (match-define (work job-id info sema) job-info)
- (define path (format "~a.~a" job-id *herbie-commit*))
- (cond ;; Check caches if job as already been completed
-  [(hash-has-key? *completed-jobs* job-id)
-   (semaphore-post sema)]
-  [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
-   (semaphore-post sema)]
-  [else (wrapper-run-herbie info job-id)
-   (hash-remove! *jobs* job-id)
-   (semaphore-post sema)]))
-
-; Handles semaphore and async part of a job
-(struct work (id job sema))
-
-; Encapsulates semaphores and async part of jobs.
-(define (run-work #:sync? [sync-job? #t] job)
- (define job-id (compute-job-id job))
- (hash-set! *jobs* job-id (*timeline*))
- (define sema (make-semaphore))
-  (thread-send *worker-thread* (work job-id job sema))
-  (when sync-job?
-   (semaphore-wait sema)
-   (hash-ref *completed-jobs* job-id)))
-
-(define (print-job-message command job-id job-str)
-  (define job-label
-    (match command 
-      ['alternatives "Alternatives"]
-      ['evaluate "Evaluation"]
-      ['cost "Computing"]
-      ['errors "Analyze"]
-      ['exacts "Ground truth"]
-      ['improve "Improve"]
-      ['local-error "Local error"]
-      ['sample "Sampling"]
-      [_ (error 'compute-result "unknown command ~a" command)]))
-  (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label (symbol->string command) job-id job-str))
-
 (define (update-report result dir seed data-file html-file)
   (define link (path-element->string (last (explode-path dir))))
   (define data (get-table-data result link))
@@ -294,11 +361,6 @@
   (write-datafile tmp-file info)
   (rename-file-or-directory tmp-file data-file #t)
   (call-with-output-file html-file #:exists 'replace (curryr make-report-page info #f)))
-
-(define (already-computed? job-id formula)
-  (or (hash-has-key? *completed-jobs* job-id)
-      (and (*demo-output*)
-           (directory-exists? (build-path (*demo-output*) (format "~a.~a" job-id *herbie-commit*))))))
 
 (define (post-with-json-response fn)
   (lambda (req)
@@ -354,8 +416,7 @@
          (raise-herbie-error "no formula specified"))
        (parse-test formula)
        (define command (run-herbie-command 'improve formula (get-seed) #f #f #f))
-       (define job-id (compute-job-id command))
-       (body job-id command formula))]
+       (body command))]
     [_
      (response/error "Demo Error"
                      `(p "You didn't specify a formula (or you specified several). "
@@ -364,20 +425,19 @@
 (define (improve-start req)
   (improve-common
    req
-   (λ (job-id command formula)
-     (unless (already-computed? job-id formula)
-      (run-work #:sync? #f command))
+   (λ (command)
+     (define job-id (start-job command))
      (response/full 201 #"Job started" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (url check-status job-id)))
-                          (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+                          (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
                     '()))
    (url main)))
 
 (define (check-status req job-id)
-  (match (hash-ref *jobs* job-id #f)
+  (match (is-job-finished job-id)
     [(? box? timeline)
      (response 202 #"Job in progress" (current-seconds) #"text/plain"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
                (λ (out) (display (apply string-append
                                         (for/list ([entry (reverse (unbox timeline))])
                                           (format "Doing ~a\n" (hash-ref entry 'type))))
@@ -385,26 +445,23 @@
     [#f
      (response/full 201 #"Job complete" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
-                          (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*)))))
+                          (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
                     '())]))
 
 (define (check-up req)
-  (response/full (if (thread-running? *worker-thread*) 200 500)
-                 (if (thread-running? *worker-thread*) #"Up" #"Down")
+  (response/full (if (is-server-up) 200 500)
+                 (if (is-server-up) #"Up" #"Down")
                  (current-seconds) #"text/plain"
-                 (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (hash-count *jobs*))))
+                 (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                        (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                  '()))
-
-(define (compute-job-id job-info)
- (sha1 (open-input-string (~s job-info))))
 
 (define (improve req)
   (improve-common
    req
-   (λ (job-id command formula)
-     (unless (already-computed? job-id formula)
-      (run-work command))
+   (λ (command)
+     (define job-id (start-job command))
+     (wait-for-job job-id)
      (redirect-to (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*)) see-other))
    (url main)))
 
@@ -416,9 +473,10 @@
       (define formula-str (hash-ref post-data 'formula))
       (define formula (read-syntax 'web (open-input-string formula-str)))
       (define seed* (hash-ref post-data 'seed))
-      (define command (run-herbie-command 'sample formula seed* #f #f #t))
+      (define command (create-job 'sample formula #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (define test (parse-test formula))
-      (define result (run-work command))
       (define pctx (job-result-backend result))
       (define repr (context-repr (test-context test)))
       (hasheq 'points (pcontext->json pctx repr)))))
@@ -433,7 +491,8 @@
       (define pcontext (json->pcontext sample 
        (test-context (parse-test formula))))     
       (define command (run-herbie-command 'errors formula seed pcontext #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (define errs
         (for/list ([pt&err (job-result-backend result)])
           (define pt (first pt&err))
@@ -451,7 +510,8 @@
       (define test (parse-test formula))
       (define pcontext (json->pcontext sample (test-context test)))
       (define command (run-herbie-command 'exacts formula seed pcontext #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (hasheq 'points (job-result-backend result)))))
 
 (define calculate-endpoint 
@@ -463,7 +523,8 @@
       (define test (parse-test formula))
       (define pcontext (json->pcontext sample (test-context test)))
       (define command (run-herbie-command 'evaluate formula seed pcontext #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (define approx (job-result-backend result))
       (hasheq 'points approx))))
 
@@ -477,7 +538,8 @@
       (define expr (prog->fpcore (test-input test) (test-output-repr test)))
       (define pcontext (json->pcontext sample (test-context test)))
       (define command (run-herbie-command 'local-error formula seed pcontext #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (define local-error (job-result-backend result))
       ;; TODO: potentially unsafe if resugaring changes the AST
       (define tree
@@ -509,7 +571,8 @@
       (define pcontext (json->pcontext sample (test-context test)))
       (define command 
        (run-herbie-command 'alternatives formula seed pcontext #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (match-define (list altns test-pcontext processed-pcontext) 
        (job-result-backend result))
       (define splitpoints
@@ -562,7 +625,8 @@
       (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
       (define test (parse-test formula))
       (define command (run-herbie-command 'cost formula #f #f #f #t))
-      (define result (run-work command))
+      (define id (start-job command))
+      (define result (wait-for-job id))
       (define cost (job-result-backend result))
       (hasheq 'cost cost))))
 
@@ -602,7 +666,7 @@
   (define config
     `(init rand ,(get-seed) flags ,(*flags*) num-iters ,(*num-iterations*) points ,(*num-points*)
            timeout ,(*timeout*) output-dir ,(*demo-output*) reeval ,(*reeval-pts*) demo? ,(*demo?*)))
-  (thread-send *worker-thread* config)
+  (start-job-server config)
 
   (eprintf "Herbie ~a with seed ~a\n" *herbie-version* (get-seed))
   (eprintf "Find help on https://herbie.uwplse.org/, exit with Ctrl-C\n")

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -33,7 +33,7 @@
            (and m (completed-job? (second m))))))
   (λ (x)
     (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
-      (remove-me (if m (second m) x)))))
+      (get-results-for (if m (second m) x)))))
 
 (define-bidi-match-expander hash-arg hash-arg/m hash-arg/m)
 
@@ -81,11 +81,7 @@
     (next-dispatcher)]))
 
 (define (generate-report req)
-  (define data
-    (for/list ([(k v) (remove-me2)]
-      #:when (equal? (job-result-command v) 'improve))
-       (get-table-data v (format "~a.~a" k *herbie-commit*))))
-  (define info (make-report-info data #:seed (get-seed) #:note (if (*demo?*) "Web demo results" "Herbie results")))
+  (define info (make-report-info (get-improve-job-data) #:seed (get-seed) #:note (if (*demo?*) "Web demo results" "Herbie results")))
   (response 200 #"OK" (current-seconds) #"text"
             (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
             (λ (out) (write-datafile out info))))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -18,10 +18,10 @@
 
 (provide run-demo)
 
-(define *demo-prefix* (make-parameter "/"))
-(define *demo-log* (make-parameter false))
 (define *demo?* (make-parameter false))
+(define *demo-prefix* (make-parameter "/"))
 (define *demo-output* (make-parameter false))
+(define *demo-log* (make-parameter false))
 
 (define (add-prefix url)
   (string-replace (string-append (*demo-prefix*) url) "//" "/"))
@@ -55,13 +55,6 @@
    [("api" "translate") #:method "post" translate-endpoint]
    [((hash-arg) (string-arg)) generate-page]
    [("results.json") generate-report]))
-
-
-;; TODO figure out what to do with *demo-output*
-(define (already-computed? job-id)
-  (or (job-done? job-id)
-      (and (*demo-output*)
-           (directory-exists? (build-path (*demo-output*) (format "~a.~a" job-id *herbie-commit*))))))
 
 (define (generate-page req results page)
   (match-define result results)

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -1,0 +1,166 @@
+#lang racket
+
+(require json)
+(require racket/exn)
+(require openssl/sha1 (rename-in xml [location? xml-location?]))
+(require web-server/servlet web-server/servlet-env web-server/dispatch
+         web-server/dispatchers/dispatch web-server/dispatch/extend
+         web-server/http/bindings web-server/configuration/responders
+         web-server/managers/none)
+
+(require "../common.rkt" "../config.rkt" "../syntax/read.rkt" "../errors.rkt")
+(require "../syntax/syntax-check.rkt" "../syntax/type-check.rkt" "../syntax/types.rkt"
+         "../syntax/sugar.rkt" "../alternative.rkt" "../points.rkt"
+         "../programs.rkt" "../sandbox.rkt" "../float.rkt")
+(require "../datafile.rkt" "pages.rkt" "make-report.rkt"
+         "common.rkt" "core2mathjs.rkt" "history.rkt" "plot.rkt")
+(require (submod "../timeline.rkt" debug))
+
+
+(provide helper helper2 helper3 job-done? job-count is-server-up create-job start-job is-job-finished wait-for-job start-job-server)
+#| 
+Job Server Public API section
+
+This section just servers as a place for us to create the API's but give a
+|#
+
+;; Job object, What herbie excepts as input for a new job.
+
+;; TODO rename to herbie-command
+(struct herbie-command 
+ (command formula seed pcontext profile? timeline-disabled?) #:transparent)
+
+;; Creates a command object to be passed to start-job server.
+;; TODO contract?
+(define (create-job command formula 
+                    #:seed [seed #f] 
+                    #:pcontext [pcontext #f]
+                    #:profile? [profile? #f]
+                    #:timeline-disabled? [timeline-disabled? #f])
+  (herbie-command command formula seed pcontext profile? timeline-disabled?))
+
+;; Starts a job for a given command object
+(define (start-job command)
+  (start-work command))
+#| 
+Not ready for this API yet as i'm not sure how syncing with this abstraction will work. I could try using semaphores as the current server does.
+|#
+(define (wait-for-job job-id)
+  #| Where should we store job ids
+  How does access control in Racket work?
+  |#
+  (eprintf "Waiting for job\n")
+  (define sema (hash-ref *job-semma* job-id))
+  (semaphore-wait sema)
+  (hash-remove! *job-semma* job-id)
+  (hash-ref *completed-jobs* job-id))
+
+(define (is-job-finished job-id)
+#| Not really sure what this should return yet. s|#
+ (hash-ref *job-status* job-id #f))
+
+(define (job-count)
+ (hash-count *job-status*))
+
+(define (start-job-server config global-demo global-output)
+ (set! *demo?* global-demo)
+ (set! *demo-output* global-output)
+ (thread-send *worker-thread* config))
+(define (is-server-up)
+ (thread-running? *worker-thread*))
+
+; Helers to isolated *completed-jobs*
+(define (helper what-ever) 
+ (hash-has-key? *completed-jobs* what-ever))
+(define (helper2 what-ever) 
+ (hash-ref *completed-jobs* what-ever))
+(define (helper3)
+  (in-hash *completed-jobs*))
+
+(define (compute-job-id job-info)
+ (sha1 (open-input-string (~s job-info))))
+
+; public but not sure how to make private yet
+(define *demo?* (make-parameter false))
+(define *demo-output* (make-parameter false))
+;; Private 
+; globals
+; TODO I'm sure these can encapslated some how.
+(define *completed-jobs* (make-hash))
+(define *job-status* (make-hash))
+(define *job-semma* (make-hash))
+
+;; Helpers 
+; Handles semaphore and async part of a job
+(struct work (id job sema))
+
+; Encapsulates semaphores and async part of jobs.
+(define (start-work job)
+ (define job-id (compute-job-id job))
+ (hash-set! *job-status* job-id (*timeline*))
+ (define sema (make-semaphore))
+ (hash-set! *job-semma* job-id sema)
+ (thread-send *worker-thread* (work job-id job sema))
+ job-id)
+
+(define *worker-thread*
+ (thread
+  (λ ()
+    (let loop ([seed #f])
+      (match (thread-receive)
+        [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
+                timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
+        (set! seed vec)
+        (*flags* flag-table)
+        (*num-iterations* iterations)
+        (*num-points* points)
+        (*timeout* timeout)
+        (*demo-output* output)
+        (*reeval-pts* reeval)
+        (*demo?* demo?)]
+        [job-info (run-job job-info)])
+      (loop seed)))))
+
+(define (run-job job-info)
+ (match-define (work job-id info sema) job-info)
+ (define path (format "~a.~a" job-id *herbie-commit*))
+ (cond ;; Check caches if job as already been completed
+  ; [(hash-has-key? *completed-jobs* job-id)
+  ;  (semaphore-post sema)]
+  ; [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
+  ;  (semaphore-post sema)]
+  [else (wrapper-run-herbie info job-id)
+   (hash-remove! *job-status* job-id)
+   (semaphore-post sema)])
+ (hash-remove! *job-semma* job-id))
+
+(define (wrapper-run-herbie cmd job-id)
+  (print-job-message (herbie-command-command cmd) job-id (syntax->datum (herbie-command-formula cmd)))
+  (define result (run-herbie 
+   (herbie-command-command cmd)
+   (parse-test (herbie-command-formula cmd))
+   #:seed (herbie-command-seed cmd)
+   #:pcontext (herbie-command-pcontext cmd)
+   #:profile? (herbie-command-profile? cmd)
+   #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
+  (hash-set! *completed-jobs* job-id result)
+  (eprintf "Job ~a complete\n" job-id))
+
+(define (print-job-message command job-id job-str)
+  (define job-label
+    (match command 
+      ['alternatives "Alternatives"]
+      ['evaluate "Evaluation"]
+      ['cost "Computing"]
+      ['errors "Analyze"]
+      ['exacts "Ground truth"]
+      ['improve "Improve"]
+      ['local-error "Local error"]
+      ['sample "Sampling"]
+      [_ (error 'compute-result "unknown command ~a" command)]))
+  (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label (symbol->string command) job-id job-str))
+
+(define (job-done? job-id)
+  (hash-has-key? *completed-jobs* job-id))
+
+;; End Job Server section

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -17,7 +17,7 @@
 (require (submod "../timeline.rkt" debug))
 
 
-(provide helper helper2 helper3 job-count is-server-up create-job start-job is-job-finished wait-for-job start-job-server)
+(provide completed-job? remove-me remove-me2 job-count is-server-up create-job start-job is-job-finished wait-for-job start-job-server)
 #| 
 Job Server Public API section
 
@@ -40,6 +40,7 @@ This section just servers as a place for us to create the API's but give a
 
 ;; Starts a job for a given command object|
 #|
+TODO re-enable chaching
 (define (start-job command)
  (define id (compute-job-id command))
  (unless already-computed? id
@@ -78,13 +79,13 @@ Not ready for this API yet as i'm not sure how syncing with this abstraction wil
  (thread-running? *worker-thread*))
 
 ; Helers to isolated *completed-jobs*
-(define (helper id) 
+(define (completed-job? id) 
  (hash-has-key? *completed-jobs* id))
 
 ; TODO remove this as it returns the job outside it's scope
-(define (helper2 id) 
+(define (remove-me id) 
  (hash-ref *completed-jobs* id))
-(define (helper3)
+(define (remove-me2)
   (in-hash *completed-jobs*))
 
 (define (already-computed? job-id)

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -1,19 +1,8 @@
 #lang racket
 
-(require json)
-(require racket/exn)
-(require openssl/sha1 (rename-in xml [location? xml-location?]))
-(require web-server/servlet web-server/servlet-env web-server/dispatch
-         web-server/dispatchers/dispatch web-server/dispatch/extend
-         web-server/http/bindings web-server/configuration/responders
-         web-server/managers/none)
+(require openssl/sha1)
 
-(require "../common.rkt" "../config.rkt" "../syntax/read.rkt" "../errors.rkt")
-(require "../syntax/syntax-check.rkt" "../syntax/type-check.rkt" "../syntax/types.rkt"
-         "../syntax/sugar.rkt" "../alternative.rkt" "../points.rkt"
-         "../programs.rkt" "../sandbox.rkt" "../float.rkt")
-(require "../datafile.rkt" "pages.rkt" "make-report.rkt"
-         "common.rkt" "core2mathjs.rkt" "history.rkt" "plot.rkt")
+(require "../sandbox.rkt" "../config.rkt" "../syntax/read.rkt")
 (require (submod "../timeline.rkt" debug))
 
 (provide completed-job? get-results-for get-improve-job-data job-count

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -6,29 +6,29 @@
 (require (submod "../timeline.rkt" debug))
 
 (provide completed-job? get-results-for get-improve-job-data job-count
- is-server-up create-job start-job is-job-finished wait-for-job
- start-job-server)
+  is-server-up create-job start-job is-job-finished wait-for-job
+  start-job-server)
 
 #| Job Server Public API section |#
 
 ; Helers to isolated *completed-jobs*
 (define (completed-job? id) 
- (hash-has-key? *completed-jobs* id))
+  (hash-has-key? *completed-jobs* id))
 
 (define (get-results-for id) 
- (hash-ref *completed-jobs* id))
+  (hash-ref *completed-jobs* id))
 
 ; I don't like how specific this function is but it keeps the API boundary.
 (define (get-improve-job-data)
- (for/list ([(k v) (in-hash *completed-jobs*)]
-     #:when (equal? (job-result-command v) 'improve))
-      (get-table-data v (format "~a.~a" k *herbie-commit*))))
+  (for/list ([(k v) (in-hash *completed-jobs*)]
+    #:when (equal? (job-result-command v) 'improve))
+    (get-table-data v (format "~a.~a" k *herbie-commit*))))
 
 (define (job-count)
- (hash-count *job-status*))
+  (hash-count *job-status*))
 
 (define (is-server-up)
- (thread-running? *worker-thread*))
+  (thread-running? *worker-thread*))
 
 ;; Creates a command object to be passed to start-job server.
 ;; TODO contract?
@@ -41,29 +41,29 @@
 
 ;; Starts a job for a given command object|
 (define (start-job command)
- (define job-id (compute-job-id command))
- (if (already-computed? job-id) job-id (start-work command)))
+  (define job-id (compute-job-id command))
+  (if (already-computed? job-id) job-id (start-work command)))
 
 (define (is-job-finished job-id)
- (hash-ref *job-status* job-id #f))
+  (hash-ref *job-status* job-id #f))
 
 (define (wait-for-job job-id)
- (if (already-computed? job-id) 
-  (hash-ref *completed-jobs* job-id) 
-  (internal-wait-for-job job-id)))
+  (if (already-computed? job-id) 
+      (hash-ref *completed-jobs* job-id) 
+      (internal-wait-for-job job-id)))
 
 (define (start-job-server config global-demo global-output)
- ;; Pass along local global values
- ;; TODO can I pull these out of config or not need ot pass them along.
- (set! *demo?* global-demo)
- (set! *demo-output* global-output)
- (thread-send *worker-thread* config))
+  ;; Pass along local global values
+  ;; TODO can I pull these out of config or not need ot pass them along.
+  (set! *demo?* global-demo)
+  (set! *demo-output* global-output)
+  (thread-send *worker-thread* config))
 
 #| End Job Server Public API section |#
 
 ;; Job object, What herbie excepts as input for a new job.
 (struct herbie-command 
- (command formula seed pcontext profile? timeline-disabled?) #:transparent)
+  (command formula seed pcontext profile? timeline-disabled?) #:transparent)
  
 ; Private globals
 ; TODO I'm sure these can encapslated some how.
@@ -77,85 +77,86 @@
  (or (hash-has-key? *completed-jobs* job-id)
      (and (*demo-output*)
           (directory-exists? (build-path (*demo-output*) 
-           (format "~a.~a" job-id *herbie-commit*))))))
+          (format "~a.~a" job-id *herbie-commit*))))))
 
 (define (internal-wait-for-job job-id)
- (eprintf "Waiting for job\n")
- (define sema (hash-ref *job-sema* job-id))
- (semaphore-wait sema)
- (hash-remove! *job-sema* job-id)
- (hash-ref *completed-jobs* job-id))
+  (eprintf "Waiting for job\n")
+  (define sema (hash-ref *job-sema* job-id))
+  (semaphore-wait sema)
+  (hash-remove! *job-sema* job-id)
+  (hash-ref *completed-jobs* job-id))
 
 (define (compute-job-id job-info)
- (sha1 (open-input-string (~s job-info))))
+  (sha1 (open-input-string (~s job-info))))
 
 ; Encapsulates semaphores and async part of jobs.
 (define (start-work job)
- (define job-id (compute-job-id job))
- (hash-set! *job-status* job-id (*timeline*))
- (define sema (make-semaphore))
- (hash-set! *job-sema* job-id sema)
- (thread-send *worker-thread* (work job-id job sema))
- job-id)
+  (define job-id (compute-job-id job))
+  (hash-set! *job-status* job-id (*timeline*))
+  (define sema (make-semaphore))
+  (hash-set! *job-sema* job-id sema)
+  (thread-send *worker-thread* (work job-id job sema))
+  job-id)
 
 ; Handles semaphore and async part of a job
 (struct work (id job sema))
 
 (define (run-job job-info)
- (match-define (work job-id info sema) job-info)
- (define path (format "~a.~a" job-id *herbie-commit*))
- (cond ;; Check caches if job as already been completed
-  [(hash-has-key? *completed-jobs* job-id)
-   (semaphore-post sema)]
-  [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
-   (semaphore-post sema)]
-  [else (wrapper-run-herbie info job-id)
-   (hash-remove! *job-status* job-id)
-   (semaphore-post sema)])
- (hash-remove! *job-sema* job-id))
+  (match-define (work job-id info sema) job-info)
+  (define path (format "~a.~a" job-id *herbie-commit*))
+  (cond ;; Check caches if job as already been completed
+   [(hash-has-key? *completed-jobs* job-id)
+    (semaphore-post sema)]
+   [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))
+    (semaphore-post sema)]
+   [else (wrapper-run-herbie info job-id)
+    (hash-remove! *job-status* job-id)
+    (semaphore-post sema)])
+  (hash-remove! *job-sema* job-id))
 
 (define (wrapper-run-herbie cmd job-id)
- (print-job-message (herbie-command-command cmd) job-id 
-  (syntax->datum (herbie-command-formula cmd)))
- (define result (run-herbie 
-  (herbie-command-command cmd)
-  (parse-test (herbie-command-formula cmd))
-  #:seed (herbie-command-seed cmd)
-  #:pcontext (herbie-command-pcontext cmd)
-  #:profile? (herbie-command-profile? cmd)
-  #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
- (hash-set! *completed-jobs* job-id result)
- (eprintf "Job ~a complete\n" job-id))
+  (print-job-message (herbie-command-command cmd) job-id 
+    (syntax->datum (herbie-command-formula cmd)))
+  (define result (run-herbie 
+    (herbie-command-command cmd)
+    (parse-test (herbie-command-formula cmd))
+    #:seed (herbie-command-seed cmd)
+    #:pcontext (herbie-command-pcontext cmd)
+    #:profile? (herbie-command-profile? cmd)
+    #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
+  (hash-set! *completed-jobs* job-id result)
+  (eprintf "Job ~a complete\n" job-id))
 
 (define (print-job-message command job-id job-str)
- (define job-label
-  (match command 
-   ['alternatives "Alternatives"]
-   ['evaluate "Evaluation"]
-   ['cost "Computing"]
-   ['errors "Analyze"]
-   ['exacts "Ground truth"]
-   ['improve "Improve"]
-   ['local-error "Local error"]
-   ['sample "Sampling"]
-   [_ (error 'compute-result "unknown command ~a" command)]))
- (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label 
-  (symbol->string command) job-id job-str))
+  (define job-label
+    (match command 
+     ['alternatives "Alternatives"]
+     ['evaluate "Evaluation"]
+     ['cost "Computing"]
+     ['errors "Analyze"]
+     ['exacts "Ground truth"]
+     ['improve "Improve"]
+     ['local-error "Local error"]
+     ['sample "Sampling"]
+     [_ (error 'compute-result "unknown command ~a" command)]))
+  (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label 
+    (symbol->string command) job-id job-str))
 
 (define *worker-thread*
- (thread
-  (λ ()
-   (let loop ([seed #f])
-    (match (thread-receive)
-     [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
-        timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
-       (set! seed vec)
-       (*flags* flag-table)
-       (*num-iterations* iterations)
-       (*num-points* points)
-       (*timeout* timeout)
-       (*demo-output* output)
-       (*reeval-pts* reeval)
-       (*demo?* demo?)]
-     [job-info (run-job job-info)])
-    (loop seed)))))
+  (thread
+    (λ ()
+      (let loop ([seed #f])
+        (match (thread-receive)
+          [`(init rand ,vec flags ,flag-table num-iters ,iterations 
+             points ,points timeout ,timeout output-dir ,output reeval ,reeval
+             demo? ,demo?)
+            (set! seed vec)
+            (*flags* flag-table)
+            (*num-iterations* iterations)
+            (*num-points* points)
+            (*timeout* timeout)
+            (*demo-output* output)
+            (*reeval-pts* reeval)
+            (*demo?* demo?)]
+          [job-info (run-job job-info)])
+        (loop seed)))))

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -143,20 +143,19 @@
     (symbol->string command) job-id job-str))
 
 (define *worker-thread*
-  (thread
+   (thread
     (λ ()
       (let loop ([seed #f])
         (match (thread-receive)
-          [`(init rand ,vec flags ,flag-table num-iters ,iterations 
-             points ,points timeout ,timeout output-dir ,output reeval ,reeval
-             demo? ,demo?)
-            (set! seed vec)
-            (*flags* flag-table)
-            (*num-iterations* iterations)
-            (*num-points* points)
-            (*timeout* timeout)
-            (*demo-output* output)
-            (*reeval-pts* reeval)
-            (*demo?* demo?)]
+          [`(init rand ,vec flags ,flag-table num-iters ,iterations points ,points
+                  timeout ,timeout output-dir ,output reeval ,reeval demo? ,demo?)
+           (set! seed vec)
+           (*flags* flag-table)
+           (*num-iterations* iterations)
+           (*num-points* points)
+           (*timeout* timeout)
+           (*demo-output* output)
+           (*reeval-pts* reeval)
+           (*demo?* demo?)]
           [job-info (run-job job-info)])
         (loop seed)))))

--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -71,7 +71,7 @@
 (define *demo-output* (make-parameter false))
 (define *completed-jobs* (make-hash))
 (define *job-status* (make-hash))
-(define *job-semma* (make-hash))
+(define *job-sema* (make-hash))
 
 (define (already-computed? job-id)
  (or (hash-has-key? *completed-jobs* job-id)
@@ -81,9 +81,9 @@
 
 (define (internal-wait-for-job job-id)
  (eprintf "Waiting for job\n")
- (define sema (hash-ref *job-semma* job-id))
+ (define sema (hash-ref *job-sema* job-id))
  (semaphore-wait sema)
- (hash-remove! *job-semma* job-id)
+ (hash-remove! *job-sema* job-id)
  (hash-ref *completed-jobs* job-id))
 
 (define (compute-job-id job-info)
@@ -94,7 +94,7 @@
  (define job-id (compute-job-id job))
  (hash-set! *job-status* job-id (*timeline*))
  (define sema (make-semaphore))
- (hash-set! *job-semma* job-id sema)
+ (hash-set! *job-sema* job-id sema)
  (thread-send *worker-thread* (work job-id job sema))
  job-id)
 
@@ -112,7 +112,7 @@
   [else (wrapper-run-herbie info job-id)
    (hash-remove! *job-status* job-id)
    (semaphore-post sema)])
- (hash-remove! *job-semma* job-id))
+ (hash-remove! *job-sema* job-id))
 
 (define (wrapper-run-herbie cmd job-id)
  (print-job-message (herbie-command-command cmd) job-id 


### PR DESCRIPTION
This PR cleanly separates the `job-server` abstraction from the current `demo` abstractions by moving them into their own file. Decoupling this code sets us up for allowing multiple threads to perform work instead of just one `worker-thread` and its associated job queue.