### PR TITLE
Remove `expand-rules`

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -30,7 +30,6 @@
          default-egg-cost-proc
          make-egg-runner
          run-egg
-         get-canon-rule-name
          remove-rewrites)
 
 (module+ test

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -485,7 +485,7 @@
       (sweep! (add1 iter))))
 
   ; Invariant: all eclasses have an analysis
-  (for ([id (in-range n)])
+  #;(for ([id (in-range n)])
     (unless (vector-ref analysis id)
       (error 'regraph-analyze
              "analysis not run on all eclasses: ~a ~a"

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -11,8 +11,8 @@
 
 (define (canonicalize-rewrite proof)
   (match proof
-    [`(Rewrite=> ,rule ,something) (list 'Rewrite=> (get-canon-rule-name rule rule) something)]
-    [`(Rewrite<= ,rule ,something) (list 'Rewrite<= (get-canon-rule-name rule rule) something)]
+    [`(Rewrite=> ,rule ,something) (list 'Rewrite=> rule something)]
+    [`(Rewrite<= ,rule ,something) (list 'Rewrite<= rule something)]
     [(list _ ...) (map canonicalize-rewrite proof)]
     [_ proof]))
 


### PR DESCRIPTION
This PR removes the `expand-rules` function and then a lot of other code that only it calls. In the olden days, the goal of `expand-rules` was to: 1) convert a rule into one rule per representation; and 2) convert expansive rules like `a → 1 * a` into versions that weren't expansive, by inlining every possible head operator in place of `a`. However, nowadays our egraph extraction preserves types, so probably none of this is necessary, and we can simplify dramatically.