### PR TITLE
IR cleanup

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -488,7 +488,7 @@
                              (define sample (hash-ref post-data 'sample))
                              (define seed (hash-ref post-data 'seed #f))
                              (define test (parse-test formula))
-                             (define expr (prog->fpcore (test-input test) (test-output-repr test)))
+                             (define expr (prog->fpcore (test-input test)))
                              (define pcontext (json->pcontext sample (test-context test)))
                              (define command
                                (create-job 'local-error

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -6,7 +6,6 @@
 
 (require "../syntax/read.rkt"
          "../syntax/sugar.rkt"
-         "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "../core/localize.rkt"
          "../utils/alternative.rkt"
@@ -293,15 +292,15 @@
   (table-row (test-name test)
              (test-identifier test)
              status
-             (prog->fpcore (test-pre test) repr)
+             (prog->fpcore (test-pre test))
              preprocess
              (representation-name repr)
              '() ; TODO: eliminate field
              (test-vars test)
              (map car (job-result-warnings result))
-             (prog->fpcore (test-input test) repr)
+             (prog->fpcore (test-input test))
              #f
-             (prog->fpcore (test-spec test) repr)
+             (prog->fpcore (test-spec test))
              (test-output test)
              #f
              #f
@@ -422,4 +421,4 @@
            ,@(append (for/list ([(target enabled?) (in-dict (table-row-target-prog row))]
                                 #:when enabled?)
                        `(:alt ,target)))
-           ,(prog->fpcore expr* repr)))
+           ,(prog->fpcore expr*)))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -2,7 +2,6 @@
 
 (require "rules.rkt"
          "../syntax/sugar.rkt"
-         "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "egg-herbie.rkt"
          "rr.rkt"
@@ -34,7 +33,7 @@
                               #;(log ,log-x ,exp-x))))
 
 (define (taylor-alt altn)
-  (define expr (expand-accelerators (prog->spec (alt-expr altn))))
+  (define expr (prog->spec (alt-expr altn)))
   (reap [sow]
         (for* ([var (free-variables expr)] [transform-type transforms-to-try])
           (match-define (list name f finv) transform-type)

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -5,8 +5,7 @@
          "programs.rkt"
          "egg-herbie.rkt"
          "rules.rkt"
-         "../syntax/sugar.rkt"
-         "../syntax/syntax.rkt")
+         "../syntax/sugar.rkt")
 
 (provide add-soundiness)
 
@@ -74,7 +73,7 @@
       ; recursive rewrite using egg (spec -> impl)
       [(alt expr `(rr ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
-       (define start-expr* (expand-accelerators (prog->spec start-expr)))
+       (define start-expr* (prog->spec start-expr))
        (define end-expr (location-get loc expr))
        (define rewrite (cons start-expr* end-expr))
        (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
@@ -88,7 +87,7 @@
        (define start-expr*
          (match (alt-event prev)
            [(list 'taylor _ ...) start-expr] ; input was inserted as-is
-           [_ (expand-accelerators (prog->spec start-expr))]))
+           [_ (prog->spec start-expr)]))
        (define rewrite (cons start-expr* end-expr))
 
        (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -2,17 +2,14 @@
 
 (require rackunit)
 (require "../utils/common.rkt"
-         "../utils/errors.rkt"
          "../utils/float.rkt"
          "rules.rkt"
          (submod "rules.rkt" internals)
          "../syntax/platform.rkt"
          "../syntax/load-plugin.rkt"
-         "../syntax/syntax.rkt"
          "../syntax/sugar.rkt"
          "../syntax/types.rkt"
          "compiler.rkt"
-         "programs.rkt"
          "rival.rkt"
          "sampling.rkt")
 
@@ -46,8 +43,8 @@
   (define itypes (map cdr env))
   (define ctx (context vars repr itypes))
 
-  (define spec1 (expand-accelerators (prog->spec p1)))
-  (define spec2 (expand-accelerators (prog->spec p2)))
+  (define spec1 (prog->spec p1))
+  (define spec2 (prog->spec p2))
   (match-define (list pts exs)
     (parameterize ([*num-points* (num-test-points)] [*max-find-range-depth* 0])
       (cdr (sample-points '(TRUE) (list spec1) (list ctx)))))
@@ -69,8 +66,8 @@
   (define ctx (context fv repr (map (curry dict-ref itypes) fv)))
 
   (define pre (dict-ref *conditions* name '(TRUE)))
-  (define spec1 (expand-accelerators (prog->spec p1)))
-  (define spec2 (expand-accelerators (prog->spec p2)))
+  (define spec1 (prog->spec p1))
+  (define spec2 (prog->spec p2))
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)] [*max-find-range-depth* 0])
       (cdr (sample-points pre (list spec1 spec2) (list ctx ctx)))))

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -266,18 +266,15 @@
                  `(option ,lang))))
 
   (define body
-    `(div ,(if (equal? precondition '(TRUE))
-               ""
-               `(div ([id "precondition"])
-                     (div ((class "program math"))
-                          "\\["
-                          ,(expr->tex (prog->fpcore precondition))
-                          "\\]")))
-          (div ((class "implementation") [data-language "Math"])
-               (div ((class "program math")) "\\[" ,math-out "\\]"))
-          ,@(for/list ([(lang out) (in-dict versions)])
-              `(div ((class "implementation") [data-language ,lang])
-                    (pre ((class "program")) ,out)))))
+    `(div
+      ,(if (equal? precondition '(TRUE))
+           ""
+           `(div ([id "precondition"])
+                 (div ((class "program math")) "\\[" ,(expr->tex (prog->fpcore precondition)) "\\]")))
+      (div ((class "implementation") [data-language "Math"])
+           (div ((class "program math")) "\\[" ,math-out "\\]"))
+      ,@(for/list ([(lang out) (in-dict versions)])
+          `(div ((class "implementation") [data-language ,lang]) (pre ((class "program")) ,out)))))
 
   (values dropdown body))
 
@@ -294,27 +291,25 @@
 (define/contract (render-fpcore test)
   (-> test? string?)
   (define output-repr (test-output-repr test))
-  (string-join (filter identity
-                       (list (if (test-identifier test)
-                                 (format "(FPCore ~a ~a" (test-identifier test) (test-vars test))
-                                 (format "(FPCore ~a" (test-vars test)))
-                             (format "  :name ~s" (test-name test))
-                             (format "  :precision ~s" (representation-name (test-output-repr test)))
-                             (if (equal? (test-pre test) '(TRUE))
-                                 #f
-                                 (format "  :pre ~a" (prog->fpcore (test-pre test))))
-                             (if (equal? (test-expected test) #t)
-                                 #f
-                                 (format "  :herbie-expected ~a" (test-expected test)))
-                             (and (test-output test)
-                                  (not (null? (test-output test)))
-                                  (format "\n~a"
-                                          (string-join (map (lambda (exp)
-                                                              (format "  :alt\n  ~a\n" (car exp)))
-                                                            (test-output test))
-                                                       "\n")))
-                             (format "  ~a)" (prog->fpcore (test-input test)))))
-               "\n"))
+  (string-join
+   (filter
+    identity
+    (list
+     (if (test-identifier test)
+         (format "(FPCore ~a ~a" (test-identifier test) (test-vars test))
+         (format "(FPCore ~a" (test-vars test)))
+     (format "  :name ~s" (test-name test))
+     (format "  :precision ~s" (representation-name (test-output-repr test)))
+     (if (equal? (test-pre test) '(TRUE)) #f (format "  :pre ~a" (prog->fpcore (test-pre test))))
+     (if (equal? (test-expected test) #t) #f (format "  :herbie-expected ~a" (test-expected test)))
+     (and (test-output test)
+          (not (null? (test-output test)))
+          (format "\n~a"
+                  (string-join (map (lambda (exp) (format "  :alt\n  ~a\n" (car exp)))
+                                    (test-output test))
+                               "\n")))
+     (format "  ~a)" (prog->fpcore (test-input test)))))
+   "\n"))
 
 (define (format-percent num den)
   (string-append (if (zero? den)

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -51,7 +51,7 @@
          core->js)
 
 (define (program->fpcore expr ctx #:ident [ident #f])
-  (define body (prog->fpcore expr (context-repr ctx)))
+  (define body (prog->fpcore expr))
   (if ident (list 'FPCore ident (context-vars ctx) body) (list 'FPCore (context-vars ctx) body)))
 
 (define (fpcore-add-props core props)
@@ -271,7 +271,7 @@
                `(div ([id "precondition"])
                      (div ((class "program math"))
                           "\\["
-                          ,(expr->tex (prog->fpcore precondition output-repr))
+                          ,(expr->tex (prog->fpcore precondition))
                           "\\]")))
           (div ((class "implementation") [data-language "Math"])
                (div ((class "program math")) "\\[" ,math-out "\\]"))
@@ -302,7 +302,7 @@
                              (format "  :precision ~s" (representation-name (test-output-repr test)))
                              (if (equal? (test-pre test) '(TRUE))
                                  #f
-                                 (format "  :pre ~a" (prog->fpcore (test-pre test) output-repr)))
+                                 (format "  :pre ~a" (prog->fpcore (test-pre test))))
                              (if (equal? (test-expected test) #t)
                                  #f
                                  (format "  :herbie-expected ~a" (test-expected test)))
@@ -313,7 +313,7 @@
                                                               (format "  :alt\n  ~a\n" (car exp)))
                                                             (test-output test))
                                                        "\n")))
-                             (format "  ~a)" (prog->fpcore (test-input test) output-repr))))
+                             (format "  ~a)" (prog->fpcore (test-input test)))))
                "\n"))
 
 (define (format-percent num den)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -17,7 +17,7 @@
 ;; - operators denote real computations while rounding contexts decide format
 ;;
 ;;  <FPCore> ::= (FPCore (<var> ...) <props> ... <expr>)
-;;             | (FPCore <name> (<var> ...) <props> ... <expr>)
+;;             | (FPCore <id> (<var> ...) <props> ... <expr>)
 ;;
 ;;  <expr>   ::= (let ([<id> <expr>] ...) <expr>)
 ;;             | (let* ([<id> <expr>] ...) <expr>)
@@ -42,7 +42,7 @@
 ;; <expr> ::= (if <expr> <expr> <expr>)
 ;;        ::= (<impl> <expr> ...)
 ;;        ::= (literal <number> <repr>)
-;;        ::= <var>
+;;        ::= <id>
 ;;
 ;; Every operator has a type signature where types are representations.
 ;; In practice, most operator implemenetations have uniform representations but
@@ -61,7 +61,7 @@
 ;; <expr> ::= (if <expr> <expr> <expr>)
 ;;        ::= (<op> <expr> ...)
 ;;        ::= <number>
-;;        ::= <var>
+;;        ::= <id>
 ;;
 
 ;; Expression pre-processing for normalizing expressions.

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -1,8 +1,8 @@
 #lang racket
 
-(require "../utils/errors.rkt"
-         "types.rkt"
+(require "types.rkt"
          "syntax.rkt")
+
 (provide fpcore->prog
          prog->fpcore
          prog->spec)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -7,64 +7,61 @@
          prog->fpcore
          prog->spec)
 
-;; Herbie uses various IRs.
-;; All IRs are S-expressions with symbolic operators, variables and numbers.
+;; Herbie uses three expression languages.
+;; All formats are S-expressions with variables, numbers, and applications.
 ;;
-;; ## FPCore (with a couple modifications) ##
+;; FPCore: the input/output language
 ;;
-;; - input language, loopless, with bindings, lightly annotated
-;; - operators denote real computations
-;; - rounding context (in addition to variable context) decides format at node
+;; - standardized interchange format with other tools
+;; - using loopless, tensorless subset
+;; - operators denote real computations while rounding contexts decide format
 ;;
 ;;  <FPCore> ::= (FPCore (<var> ...) <props> ... <expr>)
-;;           ::= (FPCore <name> (<var> ...) <props> ... <expr>)
-;;  <expr>   ::= (let ([<var> <expr>] ...) <expr>)
-;;           ::= (let* ([<var> <expr>] ...) <expr>)
-;;           ::= (if <expr> <expr> <expr>
-;;           ::= (! <props> ... <expr>)
-;;           ::= (<op> <expr> ...)
-;;           ::= <var>
-;;           ::= <number>
+;;             | (FPCore <name> (<var> ...) <props> ... <expr>)
 ;;
-;; To propagate types through an FPCore, the types of the rounding context and
-;; variables must be known. Variable types propagate up and rounding contexts
-;; propagate down (modified only by !)
+;;  <expr>   ::= (let ([<id> <expr>] ...) <expr>)
+;;             | (let* ([<id> <expr>] ...) <expr>)
+;;             | (if <expr> <expr> <expr>
+;;             | (cast <expr>)
+;;             | (! <props> ... <expr>)
+;;             | (<op> <expr> ...)
+;;             | <number>
+;;             | <id>
 ;;
-;; ## ImplProg ##
+;;  <var>    ::= <id>
+;;             | (! <props> ... <expr>)
 ;;
-;; - internal language, floating-point programs
-;; - rounding context from FPCore embedded in operators (called implementations)
+;; LImpl: the language of floating-point expressions
+;;
+;; - internal language, describes floating-point expressions
+;; - unary minus represented by `neg`
+;; - every operator is rounded
 ;; - let expressions are inlined
+;; - numbers are rounded to a particular format
 ;;
 ;; <expr> ::= (if <expr> <expr> <expr>)
 ;;        ::= (<impl> <expr> ...)
+;;        ::= (literal <number> <repr>)
 ;;        ::= <var>
-;;        ::= (literal <number> <repr-name>)
 ;;
-;; Every (operator) implementation has a type signature taking inputs each
-;; with a given number format producing an output of a possibly different
-;; number format. In practice, most operator implemenetations have uniform
-;; precision with only casts being multi-precision.
+;; Every operator has a type signature where types are representations.
+;; In practice, most operator implemenetations have uniform representations but
+;; operations like casts are multi-format.
 ;;
-;; ## Spec ##
+;; LSpec: the language of mathematical formula
 ;;
-;; - internal language, (almost) real-number programs
+;; - internal language, describes real-number formula
+;; - unary minus represented by `neg`
+;; - every operator is a real-number operation
+;; - every operator is atomic (cannot be decomposed into simpler operations)
 ;; - let expressions are inlined
-;; - almost like FPCore exception
-;;   (i) unary negation is `neg`
-;;   (ii) casts are left as-is
+;; - casts are mapped to the identity operation
+;; - numbers are formatless
 ;;
 ;; <expr> ::= (if <expr> <expr> <expr>)
 ;;        ::= (<op> <expr> ...)
-;;        ::= <var>
 ;;        ::= <number>
-;;
-;; Every operator takes real numbers and produces a real number output.
-;; Ideally, a specification would be an FPCore with its rounding
-;; annotations completely stripped, but this conversion would be irreversible
-;; for multi-precision expressions due to the removal of casts.
-;; These issues exist for historical reasons and should be removed from Herbie.
-;; Unfortunately, removing it will require refactoring core algorithms.
+;;        ::= <var>
 ;;
 
 ;; Expression pre-processing for normalizing expressions.

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -7,7 +7,7 @@
          "../core/rival.rkt"
          "types.rkt")
 
-(provide (rename-out [operator-or-impl? operator?] [expand-accelerator-spec expand-accelerators])
+(provide (rename-out [operator-or-impl? operator?])
          (struct-out literal)
          variable?
          constant-operator?
@@ -18,6 +18,7 @@
          all-operators
          all-constants
          all-accelerators
+         expand-accelerators
          impl-exists?
          impl-info
          impl->operator
@@ -180,7 +181,7 @@
 
 ;; Expands an "accelerator" specification.
 ;; Any nested accelerator is unfolded into its definition.
-(define (expand-accelerator-spec spec)
+(define (expand-accelerators spec)
   (let loop ([expr spec])
     (match expr
       [(? number?) expr]
@@ -208,7 +209,7 @@
   ; check the spec if it is provided
   (when spec
     (check-accelerator-spec! name itypes otype spec)
-    (set! spec (expand-accelerator-spec spec)))
+    (set! spec (expand-accelerators spec)))
   ; update tables
   (define info (operator name itypes* otype* spec deprecated?))
   (hash-set! operators name info)


### PR DESCRIPTION
Follow up to #919.
- `prog->spec` always expands accelerators
- removes unnecessary argument to `prog->fpcore`
- updates comment describing the IRs