### PR TITLE
Add update rival to make install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 
 update:
 	raco pkg install --skip-installed --no-docs --auto --name herbie src/
+	raco pkg update rival
 	raco pkg update --name herbie --deps search-auto src/
 
 egg-herbie:


### PR DESCRIPTION
This PR adjusts the `make install` command to also update the `rival` package to help keep dependencies in sync.