### PR TITLE
Help users with local reports

### DIFF
--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -15,7 +15,7 @@
       (title "Herbie results")
       (meta ((charset "utf-8")))
       (link ((rel "stylesheet") (type "text/css") (href "report.css")))
-      (script ([src "report-page.js"][type "module"]))
+      (script ([src "report-page.js"]))
       (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"]))
       (script ([src "https://unpkg.com/d3@6.7.0/dist/d3.min.js"]))
       (script ([src "https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"])))

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -880,4 +880,4 @@ var diffAgainstFields = {}
 var otherJsonData = null
 var resultsJsonData = null
 
-await getResultsJson()
+getResultsJson()

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -765,7 +765,7 @@ function showGetJsonError(error) {
                     : "python3 -m http.server -d " + page_location + " 8123"
             ]),
             Element("p", [
-                "an then navigating to ",
+                "and then navigating to ",
                 Element("a", {
                     href: "http://localhost:8123/" + page_name,
                 }, Element("kbd", "http://localhost:8123/" + page_name)),

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -731,6 +731,63 @@ function update(jsonData, otherJsonData) {
     bodyNode.replaceChildren.apply(bodyNode, buildBody(jsonData, otherJsonData));
 }
 
+function showGetJsonError(error) {
+    const header = Element("header", {}, [
+        Element("h1", {}, "Error loading results"),
+        Element("img", { src: "logo-car.png" }, []),
+        Element("nav", {}, [
+            Element("ul", {}, [Element("li", {}, [Element("a", { href: "timeline.html" }, ["Metrics"])])])
+        ]),
+    ])
+
+    let is_windows = navigator.userAgent.indexOf("Windows") !== -1;
+    let page_name = window.location.pathname.split("/").at(-1);
+    let page_location;
+    if (is_windows) {
+        page_location = window.location.pathname.split("/").slice(1, -1).join("\\");
+    } else {
+        page_location = window.location.pathname.split("/").slice(0, -1).join("/");
+    }
+
+    let reason;
+    if (window.location.protocol == "file:") {
+        reason = [
+            Element("p", [
+                "Modern browsers prevent access over ",
+                Element("code", "file://"), " URLs, which Herbie requires.",
+            ]),
+            Element("p", [
+                "You can work around this by starting a local server, like so:"
+            ]),
+            Element("pre", [
+                is_windows // Python on windows is usually called python, not python3
+                    ? "python -m http.server -d " + page_location + " 8123"
+                    : "python3 -m http.server -d " + page_location + " 8123"
+            ]),
+            Element("p", [
+                "an then navigating to ",
+                Element("a", {
+                    href: "http://localhost:8123/" + page_name,
+                }, Element("kbd", "http://localhost:8123/" + page_name)),
+            ]),
+        ];
+    }
+    
+    const message = Element("section", {className: "error"}, [
+        Element("h2", "Could not load results"),
+        reason,
+    ]);
+
+    let body = [header, message];
+
+    let bodyNode = document.querySelector("body");
+    if (bodyNode) {
+        bodyNode.replaceChildren.apply(bodyNode, body);
+    } else {
+        document.addEventListener("DOMContentLoaded", () => showGetJsonError(error));
+    }
+}
+
 function makeFilterFunction() {
     return function filterFunction(baseData, diffData) {
         var returnValue = true
@@ -848,11 +905,14 @@ async function fetchAndUpdate(jsonData) {
 
 async function getResultsJson() {
     if (resultsJsonData == null) {
-        let response = await fetch("results.json", {
-            headers: { "content-type": "text/plain" },
-            method: "GET",
-            mode: "cors",
-        });
+        let response;
+        try {
+            response = await fetch("results.json", {
+                headers: { "content-type": "application/json" },
+            });
+        } catch (err) {
+            return showGetJsonError(err);
+        }
         resultsJsonData = (await response.json());
         storeBenchmarks(resultsJsonData.tests)
     }


### PR DESCRIPTION
This PR fixes #730, or at least, as close to fixing as we're going to get. Basically, if you generate a report in Herbie and double-click on the resulting file, nothing shows up. That's because when you just double-click on a file, it opens it in your browser with a `file://` URL, and those are heavily limited by browsers.[1] We can't exactly fix this [2] but we can show a nice error message and teach users to avoid this error, which is what this PR does. The resulting page looks like this:

<img width="811" alt="image" src="https://github.com/herbie-fp/herbie/assets/30707/d2647089-0738-4412-a7ec-3c75c1a9085b">

One nicety is that the Python command automatically subs in the right path because we can get it from the `file://` URL. It also switches to Windows paths for Windows machines.


[1] I do not agree with this decision, even after investigating the reasons, but it is now standard so hard to change.

[2] One option would be to use a trick called JSONP. This is doable but would be a lot of work and would muck up a lot of other nice uses of Herbie's data (the files on disk would no longer quite be JSON) so I decided against it.