### PR TITLE
Web demo patch 1

### DIFF
--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -125,7 +125,7 @@
 
 (define (representation->discretization repr)
   (discretization
-   (representation-total-bits repr)
+   ;(representation-total-bits repr)
    (representation-bf->repr repr)
    (lambda (x y) (- (ulp-difference x y repr) 1))))
 


### PR DESCRIPTION
This PR fixes the following crash on the web demo running `racket -y src/herbie.rkt web --quiet`. 

⚠️ I am not sure if this is correct in regards to how sampling works.

<img width="792" alt="Screenshot 2024-07-16 at 2 31 43 PM" src="https://github.com/user-attachments/assets/b73ca730-05ad-4a84-b100-58c0c05b9412">
