### PR TITLE
Only print test name

### DIFF
--- a/src/web/server.rkt
+++ b/src/web/server.rkt
@@ -117,7 +117,7 @@
 
 (define (wrapper-run-herbie cmd job-id)
   (print-job-message (herbie-command-command cmd) job-id 
-    (herbie-command-test cmd))
+    (test-name (herbie-command-test cmd)))
   (define result (run-herbie 
     (herbie-command-command cmd)
     (herbie-command-test cmd)


### PR DESCRIPTION
This PR changes the printed output of jobs to only display the name of the test not the entire test for cleaner terminal output.

before:
```
Improve Job improve started:
  b476925bc3c1474f6b20181eec4414df3e795cb4 #s(test sqrt(x + 1) - sqrt(x) #f (x) (-.f64 (sqrt.f64 (+.f64 x #s(literal 1 binary64))) (sqrt.f64 x)) () #t (-.f64 (sqrt.f64 (+.f64 x #s(literal 1 binary64))) (sqrt.f64 x)) (and (<=.f64 #s(literal 0 binary64) x) (<=.f64 x #s(literal 178999999999999996376899522972626047077637637819240219954027593177370961667659291027329061638406108931437333529420935752785895444161234074984843178962619172326295244262722141766382622299223626438470088150218987997954747866198184686628013966119769261150988554952970462018533787926725176560021258785656871583744 binary64))) () binary64 ((x . binary64)))...
Job b476925bc3c1474f6b20181eec4414df3e795cb4 complete
```

after:
```
Improve Job improve started:
  817dc9ecc47bb9cbe85ce767a4c72e8330b1feeb sqrt(x + 1) - sqrt(x)...
Job 817dc9ecc47bb9cbe85ce767a4c72e8330b1feeb complete
```