### PR TITLE
Optimize `run-egg` to only do necessary work

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -18,7 +18,7 @@
          "../programs.rkt"
          "../timeline.rkt" )
 
-(provide (struct-out egraph-query)
+(provide (struct-out egg-runner)
          (struct-out regraph)
          untyped-egg-extractor
          typed-egg-extractor
@@ -1388,16 +1388,16 @@
 ;; Public API
 ;;
 ;; Most calls to egg should be done through this interface.
-;;  - `make-egg-query` creates a struct that describes a _reproducible_ egg instance
-;;  - `run-egg` actually runs egg and extracts expressions and possibly proofs
+;;  - `make-egg-runner`: creates a struct that describes a _reproducible_ egg instance
+;;  - `run-egg`: takes an egg runner and performs an extraction (exprs or proof)
 
 ;; Herbie's version of an egg runner
 ;; Defines parameters for running rewrite rules with egg
-(struct egraph-query (exprs reprs schedule ctx extractor)
+(struct egg-runner (exprs reprs schedule ctx extractor)
                      #:transparent ; for equality
                      #:methods gen:custom-write ; for abbreviated printing
                      [(define (write-proc alt port mode)
-                        (fprintf port "#<egraph-query>"))])
+                        (fprintf port "#<egg-runner>"))])
 
 ;; Fallback extractor if none is specified
 (define default-egg-extractor
@@ -1410,7 +1410,7 @@
                         #:context [ctx (*context*)]
                         #:extractor [extractor #f])
   (verify-schedule! schedule)
-  (egraph-query exprs
+  (egg-runner exprs
                 reprs
                 schedule
                 ctx
@@ -1419,15 +1419,15 @@
 ;; Runs egg using an egg runner.
 (define (run-egg input variants? #:proof-inputs [proof-inputs '()])
   ;; Run egg and extract iteration data
-  (define ctx (egraph-query-ctx input))
+  (define ctx (egg-runner-ctx input))
   (define-values (node-ids egg-graph regraph)
-    (egraph-run-schedule (egraph-query-exprs input)
-                         (egraph-query-schedule input)
+    (egraph-run-schedule (egg-runner-exprs input)
+                         (egg-runner-schedule input)
                          ctx))
   ;; Compute eclass/enode cost in the graph
-  (define extractor (egraph-query-extractor input))
+  (define extractor (egg-runner-extractor input))
   (define extract-id (extractor regraph))
-  (define reprs (egraph-query-reprs input))
+  (define reprs (egg-runner-reprs input))
   ;; Extract the expressions
   (define extract-proc
     (if variants?

--- a/src/core/rr.rkt
+++ b/src/core/rr.rkt
@@ -49,7 +49,7 @@
             platform-egg-cost-proc
             default-egg-cost-proc)))
   (define e-input
-    (make-egg-query exprs
+    (make-egg-runner exprs
                     reprs
                     schedule
                     #:context ctx

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -13,13 +13,13 @@
 ;; the last expression is the simplest unless something went wrong due to unsoundness
 ;; if the input specifies proofs, it instead returns proofs for these expressions
 (define/contract (simplify-batch input)
-  (-> egraph-query? (listof (listof expr?)))
-  (timeline-push! 'inputs (map ~a (egraph-query-exprs input)))
+  (-> egg-runner? (listof (listof expr?)))
+  (timeline-push! 'inputs (map ~a (egg-runner-exprs input)))
   (timeline-push! 'method "egg-herbie")
   (match-define (cons results _) (run-egg input #f))
 
   (define out
-    (for/list ([result results] [expr (egraph-query-exprs input)])
+    (for/list ([result results] [expr (egg-runner-exprs input)])
       (remove-duplicates (cons expr result))))
   (timeline-push! 'outputs (map ~a (apply append out)))
     

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -403,25 +403,26 @@
   (cond
     [(flag-set? 'generate 'simplify)
      (timeline-event! 'simplify)
-
+    
      (define progs (map alt-expr alts))
      (define reprs (map (lambda (prog) (repr-of prog (*context*))) progs))
      (define rules (platform-impl-rules (*fp-safe-simplify-rules*)))
 
      ; egg runner
-     (define extractor
-      (typed-egg-extractor
-        (if (*egraph-platform-cost*)
-            platform-egg-cost-proc
-            default-egg-cost-proc)))
-     (define egg-query
-       (make-egg-runner progs
+     (define runner
+      (make-egg-runner progs
                        reprs
-                       `((run ,rules ((node . ,(*node-limit*)) (const-fold? . #f))))
-                       #:extractor extractor))
+                       `((,rules . ((node . ,(*node-limit*)) (const-fold? . #f))))))
 
      ; run egg
-     (define simplified (map last (simplify-batch egg-query)))
+     (define simplified
+       (map last
+            (simplify-batch
+              runner
+              (typed-egg-extractor
+                (if (*egraph-platform-cost*)
+                    platform-egg-cost-proc
+                    default-egg-cost-proc)))))
 
      ; de-duplication
      (remove-duplicates

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -415,7 +415,7 @@
             platform-egg-cost-proc
             default-egg-cost-proc)))
      (define egg-query
-       (make-egg-query progs
+       (make-egg-runner progs
                        reprs
                        `((run ,rules ((node . ,(*node-limit*)) (const-fold? . #f))))
                        #:extractor extractor))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -142,7 +142,7 @@
             platform-egg-cost-proc
             default-egg-cost-proc)))
   (define egg-query
-    (make-egg-query specs
+    (make-egg-runner specs
                     reprs
                     schedule
                     #:extractor extractor))

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -79,7 +79,7 @@
   (define (build! altn)
     (match altn
       ; recursive rewrite using egg (spec -> impl)
-      [(alt expr `(rr ,loc ,(? egraph-query? e-input) #f #f) `(,prev) _)
+      [(alt expr `(rr ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define start-expr* (expand-accelerators (prog->spec start-expr)))
        (define end-expr (location-get loc expr))
@@ -88,7 +88,7 @@
        (hash-update! query->rws e-input (lambda (rws) (set-add rws rewrite)) '())]
       
       ; simplify using egg (spec -> impl)
-      [(alt expr `(simplify ,loc ,(? egraph-query? e-input) #f #f) `(,prev) _)
+      [(alt expr `(simplify ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define end-expr (location-get loc expr))
 
@@ -127,7 +127,7 @@
 (define (add-soundiness-to altn pcontext ctx alt->proof)
   (match altn
     ; recursive rewrite using egg
-    [(alt expr `(rr ,loc ,(? egraph-query? e-input) #f #f) `(,prev) _)
+    [(alt expr `(rr ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
      (match-define (cons proof* errs)
        (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
      (alt expr `(rr ,loc ,e-input ,proof* ,errs) `(,prev) '())]
@@ -141,7 +141,7 @@
      (alt expr `(rr ,loc ,input ,proof ,errs) `(,prev) '())]
     
     ; simplify using egg
-    [(alt expr `(simplify ,loc ,(? egraph-query? e-input) #f #f) `(,prev) _)
+    [(alt expr `(simplify ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
      (match-define (cons proof* errs)
        (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
      (alt expr `(simplify ,loc ,e-input ,proof* ,errs) `(,prev) '())]

--- a/src/soundiness.rkt
+++ b/src/soundiness.rkt
@@ -69,7 +69,7 @@
      (error 'altn->key "unimplemented ~a" altn)]))
 
 ;; Creates two tables:
-;;  - map from alternative to a pair (e, l ~> r) where `e` is an `egg-query`
+;;  - map from alternative to a pair (e, l ~> r) where `e` is an `egg-runner`
 ;;      and `l ~> r` is the rewrite we want a proof for.
 ;;  - map from egg query to list of proofs
 (define (make-proof-tables altns)
@@ -79,16 +79,16 @@
   (define (build! altn)
     (match altn
       ; recursive rewrite using egg (spec -> impl)
-      [(alt expr `(rr ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
+      [(alt expr `(rr ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define start-expr* (expand-accelerators (prog->spec start-expr)))
        (define end-expr (location-get loc expr))
        (define rewrite (cons start-expr* end-expr))
-       (hash-set! alt->query&rws (altn->key altn) (cons e-input rewrite))
-       (hash-update! query->rws e-input (lambda (rws) (set-add rws rewrite)) '())]
+       (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
+       (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
       
       ; simplify using egg (spec -> impl)
-      [(alt expr `(simplify ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
+      [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define end-expr (location-get loc expr))
 
@@ -98,8 +98,8 @@
            [_ (expand-accelerators (prog->spec start-expr))]))
        (define rewrite (cons start-expr* end-expr))
 
-       (hash-set! alt->query&rws (altn->key altn) (cons e-input rewrite))
-       (hash-update! query->rws e-input (lambda (rws) (set-add rws rewrite)) '())]
+       (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
+       (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
 
       ; everything else
       [_ (void)])
@@ -114,23 +114,23 @@
 ;; Runs proof extraction.
 ;; Result is a map from egg query to rewrites.
 (define (compute-proofs query->rws)
-  (for/hash ([(e-input rws) (in-hash query->rws)])
-    (match-define (cons _ proofs) (run-egg e-input #f #:proof-inputs rws))
-    (values e-input (map cons rws proofs))))
+  (for/hash ([(runner rws) (in-hash query->rws)])
+    (define proofs (run-egg runner `(proofs . ,rws)))
+    (values runner (map cons rws proofs))))
 
 ;; Lookups a proof based on an alternative
 (define ((lookup-proof alt->query&rws query->proofs) altn)
-  (match-define (cons e-input rw) (hash-ref alt->query&rws (altn->key altn)))
-  (cdr (assoc rw (hash-ref query->proofs e-input))))
+  (match-define (cons runner rw) (hash-ref alt->query&rws (altn->key altn)))
+  (cdr (assoc rw (hash-ref query->proofs runner))))
 
 ;; Adds proof information to alternatives.
 (define (add-soundiness-to altn pcontext ctx alt->proof)
   (match altn
     ; recursive rewrite using egg
-    [(alt expr `(rr ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
+    [(alt expr `(rr ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
      (match-define (cons proof* errs)
        (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
-     (alt expr `(rr ,loc ,e-input ,proof* ,errs) `(,prev) '())]
+     (alt expr `(rr ,loc ,runner ,proof* ,errs) `(,prev) '())]
 
     ; recursive rewrite using rewrite-once
     [(alt expr `(rr ,loc ,(? rule? input) #f #f) `(,prev) _)
@@ -141,10 +141,10 @@
      (alt expr `(rr ,loc ,input ,proof ,errs) `(,prev) '())]
     
     ; simplify using egg
-    [(alt expr `(simplify ,loc ,(? egg-runner? e-input) #f #f) `(,prev) _)
+    [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
      (match-define (cons proof* errs)
        (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
-     (alt expr `(simplify ,loc ,e-input ,proof* ,errs) `(,prev) '())]
+     (alt expr `(simplify ,loc ,runner ,proof* ,errs) `(,prev) '())]
     
     ; everything else
     [_ altn]))


### PR DESCRIPTION
Refactors the `egg-herbie` interface. Only two functions are important.

`make-egg-runner(exprs, reprs, schedule)` (previously `make-egg-query`):
 - takes a list of exprs (and output reprs) and a rule "schedule"
 - the egg runner specifies how to  _reproducibly_  run egg for a set of expressions

`run-egg(runner, cmd)`:
 - actually creates an e-graph and runs the rule schedule and then performs an "extraction"
 - an extraction is one of single-expression extraction, multi-expression extraction, or proofs
 - importantly expression extraction is not run when finding proofs
 - future work: preprocess only needs to check if expressions are in the same e-class

Hoping for a performance boost. This PR is a follow-up to #875 .