### PR TITLE
Add commit hash and Access-Control-Allow-Origin for Odyssey

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -62,10 +62,7 @@ const jid = sampleRSP.headers.get("x-herbie-job-id")
 assert.notEqual(jid, null)
 
 const sample = await sampleRSP.json()
-
-// Test for job id and path, these could be better
-assert.equal(sample.job.length > 0, true)
-assert.equal(sample.path.includes("."), true)
+assertIdAndPath(sample)
 
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)
@@ -77,7 +74,7 @@ const jid2 = sample2RPS.headers.get("x-herbie-job-id")
 assert.notEqual(jid2, null)
 const sample2 = await sample2RPS.json()
 const points2 = sample2.points
-
+assertIdAndPath(sample2)
 assert.deepEqual(points[1], points2[1])
 
 // Analyze endpoint
@@ -88,6 +85,7 @@ const errors = await callHerbie("/api/analyze", {
     ], 0.12711304680349078]]
   })
 })
+assertIdAndPath(errors)
 assert.deepEqual(errors.points, [[[14.97651307489794], "2.3"]])
 
 // Local error endpoint
@@ -96,7 +94,7 @@ const localError = await callHerbie("/api/localerror", {
     formula: FPCoreFormula, sample: sample2.points
   })
 })
-
+assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)
 
 // Alternatives endpoint
@@ -108,6 +106,7 @@ const alternatives = await callHerbie("/api/alternatives", {
     ], 0.12711304680349078]]
   })
 })
+assertIdAndPath(alternatives)
 assert.equal(Array.isArray(alternatives.alternatives), true)
 
 // Exacts endpoint
@@ -116,6 +115,7 @@ const exacts = await callHerbie("/api/exacts", {
     formula: FPCoreFormula2, sample: eval_sample
   })
 })
+assertIdAndPath(exacts)
 assert.deepEqual(exacts.points, [[[1], -1.4142135623730951]])
 
 // Calculate endpoint
@@ -124,7 +124,7 @@ const calculate = await callHerbie("/api/calculate", {
     formula: FPCoreFormula2, sample: eval_sample
   })
 })
-
+assertIdAndPath(calculate)
 assert.deepEqual(calculate.points, [[[1], -1.4142135623730951]])
 
 // Cost endpoint
@@ -133,6 +133,7 @@ const cost = await callHerbie("/api/cost", {
     formula: FPCoreFormula2, sample: eval_sample
   })
 })
+assertIdAndPath(cost)
 assert.equal(cost.cost > 0, true)
 
 // // MathJS endpoint
@@ -185,4 +186,9 @@ async function callHerbie(endPoint, body) {
   } else {
     return rsp.json()
   }
+}
+
+function assertIdAndPath(json) {
+  assert.equal(json.job.length > 0, true)
+  assert.equal(json.path.includes("."), true)
 }

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -1,5 +1,4 @@
 import { strict as assert } from 'node:assert';  // use strict equality everywhere 
-import { time } from 'node:console';
 
 // Future TODO: before this API becomes set in stone/offered publicly, we should change the results of these methods to be just the output data rather than duplicating input values.
 
@@ -64,8 +63,9 @@ assert.notEqual(jid, null)
 
 const sample = await sampleRSP.json()
 
+// Test for job id and path, these could be better
 assert.equal(sample.job.length > 0, true)
-assert.equal(sample.path.length > 0, true)
+assert.equal(sample.path.includes("."), true)
 
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';  // use strict equality everywhere 
+import { time } from 'node:console';
 
 // Future TODO: before this API becomes set in stone/offered publicly, we should change the results of these methods to be just the output data rather than duplicating input values.
 
@@ -62,6 +63,10 @@ const jid = sampleRSP.headers.get("x-herbie-job-id")
 assert.notEqual(jid, null)
 
 const sample = await sampleRSP.json()
+
+assert.equal(sample.job.length > 0, true)
+assert.equal(sample.path.length > 0, true)
+
 const SAMPLE_SIZE = 8000
 assert.ok(sample.points)
 const points = sample.points

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -415,7 +415,7 @@
      (define result (wait-for-job id))
      (define pctx (job-result-backend result))
      (define repr (context-repr (test-context test)))
-     (hasheq 'points (pcontext->json pctx repr) 'job id 'path (format "~a.~a" id *herbie-commit*)))))
+     (hasheq 'points (pcontext->json pctx repr) 'job id 'path (make-path id)))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)
@@ -439,7 +439,7 @@
                                  (define pt (first pt&err))
                                  (define err (second pt&err))
                                  (list pt (format-bits (ulps->bits err)))))
-                             (hasheq 'points errs 'job id 'path (format "~a.~a" id *herbie-commit*)))))
+                             (hasheq 'points errs 'job id 'path (make-path id)))))
 
 ;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
 (define exacts-endpoint
@@ -459,7 +459,7 @@
                    #:timeline-disabled? #t))
      (define id (start-job command))
      (define result (wait-for-job id))
-     (hasheq 'points (job-result-backend result) 'job id 'path (format "~a.~a" id *herbie-commit*)))))
+     (hasheq 'points (job-result-backend result) 'job id 'path (make-path id)))))
 
 (define calculate-endpoint
   (post-with-json-response (lambda (post-data)
@@ -479,7 +479,7 @@
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define approx (job-result-backend result))
-                             (hasheq 'points approx 'job id 'path (format "~a.~a" id *herbie-commit*)))))
+                             (hasheq 'points approx 'job id 'path (make-path id)))))
 
 (define local-error-endpoint
   (post-with-json-response (lambda (post-data)
@@ -520,7 +520,7 @@
                                             (format-bits (errors-score (first err)))
                                             'children
                                             '())])))
-                             (hasheq 'tree tree 'job id 'path (format "~a.~a" id *herbie-commit*)))))
+                             (hasheq 'tree tree 'job id 'path (make-path id)))))
 
 (define alternatives-endpoint
   (post-with-json-response
@@ -577,7 +577,7 @@
              splitpoints
              'job
              id
-             'path (format "~a.~a" id *herbie-commit*)))))
+             'path (make-path id)))))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)
@@ -598,7 +598,7 @@
      (define id (start-job command))
      (define result (wait-for-job id))
      (define cost (job-result-backend result))
-     (hasheq 'cost cost 'jod id 'path (format "~a.~a" id *herbie-commit*)))))
+     (hasheq 'cost cost 'jod id 'path (make-path id)))))
 
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -415,7 +415,7 @@
      (define result (wait-for-job id))
      (define pctx (job-result-backend result))
      (define repr (context-repr (test-context test)))
-     (hasheq 'points (pcontext->json pctx repr) 'job id 'commit *herbie-commit*))))
+     (hasheq 'points (pcontext->json pctx repr) 'job id 'path (format "~a.~a" id *herbie-commit*)))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)
@@ -439,7 +439,7 @@
                                  (define pt (first pt&err))
                                  (define err (second pt&err))
                                  (list pt (format-bits (ulps->bits err)))))
-                             (hasheq 'points errs 'job id 'commit *herbie-commit*))))
+                             (hasheq 'points errs 'job id 'path (format "~a.~a" id *herbie-commit*)))))
 
 ;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
 (define exacts-endpoint
@@ -459,7 +459,7 @@
                    #:timeline-disabled? #t))
      (define id (start-job command))
      (define result (wait-for-job id))
-     (hasheq 'points (job-result-backend result) 'job id 'commit *herbie-commit*))))
+     (hasheq 'points (job-result-backend result) 'job id 'path (format "~a.~a" id *herbie-commit*)))))
 
 (define calculate-endpoint
   (post-with-json-response (lambda (post-data)
@@ -479,7 +479,7 @@
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define approx (job-result-backend result))
-                             (hasheq 'points approx 'job id 'commit *herbie-commit*))))
+                             (hasheq 'points approx 'job id 'path (format "~a.~a" id *herbie-commit*)))))
 
 (define local-error-endpoint
   (post-with-json-response (lambda (post-data)
@@ -520,7 +520,7 @@
                                             (format-bits (errors-score (first err)))
                                             'children
                                             '())])))
-                             (hasheq 'tree tree 'job id 'commit *herbie-commit*))))
+                             (hasheq 'tree tree 'job id 'path (format "~a.~a" id *herbie-commit*)))))
 
 (define alternatives-endpoint
   (post-with-json-response
@@ -577,8 +577,7 @@
              splitpoints
              'job
              id
-             'commit
-             *herbie-commit*))))
+             'path (format "~a.~a" id *herbie-commit*)))))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)
@@ -599,7 +598,7 @@
      (define id (start-job command))
      (define result (wait-for-job id))
      (define cost (job-result-backend result))
-     (hasheq 'cost cost 'jod id 'commit *herbie-commit*))))
+     (hasheq 'cost cost 'jod id 'path (format "~a.~a" id *herbie-commit*)))))
 
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -598,7 +598,7 @@
      (define id (start-job command))
      (define result (wait-for-job id))
      (define cost (job-result-backend result))
-     (hasheq 'cost cost 'jod id 'path (make-path id)))))
+     (hasheq 'cost cost 'job id 'path (make-path id)))))
 
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -8,6 +8,7 @@
 (require (submod "../utils/timeline.rkt" debug))
 
 (provide completed-job?
+         make-path
          get-results-for
          get-improve-job-data
          job-count
@@ -19,6 +20,9 @@
          start-job-server)
 
 #| Job Server Public API section |#
+; computes the path used for server URLs
+(define (make-path id)
+  (format "~a.~a" id *herbie-commit*))
 
 ; Helers to isolated *completed-jobs*
 (define (completed-job? id)
@@ -31,7 +35,7 @@
 ; I don't like how specific this function is but it keeps the API boundary.
 (define (get-improve-job-data)
   (for/list ([(k v) (in-hash *completed-jobs*)] #:when (equal? (job-result-command v) 'improve))
-    (get-table-data v (format "~a.~a" k *herbie-commit*))))
+    (get-table-data v (make-path k))))
 
 (define (job-count)
   (hash-count *job-status*))
@@ -83,7 +87,7 @@
 (define (already-computed? job-id)
   (or (hash-has-key? *completed-jobs* job-id)
       (and (*demo-output*)
-           (directory-exists? (build-path (*demo-output*) (format "~a.~a" job-id *herbie-commit*))))))
+           (directory-exists? (build-path (*demo-output*) (make-path job-id))))))
 
 (define (internal-wait-for-job job-id)
   (eprintf "Waiting for job\n")
@@ -109,7 +113,7 @@
 
 (define (run-job job-info)
   (match-define (work job-id info sema) job-info)
-  (define path (format "~a.~a" job-id *herbie-commit*))
+  (define path (make-path job-id))
   (cond ;; Check caches if job as already been completed
     [(hash-has-key? *completed-jobs* job-id) (semaphore-post sema)]
     [(and (*demo-output*) (directory-exists? (build-path (*demo-output*) path)))


### PR DESCRIPTION
This PR adds the commit hash to reconstruct the graph.html links for Odesssy to link to.

Adds missing `Access-Control-Allow-Origin` header to the `timeline` API.