### PR TITLE
Fix `pow-pow` rule failures in CI

### DIFF
--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -23,6 +23,8 @@
     [atan-tan-s_binary32    . (<= (fabs x) 1.5708)]
     [pow-unpow_binary64     . (>= a 0)]
     [pow-unpow_binary32     . (>= a 0)]
+    [pow-pow_binary64       . (>= a 0)]
+    [pow-pow_binary32       . (>= a 0)]
     [sqrt-pow1_binary64     . (>= x 0)]
     [sqrt-pow1_binary32     . (>= x 0)]
 ))


### PR DESCRIPTION
This PR fixes #878. The `pow-pow` rule is not actually sound if `a < 0`, `b*c` is odd, and one of `b` or `c` is even.