### PR TITLE
Error Explanations API added

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -124,6 +124,14 @@ const alternatives = await callHerbie("/api/alternatives", {
 assertIdAndPath(alternatives)
 assert.equal(Array.isArray(alternatives.alternatives), true)
 
+//Explanations endpoint
+const sampleExp = (await (await fetch('http://127.0.0.1:8000/api/sample', { method: 'POST', body: JSON.stringify({ formula: FPCoreFormula2, seed: 5 }) })).json())
+const explain = await callHerbie("/api/explanations", {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: sampleExp.points
+  })
+})
+assert.equal(explain.explanation.length > 0, true, 'explanation should not be empty');
 // Exacts endpoint
 const exacts = await callHerbie("/api/exacts", {
   method: 'POST', body: JSON.stringify({

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -131,6 +131,7 @@ const explain = await callHerbie("/api/explanations", {
     formula: FPCoreFormula, sample: sampleExp.points
   })
 })
+assertIdAndPath(explain)
 assert.equal(explain.explanation.length > 0, true, 'explanation should not be empty');
 // Exacts endpoint
 const exacts = await callHerbie("/api/exacts", {

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -419,9 +419,8 @@
 
 (define explanations-endpoint
   (post-with-json-response (lambda (post-data)
-                            (define formula-str (hash-ref post-data 'formula))
-                             (define formula
-                               (read-syntax 'web (open-input-string formula-str)))
+                             (define formula-str (hash-ref post-data 'formula))
+                             (define formula (read-syntax 'web (open-input-string formula-str)))
                              (define sample (hash-ref post-data 'sample))
                              (define seed (hash-ref post-data 'seed #f))
                              (eprintf "Explanations job started on ~a...\n" formula-str)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -419,11 +419,12 @@
 
 (define explanations-endpoint
   (post-with-json-response (lambda (post-data)
+                            (define formula-str (hash-ref post-data 'formula))
                              (define formula
-                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                               (read-syntax 'web (open-input-string formula-str)))
                              (define sample (hash-ref post-data 'sample))
                              (define seed (hash-ref post-data 'seed #f))
-                             (eprintf "Explanations job started on ~a..." formula)
+                             (eprintf "Explanations job started on ~a...\n" formula-str)
 
                              (define test (parse-test formula))
                              (define expr (prog->fpcore (test-input test)))
@@ -440,7 +441,7 @@
                              (define explanations (job-result-backend result))
 
                              (eprintf " complete\n")
-                             (hasheq 'explanation explanations))))
+                             (hasheq 'explanation explanations 'job id 'path (make-path id)))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -418,29 +418,29 @@
      (hasheq 'points (pcontext->json pctx repr) 'job id 'path (make-path id)))))
 
 (define explanations-endpoint
-  (post-with-json-response
-    (lambda (post-data)
-      (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
-      (define sample (hash-ref post-data 'sample))
-      (define seed (hash-ref post-data 'seed #f))
-      (eprintf "Explanations job started on ~a..." formula)
+  (post-with-json-response (lambda (post-data)
+                             (define formula
+                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (eprintf "Explanations job started on ~a..." formula)
 
-      (define test (parse-test formula))
-      (define expr (prog->fpcore (test-input test)))
-      (define pcontext (json->pcontext sample (test-context test)))
-      (define command
-        (create-job 'explanations
-                   test
-                   #:seed seed
-                   #:pcontext pcontext
-                   #:profile? #f
-                   #:timeline-disabled? #t))
-      (define id (start-job command))
-      (define result (wait-for-job id))
-      (define explanations (job-result-backend result))
+                             (define test (parse-test formula))
+                             (define expr (prog->fpcore (test-input test)))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'explanations
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define id (start-job command))
+                             (define result (wait-for-job id))
+                             (define explanations (job-result-backend result))
 
-      (eprintf " complete\n")
-      (hasheq 'explanation explanations))))
+                             (eprintf " complete\n")
+                             (hasheq 'explanation explanations))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -69,6 +69,7 @@
                   [("api" "cost") #:method "post" cost-endpoint]
                   [("api" "mathjs") #:method "post" ->mathjs-endpoint]
                   [("api" "translate") #:method "post" translate-endpoint]
+                  [("api" "explanations") #:method "post" explanations-endpoint]
                   [((hash-arg) (string-arg)) generate-page]
                   [("results.json") generate-report]))
 
@@ -415,6 +416,31 @@
      (define pctx (job-result-backend result))
      (define repr (context-repr (test-context test)))
      (hasheq 'points (pcontext->json pctx repr) 'job id 'path (make-path id)))))
+
+(define explanations-endpoint
+  (post-with-json-response
+    (lambda (post-data)
+      (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+      (define sample (hash-ref post-data 'sample))
+      (define seed (hash-ref post-data 'seed #f))
+      (eprintf "Explanations job started on ~a..." formula)
+
+      (define test (parse-test formula))
+      (define expr (prog->fpcore (test-input test)))
+      (define pcontext (json->pcontext sample (test-context test)))
+      (define command
+        (create-job 'explanations
+                   test
+                   #:seed seed
+                   #:pcontext pcontext
+                   #:profile? #f
+                   #:timeline-disabled? #t))
+      (define id (start-job command))
+      (define result (wait-for-job id))
+      (define explanations (job-result-backend result))
+
+      (eprintf " complete\n")
+      (hasheq 'explanation explanations))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -144,8 +144,13 @@
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
   (*pcontext* test-pcontext)
-  (define-values (fperrors sorted-explanations-table confusion-matrix maybe-confusion-matrix total-confusion-matrix freqs)
-    (explain (test-input test)(*context*)(*pcontext*)))
+  (define-values (fperrors
+                  sorted-explanations-table
+                  confusion-matrix
+                  maybe-confusion-matrix
+                  total-confusion-matrix
+                  freqs)
+    (explain (test-input test) (*context*) (*pcontext*)))
 
   sorted-explanations-table)
 

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -18,6 +18,7 @@
          "../core/mainloop.rkt"
          "../syntax/platform.rkt"
          "../core/points.rkt"
+         "../core/explain.rkt"
          "../core/preprocess.rkt"
          "../utils/profile.rkt"
          "../utils/timeline.rkt"
@@ -136,6 +137,17 @@
   (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
   (*pcontext* test-pcontext)
   (local-error-as-tree (test-input test) (*context*)))
+
+(define (get-explanations test pcontext)
+  (unless pcontext
+    (error 'explain "cannot run without a pcontext"))
+
+  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
+  (*pcontext* test-pcontext)
+  (define-values (fperrors sorted-explanations-table confusion-matrix maybe-confusion-matrix total-confusion-matrix freqs)
+    (explain (test-input test)(*context*)(*pcontext*)))
+
+  sorted-explanations-table)
 
 ;; TODO: What in the timeline needs fixing with these changes?
 
@@ -264,6 +276,7 @@
             ['exacts (get-exacts test pcontext)]
             ['improve (get-alternatives/report test)]
             ['local-error (get-local-error test pcontext)]
+            ['explanations (get-explanations test pcontext)]
             ['sample (get-sample test)]
             [_ (error 'compute-result "unknown command ~a" command)]))
         (timeline-event! 'end)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -145,6 +145,7 @@
       ['exacts "Ground truth"]
       ['improve "Improve"]
       ['local-error "Local error"]
+      ['explanations "Explanations"]
       ['sample "Sampling"]
       [_ (error 'compute-result "unknown command ~a" command)]))
   (eprintf "~a Job ~a started:\n  ~a ~a...\n" job-label (symbol->string command) job-id job-str))


### PR DESCRIPTION
The changes in this branch will now allow user to get error explanations data at "/api/explanations". Earlier we didn't had any api to fetch sorted explanations table of explain.rkt . Now we can fetch that data through a fetch api call to "api/explanations". I have created a new branch from main and added all my changes here so it is easy and simple to merge.