### PR TITLE
Add job-id to response headers.

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -57,14 +57,20 @@ assert.equal('Up', up.statusText)
 // TODO how do I test down state?
 
 // Sample endpoint
-const sample = await callHerbie("/api/sample", { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })
+const sampleRSP = await callHerbie("/api/sample", { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })
+const jid = sampleRSP.headers.get("x-herbie-job-id")
+assert.notEqual(jid, null)
 
+const sample = await sampleRSP.json()
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)
 const points = sample.points
 assert.equal(points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
 
-const sample2 = await callHerbie("/api/sample", { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })
+const sample2RPS = await callHerbie("/api/sample", { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })
+const jid2 = sample2RPS.headers.get("x-herbie-job-id")
+assert.notEqual(jid2, null)
+const sample2 = await sample2RPS.json()
 const points2 = sample2.points
 
 assert.deepEqual(points[1], points2[1])
@@ -168,6 +174,7 @@ async function callHerbie(endPoint, body) {
     pathname == "/improve-start" ||
     pathname.includes("check-status") ||
     pathname.includes("timeline") ||
+    pathname.includes("sample") ||
     pathname == "/up") {
     return rsp
   } else {

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -235,9 +235,11 @@
                   #"OK"
                   (current-seconds)
                   APPLICATION/JSON-MIME-TYPE
-                  (list 
-                   (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
-                   (header #"Herbie-job-id" (string->bytes/utf-8 (hash-ref resp 'job-id "-1"))))
+                  (if (hash-has-key? resp 'job-id)
+                    (list 
+                      (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
+                      (header #"Herbie-job-id" (string->bytes/utf-8 (hash-ref resp 'job-id))))
+                    (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))))
                   (λ (op) (write-json resp op))))))
 
 (define (response/error title body)
@@ -503,7 +505,8 @@
       (define id (start-job command))
       (define result (wait-for-job id))
       (define cost (job-result-backend result))
-      (hasheq 'cost cost 'job-id id))))
+      (hasheq 'cost cost 
+              'job-id id))))
 
 (define translate-endpoint
   (post-with-json-response
@@ -530,8 +533,7 @@
       (define converted (lang-converter formula "expr"))
       (eprintf "Converted Expression: \n~a...\n" converted)
       (hasheq 'result converted
-              'language target-lang
-              'job-id "-1" #| todo real id|# ))))
+              'language target-lang))))
 
 (define (run-demo #:quiet [quiet? #f] #:output output #:demo? demo? #:prefix prefix #:log log #:port port #:public? public)
   (*demo?* demo?)

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -238,7 +238,7 @@
                   (filter values
                     (list
                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
-                      (and (hash-has-key? resp 'job-id) (header #"X-Herbie-job-id" (string->bytes/utf-8 (hash-ref resp 'job-id))))))
+                      (and (hash-has-key? resp 'job-id) (header #"X-Herbie-Job-ID" (string->bytes/utf-8 (hash-ref resp 'job-id))))))
                   (λ (op) (write-json resp op))))))
 
 (define (response/error title body)
@@ -286,7 +286,7 @@
      (response/full 201 #"Job started" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (url check-status job-id)))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
                     '()))
    (url main)))
 
@@ -303,7 +303,7 @@
      (response/full 201 #"Job complete" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
                     '())]))
 
 (define (check-up req)
@@ -329,13 +329,13 @@
      (response 404 #"Job Not Found" (current-seconds) #"text/plain"
                (list 
                 (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
+                (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
                (λ (out) `()))]
     [job-result
      (response 201 #"Job complete" (current-seconds) #"text/plain"
                     (list 
                      (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
+                     (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
                     (λ (out) (write-json (job-result-timeline job-result) out)))]))
 
 ; /api/sample endpoint: test in console on demo page:

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -235,11 +235,10 @@
                   #"OK"
                   (current-seconds)
                   APPLICATION/JSON-MIME-TYPE
-                  (if (hash-has-key? resp 'job-id)
-                    (list 
+                  (filter values
+                    (list
                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
-                      (header #"Herbie-job-id" (string->bytes/utf-8 (hash-ref resp 'job-id))))
-                    (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))))
+                      (and (hash-has-key? resp 'job-id) (header #"X-Herbie-job-id" (string->bytes/utf-8 (hash-ref resp 'job-id))))))
                   (λ (op) (write-json resp op))))))
 
 (define (response/error title body)
@@ -287,7 +286,7 @@
      (response/full 201 #"Job started" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (url check-status job-id)))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"Herbie-job-id" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
                     '()))
    (url main)))
 
@@ -304,7 +303,7 @@
      (response/full 201 #"Job complete" (current-seconds) #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"Herbie-job-id" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
                     '())]))
 
 (define (check-up req)
@@ -330,13 +329,13 @@
      (response 404 #"Job Not Found" (current-seconds) #"text/plain"
                (list 
                 (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                (header #"Herbie-job-id" (string->bytes/utf-8 job-id)))
+                (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
                (λ (out) `()))]
     [job-result
      (response 201 #"Job complete" (current-seconds) #"text/plain"
                     (list 
                      (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"Herbie-job-id" (string->bytes/utf-8 job-id)))
+                     (header #"X-Herbie-job-id" (string->bytes/utf-8 job-id)))
                     (λ (out) (write-json (job-result-timeline job-result) out)))]))
 
 ; /api/sample endpoint: test in console on demo page:


### PR DESCRIPTION
This PR adds the `x-herbie-job-id` header to the response of the API endpoints that have associated `job-id`s. This allows the client to make additional queries about the job after the initial request is made as long as the same server instance is running. 
This might also make it easier for Oddessy to experiment and patiently migrate to an async version of the current APIs if needed.

This is just an addition to the current API surface. The downside of exposing the `job-id`s is that they are only valid well that instance of the server that generated the `job-id` is still running. Further modifications could be made to write the cached data to disk and query there if the data is not found in memory from the server restarting for some reason.

Partial example of the server response.
```json
headers: Headers {
    'transfer-encoding': 'chunked',
    server: 'Racket',
    'last-modified': 'Tue, 02 Jul 2024 21:32:19 GMT',
    date: 'Tue, 02 Jul 2024 21:32:19 GMT',
    'content-type': 'application/json; charset=utf-8',
    'access-control-allow-origin': '*',
    'x-herbie-job-id': 'a916a082cd5363d5af7e531cd271c3422629c871'
  },
```