### PR TITLE
Approx nodes

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -7,7 +7,6 @@
 (provide egraph_create
          egraph_destroy
          egraph_add_expr
-         egraph_union
          egraph_run
          egraph_copy
          egraph_get_stop_reason
@@ -90,9 +89,6 @@
 
 ;; egraph pointer, s-expr string -> node number
 (define-eggmath egraph_add_expr (_fun _egraph-pointer _string/utf-8 -> _uint))
-
-;; egraph pointer, u32, u32 -> u32
-(define-eggmath egraph_union (_fun _egraph-pointer _uint _uint -> _uint))
 
 (define-eggmath destroy_egraphiters (_fun _pointer -> _void))
 

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -7,6 +7,7 @@
 (provide egraph_create
          egraph_destroy
          egraph_add_expr
+         egraph_union
          egraph_run
          egraph_copy
          egraph_get_stop_reason
@@ -90,6 +91,9 @@
 
 ;; egraph pointer, s-expr string -> node number
 (define-eggmath egraph_add_expr (_fun _egraph-pointer _string/utf-8 -> _uint))
+
+;; egraph pointer, u32, u32 -> u32
+(define-eggmath egraph_union (_fun _egraph-pointer _uint _uint -> _uint))
 
 (define-eggmath destroy_egraphiters (_fun _pointer -> _void))
 

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -22,7 +22,6 @@
          egraph_get_times_applied
          egraph_get_proof
          destroy_string
-         egraph_is_equal
          (struct-out EGraphIter)
          (struct-out FFIRule))
 
@@ -136,8 +135,6 @@
                       _pointer))
 
 (define-eggmath egraph_get_proof (_fun _egraph-pointer _string/utf-8 _string/utf-8 -> _pointer))
-
-(define-eggmath egraph_is_equal (_fun _egraph-pointer _string/utf-8 _string/utf-8 -> _stdbool))
 
 ;; node number -> (s-expr string) string
 (define-eggmath egraph_get_variants

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -82,21 +82,6 @@ pub unsafe extern "C" fn egraph_add_expr(ptr: *mut Context, expr: *const c_char)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_union(ptr: *mut Context, id1: u32, id2: u32) -> u32 {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let mut context = Box::from_raw(ptr);
-    let id1 = Id::from(id1 as usize);
-    let id2 = Id::from(id2 as usize);
-
-    context.runner.egraph.union(id1, id2);
-    context.runner.egraph.rebuild();
-    let id = context.runner.egraph.find(id1);
-
-    mem::forget(context);
-    usize::from(id) as u32
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_copy(ptr: *mut Context) -> *mut Context {
     // Safety: `ptr` was box allocated by `egraph_create`
     let context = Box::from_raw(ptr);

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -316,24 +316,6 @@ pub unsafe extern "C" fn egraph_get_proof(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_is_equal(
-    ptr: *mut Context,
-    expr: *const c_char,
-    goal: *const c_char,
-) -> bool {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let mut context = ManuallyDrop::new(Box::from_raw(ptr));
-
-    assert_eq!(context.iteration, 0);
-
-    let expr_rec = CStr::from_ptr(expr).to_str().unwrap().parse().unwrap();
-    let goal_rec = CStr::from_ptr(goal).to_str().unwrap().parse().unwrap();
-    let egraph = &mut context.runner.egraph;
-
-    egraph.add_expr(&expr_rec) == egraph.add_expr(&goal_rec)
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_get_variants(
     ptr: *mut Context,
     node_id: u32,

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -82,6 +82,21 @@ pub unsafe extern "C" fn egraph_add_expr(ptr: *mut Context, expr: *const c_char)
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn egraph_union(ptr: *mut Context, id1: u32, id2: u32) -> u32 {
+    // Safety: `ptr` was box allocated by `egraph_create`
+    let mut context = Box::from_raw(ptr);
+    let id1 = Id::from(id1 as usize);
+    let id2 = Id::from(id2 as usize);
+
+    context.runner.egraph.union(id1, id2);
+    context.runner.egraph.rebuild();
+    let id = context.runner.egraph.find(id1);
+
+    mem::forget(context);
+    usize::from(id) as u32
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn egraph_copy(ptr: *mut Context) -> *mut Context {
     // Safety: `ptr` was box allocated by `egraph_create`
     let context = Box::from_raw(ptr);

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -3,7 +3,8 @@
 (require "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "../utils/timeline.rkt"
-         "../utils/float.rkt")
+         "../utils/float.rkt"
+         "programs.rkt")
 
 (provide compile-progs
          compile-prog)
@@ -46,12 +47,6 @@
 
 (define (if-proc c a b)
   (if c a b))
-
-(define (remove-approx expr)
-  (match expr
-    [(approx _ impl) (remove-approx impl)]
-    [(list op args ...) `(,op ,@(map remove-approx args))]
-    [_ expr]))
 
 (define (progs->batch exprs vars)
   (define icache (reverse vars))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -1,15 +1,9 @@
 #lang racket
 
-(require math/bigfloat
-         math/flonum
-         rival)
-
 (require "../syntax/syntax.rkt"
          "../syntax/types.rkt"
-         "../utils/common.rkt"
          "../utils/timeline.rkt"
-         "../utils/float.rkt"
-         "../config.rkt")
+         "../utils/float.rkt")
 
 (provide compile-progs
          compile-prog)
@@ -68,6 +62,7 @@
     (set! size (+ 1 size))
     (define node ; This compiles to the register machine
       (match prog
+        [(approx _ impl) (munge impl)]
         [(list op args ...) (cons op (map munge args))]
         [_ prog]))
     (hash-ref! exprhash

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -61,18 +61,22 @@
   ; Translates programs into an instruction sequence of operations
   (define (munge prog)
     (set! size (+ 1 size))
-    (define node ; This compiles to the register machine
-      (match prog
-        [(list op args ...) (cons op (map munge args))]
-        [_ prog]))
-    (hash-ref! exprhash
-               node
-               (lambda ()
-                 (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                   (set! exprc (+ 1 exprc))
-                   (set! icache (cons node icache))))))
+    (match prog ; approx nodes are ignored
+      [(approx _ impl) (munge impl)]
+      [_
+       (define node ; This compiles to the register machine
+         (match prog
+           [(? literal?) prog]
+           [(? symbol?) prog]
+           [(list op args ...) (cons op (map munge args))]))
+       (hash-ref! exprhash
+                  node
+                  (lambda ()
+                    (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
+                      (set! exprc (+ 1 exprc))
+                      (set! icache (cons node icache)))))]))
 
-  (define roots (list->vector (map (compose munge remove-approx) exprs)))
+  (define roots (list->vector (map munge exprs)))
   (define nodes (list->vector (reverse icache)))
 
   (timeline-push! 'compiler (+ varc size) (+ exprc varc))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -96,8 +96,7 @@
        (define id2 (egraph_add_expr ptr (~a spec)))
        (egraph_union ptr id1 id2)
        (loop impl)]
-      [(list _ args ...)
-       (for-each loop args)]))
+      [(list _ args ...) (for-each loop args)]))
   ; add the actual expression
   (egraph_add_expr ptr (~a egg-expr)))
 
@@ -165,9 +164,9 @@
   (egraph_find (egraph-data-egraph-pointer egraph-data) id))
 
 (define (egraph-expr-equal? egraph-data expr goal ctx)
-  (define egg-expr (~a (expr->egg-expr expr egraph-data ctx)))
-  (define egg-goal (~a (expr->egg-expr goal egraph-data ctx)))
-  (egraph_is_equal (egraph-data-egraph-pointer egraph-data) egg-expr egg-goal))
+  (define id1 (egraph-add-expr egraph-data expr ctx))
+  (define id2 (egraph-add-expr egraph-data goal ctx))
+  (= (egraph-find egraph-data id1) (egraph-find egraph-data id2)))
 
 ;; returns a flattened list of terms or #f if it failed to expand the proof due to budget
 (define (egraph-get-proof egraph-data expr goal ctx)
@@ -765,8 +764,7 @@
       [(? symbol?)
        (define repr (cdr (hash-ref egg->herbie node)))
        (type/union repr (representation-type repr))]
-      [(list '$approx _ impl)
-       (vector-ref analysis impl)]
+      [(list '$approx _ impl) (vector-ref analysis impl)]
       [(list 'if _ ift iff)
        (define ift-types (vector-ref analysis ift))
        (define iff-types (vector-ref analysis iff))
@@ -818,8 +816,7 @@
       [(? symbol?)
        (define repr (cdr (hash-ref egg->herbie node)))
        (type/union repr (representation-type repr))]
-      [(list '$approx _ impl)
-       (vector-ref eclass-types impl)]
+      [(list '$approx _ impl) (vector-ref eclass-types impl)]
       [(list 'if _ ift iff)
        (define ift-types (vector-ref eclass-types ift))
        (define iff-types (vector-ref eclass-types iff))
@@ -906,8 +903,7 @@
 
   (define (slow-node-ready? node type)
     (match node
-      [(list '$approx _ impl)
-       (eclass-has-cost? impl type)]
+      [(list '$approx _ impl) (eclass-has-cost? impl type)]
       [(list 'if cond ift iff)
        (and (eclass-has-cost? cond (get-representation 'bool))
             (eclass-has-cost? ift type)
@@ -1006,8 +1002,8 @@
     [(? symbol?) ; variables (`egg->herbie` has the repr)
      (define repr (cdr (hash-ref egg->herbie node)))
      ((node-cost-proc node repr))]
-    [(list '$approx _ impl) ; approx node
-     (rec impl type +inf.0)]
+    ; approx node
+    [(list '$approx _ impl) (rec impl type +inf.0)]
     [(list 'if cond ift iff) ; if expression
      (define cost-proc (node-cost-proc node type))
      (cost-proc (rec cond (get-representation 'bool) +inf.0)
@@ -1024,8 +1020,8 @@
   (match node
     [(? number?) 1]
     [(? symbol?) 1]
-    [(list '$approx _ impl) ; approx node
-     (rec impl type +inf.0)]
+    ; approx node
+    [(list '$approx _ impl) (rec impl type +inf.0)]
     [(list 'if cond ift iff)
      (+ 1 (rec cond (get-representation 'bool) +inf.0) (rec ift type +inf.0) (rec iff type +inf.0))]
     [(list (? impl-exists? impl) args ...)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -244,9 +244,9 @@
       [`(,op ,args ...) (cons op (map (curryr loop env) args))])))
 
 ;; Converts an S-expr from egg into one Herbie understands
-;; TODO: typing information is confusing since we proofs
-;; mean we may process mixed spec/impl expressions;
-;; only need it to correctly interpret numbers
+;; TODO: typing information is confusing since proofs mean
+;; we may process mixed spec/impl expressions;
+;; only need `type` to correctly interpret numbers
 (define (egg-parsed->expr expr rename-dict type)
   (let loop ([expr expr] [type type])
     (match expr

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -133,8 +133,10 @@
         (match expr
           [(? literal?) 1]
           [(? variable?) 1]
+          [(approx _ impl)
+           (define repr (repr-of expr ctx))
+           (ulp-difference (hash-ref exacts-hash expr) (hash-ref exacts-hash impl) repr)]
           [`(if ,c ,ift ,iff) 1]
-          [(approx spec impl) 1]
           [(list f args ...)
            (define repr (impl-info f 'otype))
            (define argapprox

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -126,6 +126,7 @@
           [(? literal?) 1]
           [(? variable?) 1]
           [`(if ,c ,ift ,iff) 1]
+          [(approx spec impl) 1]
           [(list f args ...)
            (define repr (impl-info f 'otype))
            (define argapprox

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -102,8 +102,9 @@
   (define subexprss (map all-subexpressions exprs))
   (define errss (compute-local-errors subexprss ctx))
 
-  (for/list ([expr (in-list exprs)] [errs (in-list errss)])
-    (sort (sort (for/list ([(subexpr err) (in-hash errs)] #:when (list? subexpr))
+  (for/list ([_ (in-list exprs)] [errs (in-list errss)])
+    (sort (sort (for/list ([(subexpr err) (in-hash errs)]
+                           #:when (or (list? subexpr) (approx? subexpr)))
                   (cons err subexpr))
                 expr<?
                 #:key cdr)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -67,12 +67,11 @@
   (define (expr->cost expr)
     (cost-proc expr (repr-of expr ctx)))
 
-  (define (subexpr->cost-opportunity subexpr)
+  (define (cost-opportunity subexpr children)
     ; start and end cost of roots
     (define start-cost (expr->cost subexpr))
     (define best-cost (expr->cost (hash-ref expr->simplest subexpr)))
     ; start and end cost of children
-    (match-define (list _ children ...) subexpr)
     (define start-child-costs (map expr->cost children))
     (define best-child-costs
       (for/list ([child (in-list children)])
@@ -88,10 +87,12 @@
                     (match subexpr
                       [(? literal?) (void)]
                       [(? symbol?) (void)]
-                      [(approx _ _) (void)] ; TODO: ??
-                      [(list _ _ ...)
-                       (define cost-opportunity (subexpr->cost-opportunity subexpr))
-                       (sow (cons cost-opportunity subexpr))])))
+                      [(approx _ impl)
+                       (define cost-opp (cost-opportunity subexpr (list impl)))
+                       (sow (cons cost-opp subexpr))]
+                      [(list _ args ...)
+                       (define cost-opp (cost-opportunity subexpr args))
+                       (sow (cons cost-opp subexpr))])))
             >
             #:key car)))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -246,10 +246,12 @@
         (let loop ([expr expr] [loc '()])
           (match expr
             [(== subexpr) (sow (reverse loc))]
+            [(? literal?) (void)]
+            [(? symbol?) (void)]
+            [(approx _ impl) (loop impl (cons 2 loc))]
             [(list _ args ...)
              (for ([arg (in-list args)] [i (in-naturals 1)])
-               (loop arg (cons i loc)))]
-            [_ (void)]))))
+               (loop arg (cons i loc)))]))))
 
 ;; Converts a patch to full alt with valid history
 (define (reconstruct! alts)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -58,7 +58,8 @@
             (match-define (cons _ simplified) outputs)
             (define prev (hash-ref approx->prev altn))
             (for ([expr (in-list simplified)])
-              (sow (alt (approx (alt-expr prev) expr) `(simplify ,runner #f #f) (list altn) '()))))))
+              (define spec (prog->spec (alt-expr prev)))
+              (sow (alt (approx spec expr) `(simplify ,runner #f #f) (list altn) '()))))))
 
   (timeline-push! 'count (length approxs) (length simplified))
   simplified)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -1,17 +1,18 @@
 #lang racket
 
-(require "rules.rkt"
+(require "../syntax/platform.rkt"
+         "../syntax/syntax.rkt"
          "../syntax/sugar.rkt"
          "../syntax/types.rkt"
-         "egg-herbie.rkt"
-         "rr.rkt"
-         "simplify.rkt"
-         "taylor.rkt"
          "../utils/alternative.rkt"
          "../utils/common.rkt"
-         "../syntax/platform.rkt"
+         "../utils/timeline.rkt"
+         "egg-herbie.rkt"
          "programs.rkt"
-         "../utils/timeline.rkt")
+         "rr.rkt"
+         "rules.rkt"
+         "simplify.rkt"
+         "taylor.rkt")
 
 (provide patch-table-has-expr?
          patch-table-run)
@@ -19,6 +20,48 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Patch table ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-resetter *patch-table* (λ () (make-hash)) (λ () (make-hash)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Simplify ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (lower-approximations approxs approx->prev)
+  (timeline-event! 'simplify)
+
+  (define reprs
+    (for/list ([approx (in-list approxs)])
+      (define prev (hash-ref approx->prev approx))
+      (repr-of (alt-expr prev) (*context*))))
+
+  ; generate real rules
+  (define rules (real-rules (*simplify-rules*)))
+  (define lowering-rules (platform-lowering-rules))
+
+  ; egg runner
+  (define schedule
+    (if (flag-set? 'generate 'simplify)
+        ; if simplify enabled, 2-phases for real rewrites and implementation selection
+        `((,rules . ((node . ,(*node-limit*))))
+          (,lowering-rules . ((iteration . 1) (scheduler . simple))))
+        ; if disabled, only implementation selection
+        `((,lowering-rules . ((iteration . 1) (scheduler . simple))))))
+
+  ; run egg
+  (define runner (make-egg-runner (map alt-expr approxs) reprs schedule))
+  (define simplification-options
+    (simplify-batch runner
+                    (typed-egg-extractor
+                     (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc))))
+
+  ; convert to altns
+  (define simplified
+    (reap [sow]
+          (for ([altn (in-list approxs)] [outputs (in-list simplification-options)])
+            (match-define (cons _ simplified) outputs)
+            (define prev (hash-ref approx->prev altn))
+            (for ([expr (in-list simplified)])
+              (sow (alt (approx (alt-expr prev) expr) `(simplify ,runner #f #f) (list altn) '()))))))
+
+  (timeline-push! 'count (length approxs) (length simplified))
+  simplified)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Taylor ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -46,25 +89,27 @@
 (define (spec-has-nan? expr)
   (expr-contains? expr (lambda (term) (eq? term 'NAN))))
 
-(define (run-taylor altns reprs)
+(define (run-taylor altns)
   (timeline-event! 'series)
   (timeline-push! 'inputs (map ~a altns))
-  (define approximations
+
+  (define approx->prev (make-hasheq))
+  (define approxs
     (reap [sow]
-          (for ([altn (in-list altns)] [repr (in-list reprs)])
+          (for ([altn (in-list altns)])
             (for ([approximation (taylor-alt altn)])
               (unless (spec-has-nan? (alt-expr approximation))
-                (sow (cons approximation repr)))))))
-  (timeline-push! 'outputs (map (lambda (e&r) (~a (car e&r))) approximations))
-  (timeline-push! 'count (length altns) (length approximations))
-  approximations)
+                (hash-set! approx->prev approximation altn)
+                (sow approximation))))))
+
+  (timeline-push! 'outputs (map ~a approxs))
+  (timeline-push! 'count (length altns) (length approxs))
+  (lower-approximations approxs approx->prev))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (run-rr altns&reprs)
+(define (run-rr altns)
   (timeline-event! 'rewrite)
-  (define altns (map car altns&reprs))
-  (define reprs (map cdr altns&reprs))
 
   ; generate required rules
   (define rules (real-rules (*rules*)))
@@ -79,6 +124,7 @@
 
   ; run egg
   (define specs (map alt-expr altns))
+  (define reprs (map (lambda (altn) (repr-of (alt-expr altn) (*context*))) altns))
   (define changelistss (rewrite-expressions specs reprs schedule (*context*)))
 
   ; apply changelists
@@ -92,59 +138,20 @@
   (timeline-push! 'count (length altns) (length rewritten))
   rewritten)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;; Simplify ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (run-simplify altns&reprs)
-  (timeline-event! 'simplify)
-  (define altns (map car altns&reprs))
-  (define reprs (map cdr altns&reprs))
-
-  ; generate real rules
-  (define rules (real-rules (*simplify-rules*)))
-  (define lowering-rules (platform-lowering-rules))
-
-  ; egg runner (2-phases for real rewrites and implementation selection)
-  (define runner
-    (make-egg-runner (map alt-expr altns)
-                     reprs
-                     `((,rules . ((node . ,(*node-limit*))))
-                       (,lowering-rules . ((iteration . 1) (scheduler . simple))))))
-
-  ; run egg
-  (define simplification-options
-    (simplify-batch runner
-                    (typed-egg-extractor
-                     (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc))))
-
-  ; convert to altns
-  (define simplified
-    (reap [sow]
-          (for ([altn (in-list altns)] [outputs (in-list simplification-options)])
-            (match-define (cons _ simplified) outputs)
-            (for ([expr (in-list simplified)])
-              (sow (alt expr `(simplify ,runner #f #f) (list altn) '()))))))
-
-  (timeline-push! 'count (length altns) (length simplified))
-  simplified)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Public API ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (patch-table-has-expr? expr)
   (hash-has-key? (*patch-table*) expr))
 
 (define (patch-table-run locs)
-  ; Representations
-  (define reprs (map (lambda (e) (repr-of e (*context*))) locs))
   ; Starting alternatives
   (define start-altns
-    (for/list ([expr (in-list locs)] [repr (in-list reprs)])
+    (for/list ([expr (in-list locs)])
+      (define repr (repr-of expr (*context*)))
       (alt expr (list 'patch expr repr) '() '())))
-  ; Core
-  (define approximations (if (flag-set? 'generate 'taylor) (run-taylor start-altns reprs) '()))
-  (define rewritten (if (flag-set? 'generate 'rr) (run-rr (map cons start-altns reprs)) '()))
-  (define simplified
-    (if (flag-set? 'generate 'simplify) (run-simplify approximations) approximations))
+  ; Series expand
+  (define approximations (if (flag-set? 'generate 'taylor) (run-taylor start-altns) '()))
+  ; Recursive rewrite
+  (define rewritten (if (flag-set? 'generate 'rr) (run-rr start-altns) '()))
 
-  (define altns (append rewritten simplified))
-  ;; Uncaching
-  altns)
+  (append approximations rewritten))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -43,21 +43,19 @@
   (define subexprs
     (reap [sow]
           (let loop ([expr expr])
+            (sow expr)
             (match expr
+              [(? number?) (void)]
+              [(? literal?) (void)]
+              [(? variable?) (void)]
               [(approx _ impl) (loop impl)]
-              [_
-               (sow expr)
-               (match expr
-                 [(? number?) (void)]
-                 [(? literal?) (void)]
-                 [(? variable?) (void)]
-                 [`(if ,c ,t ,f)
-                  (loop c)
-                  (loop t)
-                  (loop f)]
-                 [(list _ args ...)
-                  (for ([arg args])
-                    (loop arg))])]))))
+              [`(if ,c ,t ,f)
+               (loop c)
+               (loop t)
+               (loop f)]
+              [(list _ args ...)
+               (for ([arg args])
+                 (loop arg))]))))
   (remove-duplicates (if reverse? (reverse subexprs) subexprs)))
 
 (define (ops-in-expr expr)

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -16,8 +16,7 @@
          location-get
          free-variables
          replace-expression
-         replace-vars
-         remove-approx)
+         replace-vars)
 
 ;; Programs are just lisp lists plus atoms
 
@@ -140,16 +139,6 @@
       [(? symbol?) (dict-ref dict expr expr)]
       [(approx impl spec) (approx (loop impl) (loop spec))]
       [(list op args ...) (cons op (map loop args))])))
-
-;; For any LImpl expression, removes any approx nodes.
-;; WARN: this is an irreversible spec-altering transformation.
-(define (remove-approx expr)
-  (match expr
-    [(? literal?) expr]
-    [(? number?) expr]
-    [(? symbol?) expr]
-    [(approx _ impl) (remove-approx impl)]
-    [(list op args ...) `(,op ,@(map remove-approx args))]))
 
 (define location? (listof natural-number/c))
 

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -16,7 +16,8 @@
          location-get
          free-variables
          replace-expression
-         replace-vars)
+         replace-vars
+         remove-approx)
 
 ;; Programs are just lisp lists plus atoms
 
@@ -138,6 +139,14 @@
      (approx (replace-vars dict (approx-spec expr)) (replace-vars dict (approx-impl expr)))]
     [(list? expr) (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
     [else expr]))
+
+;; For any LImpl expression, removes any approx nodes.
+;; WARN: this is an irreversible spec-altering transformation.
+(define (remove-approx expr)
+  (match expr
+    [(approx _ impl) (remove-approx impl)]
+    [(list op args ...) `(,op ,@(map remove-approx args))]
+    [_ expr]))
 
 (define location? (listof natural-number/c))
 

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -128,7 +128,7 @@
     [(? literal?) '()]
     [(? number?) '()]
     [(? variable?) (list prog)]
-    [(approx spec impl) (remove-duplicates (append (free-variables spec) (free-variables impl)))]
+    [(approx _ impl) (free-variables impl)]
     [(list _ args ...) (remove-duplicates (append-map free-variables args))]))
 
 (define (replace-vars dict expr)
@@ -169,11 +169,11 @@
   ; Clever continuation usage to early-return
   (let/ec return (location-do loc prog return)))
 
-(define/contract (replace-expression expr to from)
+(define/contract (replace-expression expr from to)
   (-> expr? expr? expr? expr?)
   (let loop ([expr expr])
     (match expr
-      [(== to) from]
+      [(== from) to]
       [(? number?) expr]
       [(? literal?) expr]
       [(? symbol?) expr]

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -20,7 +20,7 @@
 
 ;; Programs are just lisp lists plus atoms
 
-(define expr? (or/c list? symbol? boolean? real? literal?))
+(define expr? (or/c list? symbol? boolean? real? literal? approx?))
 
 ;; Returns repr name
 ;; Fast version does not recurse into functions applications
@@ -63,9 +63,9 @@
   (match expr
     [(? symbol?) #t]
     [(? number?) #t]
-    [(list 'if cond ift iff)
-     (and (spec-prog? cond) (spec-prog? ift) (spec-prog? iff))]
-    [(list (? operator-exists?) args ...) (andmap spec-prog? args)]))
+    [(list 'if cond ift iff) (and (spec-prog? cond) (spec-prog? ift) (spec-prog? iff))]
+    [(list (? operator-exists?) args ...) (andmap spec-prog? args)]
+    [_ #f]))
 
 ;; Is the expression in LImpl (floating-point implementations)?
 (define (impl-prog? expr)
@@ -73,9 +73,9 @@
     [(? symbol?) #t]
     [(? literal?) #t]
     [(approx spec impl) (and (spec-prog? spec) (impl-prog? impl))]
-    [(list 'if cond ift iff)
-     (and (impl-prog? cond) (impl-prog? ift) (impl-prog? iff))]
-    [(list (? impl-exists?) args ...) (andmap impl-prog? args)]))
+    [(list 'if cond ift iff) (and (impl-prog? cond) (impl-prog? ift) (impl-prog? iff))]
+    [(list (? impl-exists?) args ...) (andmap impl-prog? args)]
+    [_ #f]))
 
 ;; Total order on expressions
 

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -73,9 +73,8 @@
       ; recursive rewrite using egg (impl -> impl)
       [(alt expr `(rr ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
-       (define start-expr* (prog->spec start-expr))
        (define end-expr (location-get loc expr))
-       (define rewrite (cons start-expr* end-expr))
+       (define rewrite (cons start-expr end-expr))
        (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
        (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
 

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -4,7 +4,6 @@
          "points.rkt"
          "programs.rkt"
          "egg-herbie.rkt"
-         "rules.rkt"
          "../syntax/sugar.rkt"
          "../syntax/syntax.rkt")
 

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -258,6 +258,7 @@
 
   (define output-prec (representation-name output-repr))
   (define out-prog* (fpcore-add-props out-prog (list ':precision output-prec)))
+  (eprintf "~a\n" out-prog*)
 
   (define versions
     (reap

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -258,7 +258,6 @@
 
   (define output-prec (representation-name output-repr))
   (define out-prog* (fpcore-add-props out-prog (list ':precision output-prec)))
-  (eprintf "~a\n" out-prog*)
 
   (define versions
     (reap

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -82,6 +82,7 @@
         [(? symbol?) expr]
         [(? number?) expr]
         [(? literal?) (literal-value expr)]
+        [(approx _ impl) (loop impl)]
         [`(if ,cond ,ift ,iff) `(if ,(loop cond) ,(loop ift) ,(loop ift))]
         [`(,(? impl-exists? impl) ,args ...) `(,(impl->operator impl) ,@(map loop args))]
         [`(,op ,args ...) `(,op ,@(map loop args))])))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -70,6 +70,7 @@
     [(? symbol?) expr]
     [(? number?) expr]
     [(? literal?) (literal-value expr)]
+    [(approx spec impl) (approx (remove-literals spec) (remove-literals impl))]
     [(list op args ...) (cons op (map remove-literals args))]))
 
 (define (expr->fpcore expr ctx #:ident [ident #f])

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -27,6 +27,11 @@
 (define ((page-error-handler result page out) e)
   (define test (job-result-test result))
   (eprintf "Error generating `~a` for \"~a\":\n  ~a\n" page (test-name test) (exn-message e))
+  (eprintf "context:\n")
+  (for ([(fn loc) (in-dict (continuation-mark-set->context (exn-continuation-marks e)))])
+    (match loc
+      [(srcloc file line col _ _) (eprintf "  ~a:~a:~a: ~a\n" file line col (or fn "(unnamed)"))]
+      [#f (eprintf "  ~a\n" fn)]))
   (parameterize ([current-error-port out])
     (display "<!doctype html><pre>" out)
     ((error-display-handler) (exn-message e) e)

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -692,16 +692,21 @@
 
 ;; Synthesizes lifting rules for a given platform.
 (define (platform-lifting-rules [pform (*active-platform*)])
+  ;; every impl maps to a spec
   (define impls (platform-impls pform))
-  (for/list ([impl (in-list impls)])
-    (hash-ref! (*lifting-rules*)
-               (cons impl pform)
-               (lambda ()
-                 (define name (sym-append 'lift- impl))
-                 (define itypes (impl-info impl 'itype))
-                 (define otype (impl-info impl 'otype))
-                 (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
-                 (rule name impl-expr spec-expr (map cons vars itypes) otype)))))
+  (define impl-rules
+    (for/list ([impl (in-list impls)])
+      (hash-ref! (*lifting-rules*)
+                 (cons impl pform)
+                 (lambda ()
+                   (define name (sym-append 'lift- impl))
+                   (define itypes (impl-info impl 'itype))
+                   (define otype (impl-info impl 'otype))
+                   (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
+                   (rule name impl-expr spec-expr (map cons vars itypes) otype)))))
+  ;; special rule for approx nodes
+  (define approx-rule (rule 'lift-approx (approx 'a 'b) 'a '((a . real) (b . real)) 'real))
+  (cons approx-rule impl-rules))
 
 ;; Synthesizes lowering rules for a given platform.
 (define (platform-lowering-rules [pform (*active-platform*)])

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -662,6 +662,7 @@
       (match expr
         [(? literal?) ((node-cost-proc expr repr))]
         [(? symbol?) ((node-cost-proc expr repr))]
+        [(approx _ impl) (loop impl repr)]
         [(list 'if cond ift iff)
          (define cost-proc (node-cost-proc expr repr))
          (cost-proc (loop cond bool-repr) (loop ift repr) (loop iff repr))]

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -705,8 +705,9 @@
                    (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
                    (rule name impl-expr spec-expr (map cons vars itypes) otype)))))
   ;; special rule for approx nodes
-  (define approx-rule (rule 'lift-approx (approx 'a 'b) 'a '((a . real) (b . real)) 'real))
-  (cons approx-rule impl-rules))
+  ; (define approx-rule (rule 'lift-approx (approx 'a 'b) 'a '((a . real) (b . real)) 'real))
+  ; (cons approx-rule impl-rules))
+  impl-rules)
 
 ;; Synthesizes lowering rules for a given platform.
 (define (platform-lowering-rules [pform (*active-platform*)])

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -198,6 +198,7 @@
      (match (cons op args*)
        [`(neg ,arg) `(- ,arg)]
        [expr expr])]
+    [(approx _ impl) (prog->fpcore impl)]
     [(? variable?) expr]
     [(? literal?)
      (match (literal-value expr)
@@ -213,5 +214,6 @@
      [`(if ,cond ,ift ,iff) `(if ,(prog->spec cond) ,(prog->spec ift) ,(prog->spec iff))]
      [`(,(? cast-impl? impl) ,body) `(,impl ,(prog->spec body))]
      [`(,impl ,args ...) `(,(impl->operator impl) ,@(map prog->spec args))]
+     [(approx spec _) spec]
      [(? variable?) expr]
      [(? literal?) (literal-value expr)])))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -9,6 +9,7 @@
 
 (provide (rename-out [operator-or-impl? operator?])
          (struct-out literal)
+         (struct-out approx)
          variable?
          constant-operator?
          operator-exists?
@@ -585,6 +586,10 @@
 ;; Floating-point expressions require that number
 ;; be rounded to a particular precision.
 (struct literal (value precision) #:prefab)
+
+;; An approximation of a specification by
+;; an arbitrary floating-point expression.
+(struct approx (spec impl) #:prefab)
 
 ;; name -> (vars repr body)	;; name -> (vars prec body)
 (define *functions* (make-parameter (make-hasheq)))


### PR DESCRIPTION
This PR adds "approx" nodes to track arbitrary approximations, e.g., polynomial approximations, within floating-point programs. An approx node `(approx s e)` consists of a spec `s` and a program `e` where `(prog->spec (approx s e))` is `s` and `(eval (approx s e))` is equivalent to `(eval e)`.