### PR TITLE
Fix nightly somehow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 
 update:
 	raco pkg install --skip-installed --no-docs --auto --name herbie src/
-	raco pkg update rival
+	raco pkg update --auto rival
 	raco pkg update --name herbie --deps search-auto src/
 
 egg-herbie:


### PR DESCRIPTION
Not sure why `--auto` works in this case, but the `raco pkg update rival` command doesn't work by default if it's a linked repository.