### PR TITLE
Fixing User Defined Function (Modulus) Bug

### DIFF
--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -150,7 +150,7 @@
   (define ctx (context arg-names default-repr var-reprs))
 
   ;; Named fpcores need to be added to function table
-  (when func-name (register-function! func-name args default-repr body))
+  (when func-name (register-function! func-name args default-prec body))
 
   ;; Try props first, then identifier, else the expression itself
   (define name
@@ -256,13 +256,13 @@
   (require rackunit "../load-plugin.rkt")
   (load-herbie-builtins)
 
-  (define repr (get-representation 'binary64))
+  (define precision 'binary64)
   (define ctx (make-debug-context '(x y z a)))
 
   ;; inlining
 
   ;; Test classic quadp and quadm examples
-  (register-function! 'discr (list 'a 'b 'c) repr `(sqrt (- (* b b) (* a c))))
+  (register-function! 'discr (list 'a 'b 'c) precision `(sqrt (- (* b b) (* a c))))
   (define quadp `(/ (+ (- y) (discr x y z)) x))
   (define quadm `(/ (- (- y) (discr x y z)) x))
   (check-equal? (fpcore->prog quadp ctx)
@@ -271,8 +271,8 @@
                 '(/.f64 (-.f64 (neg.f64 y) (sqrt.f64 (-.f64 (*.f64 y y) (*.f64 x z)))) x))
 
   ;; x^5 = x^3 * x^2
-  (register-function! 'sqr (list 'x) repr '(* x x))
-  (register-function! 'cube (list 'x) repr '(* x x x))
+  (register-function! 'sqr (list 'x) precision '(* x x))
+  (register-function! 'cube (list 'x) precision '(* x x x))
   (define fifth '(* (cube a) (sqr a)))
   (check-equal? (fpcore->prog fifth ctx)
                 '(*.f64 (*.f64 (*.f64 a a) a) (*.f64 a a)))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -177,7 +177,8 @@
         (resolve-missing-op! stx op actual-types error!)
         type])]
     [#`(,(? (curry hash-has-key? (*functions*)) fname) #,exprs ...)
-     (match-define (list vars repr _) (hash-ref (*functions*) fname))
+     (match-define (list vars prec _) (hash-ref (*functions*) fname))
+     (define repr (get-representation prec))
      (define actual-types (for/list ([arg exprs]) (expression->type arg env type error!)))
      (define expected (map (const repr) vars))
      (if (andmap equal? actual-types expected)

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -2,7 +2,7 @@
 
 (require racket/place)
 (require "../common.rkt" "../sandbox.rkt" "../load-plugin.rkt" "pages.rkt"
-         "../syntax/read.rkt" "../syntax/types.rkt" "../datafile.rkt")
+         "../syntax/read.rkt" "../syntax/syntax.rkt" "../syntax/types.rkt" "../datafile.rkt")
 
 (provide get-test-results)
 
@@ -51,7 +51,7 @@
 (define (make-worker seed profile? dir)
   (place/context* ch
     #:parameters (*flags* *num-iterations* *num-points* *timeout* *reeval-pts* *node-limit*
-                  *max-find-range-depth* *pareto-mode* *platform-name* *loose-plugins*)
+                  *max-find-range-depth* *pareto-mode* *platform-name* *loose-plugins* *functions*)
     (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
       (load-herbie-plugins))
     (for ([_ (in-naturals)])


### PR DESCRIPTION
Passed in precision instead of representation to store racket expressions. Pushed *functions* hash table to thread workers such that user-defined functions are defined in the table in all threads and are able to be expanded. 