### PR TITLE
Allow filtering the report by warning

### DIFF
--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -10,7 +10,7 @@
 
 
 (struct table-row
-  (name identifier status pre preprocess precision conversions vars
+  (name identifier status pre preprocess precision conversions vars warnings
         input output spec target-prog start result target
         start-est result-est time link cost-accuracy) #:prefab)
 
@@ -84,7 +84,7 @@
 (define (write-datafile file info)
   (define (simplify-test test)
     (match test
-      [(table-row name identifier status pre preprocess prec conversions vars
+      [(table-row name identifier status pre preprocess prec conversions vars warnings
                   input output spec target-prog
                   start-bits end-bits target-bits start-est end-est
                   time link cost-accuracy)
@@ -112,6 +112,7 @@
           (start-est . ,start-est)
           (end-est . ,end-est)
           (vars . ,(if vars (map symbol->string vars) #f))
+          (warnings . ,(map ~s warnings))
           (input . ,(~s input))
           (output . ,(~s output))
           (spec . ,(~s spec))
@@ -187,7 +188,9 @@
                                   (if (string? cs)
                                       (parse-string cs)
                                       (map (curry map parse-string) cs)))
-                                vars (parse-string (get 'input)) (parse-string (get 'output))
+                                vars
+                                (map string->symbol (get 'warnings '()))
+                                (parse-string (get 'input)) (parse-string (get 'output))
                                 (parse-string (hash-ref test 'spec "#f"))
                                 (parse-string (hash-ref test 'target-prog "#f"))
                                 (get 'start) (get 'end) (get 'target)

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -189,7 +189,7 @@
                                       (parse-string cs)
                                       (map (curry map parse-string) cs)))
                                 vars
-                                (map string->symbol (get 'warnings '()))
+                                (map string->symbol (hash-ref test 'warnings '()))
                                 (parse-string (get 'input)) (parse-string (get 'output))
                                 (parse-string (hash-ref test 'spec "#f"))
                                 (parse-string (hash-ref test 'target-prog "#f"))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -301,6 +301,7 @@
              (representation-name repr)
              (map (curry map representation-name) (test-conversions test))
              (test-vars test)
+             (map car (job-result-warnings result))
              (prog->fpcore (test-input test) repr) 
              #f
              (prog->fpcore (test-spec test) repr)
@@ -403,6 +404,9 @@
      ,@(if (table-row-target row)
            `(:herbie-error-target ([,(*reeval-pts*) ,(table-row-target row)]))
            '())
+     ,@(if (empty? (table-row-warnings row))
+           '()
+           `(:herbie-warnings ,(table-row-warnings row)))
      :name ,(table-row-name row)
      ,@(if descr `(:description ,(~a descr)) '())
      :precision ,(table-row-precision row)

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -866,13 +866,8 @@ function storeBenchmarks(tests) {
             tempAllWarnings[warning] = warning
         }
     }
-    for (let b in tempDir) {
-        benchMarks.push(b)
-    }
-    allWarnings = [];
-    for (let b in tempAllWarnings) {
-        allWarnings.push(b)
-    }
+    benchMarks = Object.keys(tempDir);
+    allWarnings = Object.keys(tempAllWarnings);
     update(resultsJsonData, otherJsonData);
 }
 

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -223,6 +223,9 @@ var showCompareDetails = false;
 var selectedBenchmarkIndex = -1
 var benchMarks = []
 
+var filterByWarning = -1;
+var allWarnings = []
+
 var sortState = {
     key: "test",
     dir: true, // true = ascending, false = descending
@@ -665,14 +668,23 @@ function buildFilterControls(jsonData) {
         filterButtons.push(button)
     }
 
-    const defaultName = "Filter by suite"
     const dropDown = Element("select", [
-        Element("option", { value: -1, selected: selectedBenchmarkIndex === -1 }, [defaultName]),
+        Element("option", { value: -1, selected: selectedBenchmarkIndex === -1 }, ["Filter by suite"]),
         benchMarks.map((suite, i) => 
             Element("option", { value: i, selected: selectedBenchmarkIndex == i }, [toTitleCase(suite)]))
     ]);
     dropDown.addEventListener("input", (e) => {
         selectedBenchmarkIndex = + (dropDown.value ?? "-1");
+        update(resultsJsonData);
+    });
+
+    const dropDown2 = Element("select", [
+        Element("option", { value: -1, selected: filterByWarning === -1 }, ["Filter to warning"]),
+        allWarnings.map((name) => 
+            Element("option", { value: name, selected: filterByWarning == name }, [name]))
+    ]);
+    dropDown2.addEventListener("input", (e) => {
+        filterByWarning = dropDown2.value ?? -1;
         update(resultsJsonData);
     });
 
@@ -684,7 +696,7 @@ function buildFilterControls(jsonData) {
     const filters = Element("details", { id: "filters", open: showFilterDetails }, [
         Element("summary", {}, [
             Element("h2", {}, "Filters"),
-            groupButtons, " ", dropDown,
+            groupButtons, " ", dropDown, " ", dropDown2,
         ]),
         filterButtons,
     ]);
@@ -788,6 +800,12 @@ function makeFilterFunction() {
             }
         }
 
+        if (filterByWarning != -1) {
+            if (baseData.warnings.indexOf(filterByWarning) === -1) {
+                return false
+            }
+        }
+
         if (!filterState[baseData.status]) {
             return false
         }
@@ -838,14 +856,22 @@ async function getResultsJson() {
 
 function storeBenchmarks(tests) {
     var tempDir = {}
+    var tempAllWarnings = {}
     for (let test of tests) {
         const linkComponents = test.link.split("/")
         if (linkComponents.length > 1) {
             tempDir[linkComponents[0]] = linkComponents[0]
         }
+        for (let warning of test.warnings)  {
+            tempAllWarnings[warning] = warning
+        }
     }
     for (let b in tempDir) {
         benchMarks.push(b)
+    }
+    allWarnings = [];
+    for (let b in tempAllWarnings) {
+        allWarnings.push(b)
     }
     update(resultsJsonData, otherJsonData);
 }

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -220,10 +220,10 @@ var showFilterDetails = false;
 var showCompareDetails = false;
 
 
-var selectedBenchmarkIndex = -1
-var benchMarks = []
+var filterBySuite = ""
+var allSuites = []
 
-var filterByWarning = -1;
+var filterByWarning = ""
 var allWarnings = []
 
 var sortState = {
@@ -669,22 +669,22 @@ function buildFilterControls(jsonData) {
     }
 
     const dropDown = Element("select", [
-        Element("option", { value: -1, selected: selectedBenchmarkIndex === -1 }, ["Filter by suite"]),
-        benchMarks.map((suite, i) => 
-            Element("option", { value: i, selected: selectedBenchmarkIndex == i }, [toTitleCase(suite)]))
+        Element("option", { value: "", selected: !filterBySuite }, ["Filter by suite"]),
+        allSuites.map((suite, i) => 
+            Element("option", { value: suite, selected: filterBySuite == suite }, [toTitleCase(suite)]))
     ]);
     dropDown.addEventListener("input", (e) => {
-        selectedBenchmarkIndex = + (dropDown.value ?? "-1");
+        filterBySuite = dropDown.value ?? "";
         update(resultsJsonData);
     });
 
     const dropDown2 = Element("select", [
-        Element("option", { value: -1, selected: filterByWarning === -1 }, ["Filter to warning"]),
+        Element("option", { value: "", selected: !filterByWarning }, ["Filter to warning"]),
         allWarnings.map((name) => 
             Element("option", { value: name, selected: filterByWarning == name }, [name]))
     ]);
     dropDown2.addEventListener("input", (e) => {
-        filterByWarning = dropDown2.value ?? -1;
+        filterByWarning = dropDown2.value ?? "";
         update(resultsJsonData);
     });
 
@@ -791,19 +791,17 @@ function makeFilterFunction() {
 
         const linkComponents = baseData.link.split("/")
         // guard statement
-        if (selectedBenchmarkIndex != -1 && linkComponents.length > 1) {
+        if (filterBySuite && linkComponents.length > 1) {
             // defensive lowerCase
-            const left = benchMarks[selectedBenchmarkIndex];
+            const left = filterBySuite;
             const right = linkComponents[0]
             if (left.toLowerCase() != right.toLowerCase()) {
                 return false
             }
         }
 
-        if (filterByWarning != -1) {
-            if (baseData.warnings.indexOf(filterByWarning) === -1) {
-                return false
-            }
+        if (filterByWarning && baseData.warnings.indexOf(filterByWarning) === -1) {
+            return false
         }
 
         if (!filterState[baseData.status]) {
@@ -866,7 +864,7 @@ function storeBenchmarks(tests) {
             tempAllWarnings[warning] = warning
         }
     }
-    benchMarks = Object.keys(tempDir);
+    allSuites = Object.keys(tempDir);
     allWarnings = Object.keys(tempAllWarnings);
     update(resultsJsonData, otherJsonData);
 }

--- a/src/web/resources/report-page.js
+++ b/src/web/resources/report-page.js
@@ -665,38 +665,16 @@ function buildFilterControls(jsonData) {
         filterButtons.push(button)
     }
 
-    var dropDownElements = []
-    const defaultName = "All Benchmarks"
-    if (selectedBenchmarkIndex == -1) {
-        dropDownElements = [Element("option", { selected: true }, [defaultName])]
-        for (let i in benchMarks) {
-            const name = toTitleCase(benchMarks[i])
-            dropDownElements.push(Element("option", {}, [name]))
-        }
-    } else {
-        dropDownElements = [Element("option", {}, [defaultName])]
-        for (let i in benchMarks) {
-            const name = toTitleCase(benchMarks[i])
-            if (selectedBenchmarkIndex == i) {
-                dropDownElements.push(Element("option", { selected: true }, [name]))
-            } else {
-                dropDownElements.push(Element("option", {}, [name]))
-            }
-        }
-    }
-
-    const dropDown = Element("select", { id: "dropdown" }, dropDownElements)
+    const defaultName = "Filter by suite"
+    const dropDown = Element("select", [
+        Element("option", { value: -1, selected: selectedBenchmarkIndex === -1 }, [defaultName]),
+        benchMarks.map((suite, i) => 
+            Element("option", { value: i, selected: selectedBenchmarkIndex == i }, [toTitleCase(suite)]))
+    ]);
     dropDown.addEventListener("input", (e) => {
-        const selected = e.target.selectedOptions[0].value
-        for (let i in benchMarks) {
-            if (selected != undefined) {
-                if (benchMarks[i].toLowerCase() == selected.toLowerCase()) {
-                    selectedBenchmarkIndex = i
-                }
-            }
-        }
-        update(resultsJsonData)
-    })
+        selectedBenchmarkIndex = + (dropDown.value ?? "-1");
+        update(resultsJsonData);
+    });
 
     let groupButtons = [];
     for (let i in filterGroupState) {


### PR DESCRIPTION
This PR adds a dropdown that filters the report to certain warnings:

<img width="590" alt="Screenshot 2024-06-27 at 2 09 24 PM" src="https://github.com/herbie-fp/herbie/assets/30707/7d36262f-8fd9-4b54-b544-18b577b7dfe7">

I think this makes warnings more useful to use developers, which is nice.

This PR also refactors the dropdown to filter by suite—I used it as a model and eventually found a nicer way to do it.