### PR TITLE
CI: fix dependency caching

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -27,6 +27,7 @@ jobs:
         with:
             version: 8.12
             architecture: ${{ matrix.arch }}
+      # WARN: need to be careful with cargo paths
       - name: Cache Racket dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -35,11 +35,10 @@ jobs:
             ~/.cache/racket
             ~/.local/share/racket
             ~/Library/Racket/
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            egg-herbie/target/            
+            egg-herbie/target/
             ${{ env.APPDATA }}/Racket
       - name: Install Rust compiler
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Fixes crash in CI stemming from dependency caching. Removed `~/.cargo/bin` from cached paths since these are the executables that are downloaded when installing Rust.