### PR TITLE
Fix local error job id hashing

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -97,6 +97,18 @@ const localError = await callHerbie("/api/localerror", {
 assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)
 
+const json1 = `
+{"formula":"${FPCoreFormula}","sample":[[[2.852044568544089e-150],1e+308]],"seed":5}`
+const json2 = `{"formula":"${FPCoreFormula}","sample":[[[1.5223342548065899e-15],1e+308]],"seed":5}`
+const localError1 = await callHerbie("/api/localerror", {
+  method: 'POST', body: json1
+})
+const localError2 = await callHerbie("/api/localerror", {
+  method: 'POST', body: json2
+})
+// Test that different sample points produce different job ids ensuring that different results are served for these inputs.
+assert.notEqual(localError1.job,localError2.job)
+
 // Alternatives endpoint
 
 const alternatives = await callHerbie("/api/alternatives", {

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -97,9 +97,12 @@ const localError = await callHerbie("/api/localerror", {
 assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)
 
-const json1 = `
-{"formula":"${FPCoreFormula}","sample":[[[2.852044568544089e-150],1e+308]],"seed":5}`
-const json2 = `{"formula":"${FPCoreFormula}","sample":[[[1.5223342548065899e-15],1e+308]],"seed":5}`
+const json1 = JSON.stringify({
+  formula: FPCoreFormula, sample: [[[2.852044568544089e-150], 1e+308]], seed: 5
+})
+const json2 = JSON.stringify({
+  formula: FPCoreFormula, sample: [[[1.5223342548065899e-15], 1e+308]], seed: 5
+})
 const localError1 = await callHerbie("/api/localerror", {
   method: 'POST', body: json1
 })
@@ -107,7 +110,7 @@ const localError2 = await callHerbie("/api/localerror", {
   method: 'POST', body: json2
 })
 // Test that different sample points produce different job ids ensuring that different results are served for these inputs.
-assert.notEqual(localError1.job,localError2.job)
+assert.notEqual(localError1.job, localError2.job)
 
 // Alternatives endpoint
 

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -24,7 +24,7 @@
 ;; points; and 2) a ground-truth output for each input.
 
 (define *pcontext* (make-parameter #f))
-(struct pcontext (points exacts))
+(struct pcontext (points exacts) #:prefab)
 
 (define (in-pcontext context)
   (in-parallel (in-vector (pcontext-points context)) (in-vector (pcontext-exacts context))))


### PR DESCRIPTION
This PR fixes a bug where `/localerror` jobs were be incorrectly hashed for job ids causing two request for the same formula but different points to serve what ever response was made first.