### PR TITLE
Regimes speedup

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -24,7 +24,8 @@
 
 (define (pareto-regimes sorted ctx)
   (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))
-  (define branches (exprs-to-branch-on sorted ctx))
+  (define branches (if (null? sorted) '()
+  (exprs-to-branch-on sorted ctx)))
   (let loop ([alts sorted] [errs (hash)] [err-lsts err-lsts])
     (cond
      [(null? alts) '()]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -34,14 +34,14 @@
       '()]
      [else
       (define-values (opt new-errs) 
-        (infer-splitpoints alts err-lsts #:errs errs ctx branches))
+        (infer-splitpoints branches alts err-lsts #:errs errs ctx ))
       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
       (cons opt (loop (take alts high) new-errs (take err-lsts high)))])))
 
 ;; `infer-splitpoints` and `combine-alts` are split so the mainloop
 ;; can insert a timeline break between them.
 
-(define (infer-splitpoints alts err-lsts* #:errs [cerrs (hash)] ctx branches)
+(define (infer-splitpoints branches alts err-lsts* #:errs [cerrs (hash)] ctx )
   (define branch-exprs
     (if (flag-set? 'reduce 'branch-expressions)
         branches

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -24,9 +24,12 @@
 
 (define (pareto-regimes sorted ctx)
   (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))
+  (define branches 
+    (if (null? sorted) '()
+        (exprs-to-branch-on sorted ctx)))
   (define branch-exprs
     (if (flag-set? 'reduce 'branch-expressions)
-        (exprs-to-branch-on sorted ctx)
+        branches
         (context-vars ctx)))
   (let loop ([alts sorted] [errs (hash)] [err-lsts err-lsts])
     (cond


### PR DESCRIPTION
After running Nightly  the time of Regimes-Speedup was 91.2 min while main was 91.5 min. While make-regime! that contains pareto-regimes takes 1012.34s in Regimes-Speedup, in main it takes 1073.72s. During profiling there is much more time spent in pareto-regimes since the exprs-to-branch-on is now being calculated during this function. This makes pareto-Regimes take 30.55s in Regimes-Speedup but only takes 12.74s in main. I'm unsure where exactly the speedup can be found in the profiling but it is faster I think.