### PR TITLE
Fix bsearch to never return the right endpoint (in case we can't-split)

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -119,10 +119,14 @@
   (define (left-point p1 p2)
     (let ([left ((representation-repr->bf repr) p1)]
           [right ((representation-repr->bf repr) p2)])
-      ((representation-bf->repr repr)
-       (if (bfnegative? left)
+      (define out
+        (if (bfnegative? left)
             (bigfloat-interval-shortest left (bfmin (bf/ left 2.bf) right))
-            (bigfloat-interval-shortest left (bfmin (bf* left 2.bf) right))))))
+            (bigfloat-interval-shortest left (bfmin (bf* left 2.bf) right))))
+      ;; It's important to return something strictly less than right
+      (if (bf= out right)
+          p1
+          ((representation-bf->repr repr) out))))
 
   (define use-binary
     (and (flag-set? 'reduce 'binary-search)


### PR DESCRIPTION
Fix #840. This was a very subtle bug. Basically, suppose regimes narrows our split point to somewhere in [a, b], but also suppose we can't split after b. Then bsearch picks something in [a, b]. But it can't be b! So now we check for `b` and in that case return `a`.