### PR TITLE
Fix `raco fmt` check

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: make install
 
       - name: "Test raco fmt compliance"
-        run: (find . -type f -name '*.rkt' | xargs raco fmt) && git diff --exit-code
+        run: (find . -type f -name '*.rkt' | xargs raco fmt -i) && git diff --exit-code
 
       # Run the Herbie unit tests
       - name: "Run Herbie unit tests"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: make install
 
       - name: "Test raco fmt compliance"
-        run: raco fmt -i **/*.rkt && git diff --exit-code
+        run: (find . -type f -name '*.rkt' | xargs raco fmt) && git diff --exit-code
 
       # Run the Herbie unit tests
       - name: "Run Herbie unit tests"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: make install
 
       - name: "Test raco fmt compliance"
-        run: raco fmt -i $(find . -name '*.rkt') && git diff --exit-code
+        run: make fmt && git diff --exit-code
 
       # Run the Herbie unit tests
       - name: "Run Herbie unit tests"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: make install
 
       - name: "Test raco fmt compliance"
-        run: (find . -type f -name '*.rkt' | xargs raco fmt -i) && git diff --exit-code
+        run: raco fmt -i $(find . -name '*.rkt') && git diff --exit-code
 
       # Run the Herbie unit tests
       - name: "Run Herbie unit tests"

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ hooks:
 	echo "#!/bin/sh" >.git/hooks/pre-commit
 	echo "raco fmt -i \$$(find . -name '*.rkt')" >>.git/hooks/pre-commit
 
+format:
+	raco fmt -i $(shell find . -name '*.rkt')
+
 # This rule is run by herbie.uwplse.org on every commit to Github.
 # It does not restart the demo server, but it does pull new static content
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ start-server:
 
 hooks:
 	echo "#!/bin/sh" >.git/hooks/pre-commit
-	echo "raco fmt -i \$$(find . -name '*.rkt')" >>.git/hooks/pre-commit
+	echo "make fmt" >>.git/hooks/pre-commit
 
-format:
+fmt:
 	raco fmt -i $(shell find . -name '*.rkt')
 
 # This rule is run by herbie.uwplse.org on every commit to Github.

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -82,11 +82,11 @@
         (match-define (list cost accuracy _ ...) point)
         (list (/ cost initial-cost*) accuracy))))
   (define frontier
-    (map (match-lambda
-           [(list cost accuracy)
-            ;; Equivalent to (/ 1 (/ cost tests-length))
-            (list (/ 1 (/ cost tests-length)) (- 1 (/ accuracy maximum-accuracy)))])
-         (pareto-combine rescaled #:convex? #t)))
+    (map
+     (match-lambda
+       ;; Equivalent to (/ 1 (/ cost tests-length))
+       [(list cost accuracy) (list (/ 1 (/ cost tests-length)) (- 1 (/ accuracy maximum-accuracy)))])
+     (pareto-combine rescaled #:convex? #t)))
   (define maximum-cost
     (argmax identity
             (cons 0.0 ;; To prevent `argmax` from signaling an error in case `tests` is empty

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -577,7 +577,8 @@
              splitpoints
              'job
              id
-             'path (make-path id)))))
+             'path
+             (make-path id)))))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -86,8 +86,7 @@
 
 (define (already-computed? job-id)
   (or (hash-has-key? *completed-jobs* job-id)
-      (and (*demo-output*)
-           (directory-exists? (build-path (*demo-output*) (make-path job-id))))))
+      (and (*demo-output*) (directory-exists? (build-path (*demo-output*) (make-path job-id))))))
 
 (define (internal-wait-for-job job-id)
   (eprintf "Waiting for job\n")

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -118,9 +118,7 @@
   ; Not totally clear if this should actually use the precondition
   (define start-real-compiler
     (and start-prog
-         (make-real-compiler 
-           (list (expand-accelerators (prog->spec start-prog)))
-           (list ctx*))))
+         (make-real-compiler (list (expand-accelerators (prog->spec start-prog))) (list ctx*))))
 
   (define (find-split expr1 expr2 v1 v2)
     (define (pred v)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1326,13 +1326,12 @@
        (unless (egraph-expr-equal? egg-graph start end ctx)
          (error 'run-egg
                 "cannot find proof; start and end are not equal.\n start: ~a \n end: ~a"
-                start end))
-        (define proof (egraph-get-proof egg-graph start end ctx))
-        (when (null? proof)
-          (error 'run-egg
-                 "proof extraction failed between`~a` and `~a`"
-                 start end))
-        proof)]
+                start
+                end))
+       (define proof (egraph-get-proof egg-graph start end ctx))
+       (when (null? proof)
+         (error 'run-egg "proof extraction failed between`~a` and `~a`" start end))
+       proof)]
     [`(equal? . ((,start-exprs . ,end-exprs) ...)) ; term equality?
      (for/list ([start (in-list start-exprs)] [end (in-list end-exprs)])
        (egraph-expr-equal? egg-graph start end ctx))]

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -42,8 +42,7 @@
 (define (make-odd-identities spec ctx)
   (for/list ([var (in-list (context-vars ctx))]
              [repr (in-list (context-var-reprs ctx))]
-             #:when (and (has-fabs-neg-impls? repr)
-                         (has-copysign-impl? repr)))
+             #:when (and (has-fabs-neg-impls? repr) (has-copysign-impl? repr)))
     (list 'odd var (replace-vars `((,var . (neg ,var))) `(neg ,spec)))))
 
 ;; Swap identities: f(a, b) = f(b, a)
@@ -112,17 +111,12 @@
   (define abs-instrs '())
   (define negabs-instrs '())
   (define swaps '())
-  (for ([ident (in-list identities)]
-        [expr-equal? (in-list equal?-lst)]
-        #:when expr-equal?)
+  (for ([ident (in-list identities)] [expr-equal? (in-list equal?-lst)] #:when expr-equal?)
     (match ident
-      [(list 'even var _)
-       (set! abs-instrs (cons (list 'abs var) abs-instrs))]
-      [(list 'odd var _)
-       (set! negabs-instrs (cons (list 'negabs var) negabs-instrs))]
-      [(list 'swap pair _)
-       (set! swaps (cons pair swaps))]))
-  
+      [(list 'even var _) (set! abs-instrs (cons (list 'abs var) abs-instrs))]
+      [(list 'odd var _) (set! negabs-instrs (cons (list 'negabs var) negabs-instrs))]
+      [(list 'swap pair _) (set! swaps (cons pair swaps))]))
+
   (define components (connected-components (context-vars ctx) swaps))
   (define sort-instrs
     (for/list ([component (in-list components)] #:when (> (length component) 1))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -20,9 +20,9 @@
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
-    [(list (? cast-impl? op) body) ; conversion (e.g. posit16->f64)
-     (list op (simplify body))]
-    [`(,(and (or '+ '- '*) op) ,args ...) ; v-ary 
+    ; conversion (e.g. posit16->f64)
+    [(list (? cast-impl? op) body) (list op (simplify body))]
+    [`(,(and (or '+ '- '*) op) ,args ...) ; v-ary
      (define args* (map simplify args))
      (define val (apply eval-application op args*))
      (or val (simplify-node (list* op args*)))]

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -40,22 +40,23 @@
   (define vars (map car env))
   (define itypes (map cdr env))
   (define ctx (context vars repr itypes))
-  
+
   (define spec1 (expand-accelerators (prog->spec p1)))
   (define spec2 (expand-accelerators (prog->spec p2)))
   (match-define (list pts exs)
-    (parameterize ([*num-points* (num-test-points)]
-                   [*max-find-range-depth* 0])
+    (parameterize ([*num-points* (num-test-points)] [*max-find-range-depth* 0])
       (cdr (sample-points '(TRUE) (list spec1) (list ctx)))))
 
   (define compiler (make-real-compiler (list spec2) (list ctx)))
   (for ([pt (in-list pts)] [v1 (in-list exs)])
     (with-check-info* (map make-check-info vars pt)
-      (λ ()
-        (define-values (status v2) (real-apply compiler pt))
-        (with-check-info (['lhs v1] ['rhs v2] ['status status])
-          (when (and (real? v2) (nan? v2) (not (set-member? '(exit unsamplable) status)))
-            (fail "Right hand side returns NaN")))))))
+                      (λ ()
+                        (define-values (status v2) (real-apply compiler pt))
+                        (with-check-info (['lhs v1] ['rhs v2] ['status status])
+                                         (when (and (real? v2)
+                                                    (nan? v2)
+                                                    (not (set-member? '(exit unsamplable) status)))
+                                           (fail "Right hand side returns NaN")))))))
 
 (define (check-rule-correct test-rule)
   (match-define (rule name p1 p2 itypes repr) test-rule)

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -125,21 +125,21 @@
   (define costs (make-hash))
   (define convs
     (reap [sow]
-      (for ([impl-sig (in-list pform)])
-        (match-define (list op tsig cost) impl-sig)
-        (match* (op tsig)
-          [('cast `(,itype ,otype))
-           (define irepr (get-representation itype))
-           (define orepr (get-representation otype))
-           (cond
-             [(get-cast-impl irepr orepr) =>
-              (lambda (impl)
-                (hash-set! costs impl cost)
-                (sow impl))]
-             [else (set-add! missing (list 'cast itype otype))])]
-          [('cast _)
-           (error 'make-platform "unexpected type signature for `cast` ~a" tsig)]
-          [(_ _) (void)]))))
+          (for ([impl-sig (in-list pform)])
+            (match-define (list op tsig cost) impl-sig)
+            (match* (op tsig)
+              [('cast `(,itype ,otype))
+               (define irepr (get-representation itype))
+               (define orepr (get-representation otype))
+               (cond
+                 [(get-cast-impl irepr orepr)
+                  =>
+                  (lambda (impl)
+                    (hash-set! costs impl cost)
+                    (sow impl))]
+                 [else (set-add! missing (list 'cast itype otype))])]
+              [('cast _) (error 'make-platform "unexpected type signature for `cast` ~a" tsig)]
+              [(_ _) (void)]))))
   ; load the operator implementations
   (define impls
     (reap [sow]

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -219,8 +219,7 @@
 (define (prog->fpcore prog repr)
   (let loop ([expr prog])
     (match expr
-      [`(if ,cond ,ift ,iff)
-       `(if ,(loop cond) ,(loop ift) ,(loop iff))]
+      [`(if ,cond ,ift ,iff) `(if ,(loop cond) ,(loop ift) ,(loop iff))]
       [`(,(? cast-impl? impl) ,body)
        (match-define (list irepr) (impl-info impl 'itype))
        (define body* (prog->fpcore body irepr))
@@ -246,10 +245,8 @@
 ;; Translates an ImplProg to a Spec.
 (define (prog->spec expr)
   (match expr
-    [`(if ,cond ,ift ,iff)
-     `(if ,(prog->spec cond) ,(prog->spec ift) ,(prog->spec iff))]
-    [`(,(? cast-impl? impl) ,body)
-     `(,impl ,(prog->spec body))]
+    [`(if ,cond ,ift ,iff) `(if ,(prog->spec cond) ,(prog->spec ift) ,(prog->spec iff))]
+    [`(,(? cast-impl? impl) ,body) `(,impl ,(prog->spec body))]
     [`(,impl ,args ...)
      (define op (impl->operator impl))
      (define args* (map prog->spec args))
@@ -291,7 +288,7 @@
          (define op* (get-parametric-operator 'neg atype))
          (values (list op* arg*) (impl-info op* 'otype))]
         [`(,(? cast-impl? impl) ,body)
-        ; this case is supported here but not by fpcore->prog
+         ; this case is supported here but not by fpcore->prog
          (match-define (list irepr) (impl-info impl 'itype))
          (define-values (body* _) (loop body (struct-copy context ctx [repr irepr])))
          (values `(,impl ,body*) (impl-info impl 'otype))]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -439,11 +439,10 @@
     (define ctx (context vars orepr ireprs))
     (define compiler (make-real-compiler (list spec) (list ctx)))
     (define fail ((representation-bf->repr orepr) +nan.bf))
-    (procedure-rename
-      (lambda pt
-        (define-values (_ exs) (real-apply compiler pt))
-        (if exs (first exs) fail))
-      (sym-append 'synth: name)))
+    (procedure-rename (lambda pt
+                        (define-values (_ exs) (real-apply compiler pt))
+                        (if exs (first exs) fail))
+                      (sym-append 'synth: name)))
 
   ;; Get floating-point implementation
   (define fl-proc


### PR DESCRIPTION
Unfortunately, globstar `**` is not universal in all shells. Changes the `raco fmt` compliance check from `raco fmt -i **/*.rkt` to `raco fmt -i $(find . -name '*.rkt')`. Added a `make fmt` rules to handle this.