### PR TITLE
Fixed a bug related to handling invalid job IDs when `--save-session` is enabled

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -26,12 +26,12 @@
 
 (define-coercion-match-expander hash-arg/m
   (λ (x)
-    (cond
-      [(*demo-output*)
-       (not (directory-exists? (build-path (*demo-output*) x)))]
-      [else
-       (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
-         (and m (completed-job? (second m))))]))
+    (and
+     (not
+      (and (*demo-output*) ; If we've already saved to disk, skip this job
+           (directory-exists? (build-path (*demo-output*) x))))
+     (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
+       (and m (completed-job? (second m))))))
   (λ (x)
     (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
       (get-results-for (if m (second m) x)))))


### PR DESCRIPTION
If `--save-session` is enabled, Herbie will try to generate pages even for invalid job IDs, which will then crash. Kind of no harm no foul but better to fix it than not.