### PR TITLE
Merge-Datafiles Crash Fix

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -38,4 +38,7 @@ RECURSE=1 LOG=1 \
     $FLAGS
 
 # upload
-bash $INFRA_DIR/publish.sh upload "$OUT_DIR"
+if [ "$?" -eq 0 ]; then
+  bash $INFRA_DIR/publish.sh upload "$OUT_DIR"
+fi
+

--- a/infra/run.sh
+++ b/infra/run.sh
@@ -32,6 +32,7 @@ function output_error {
   "points": -1, "iterations": -1, "bit_width": -1,
   "note": "$NAME", "crash": true, "tests": [] }
 EOF
+  exit 1
 }
 
 # actual runner


### PR DESCRIPTION
Attempting to force exit run.sh script when a run on a specific benchmark suite fails such that merge-datafiles does not run when there is a segfault crash. Only publishing the results if run.sh succeeded.