### PR TITLE
Fix branch name on nightly

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -155,7 +155,7 @@
     (string-trim (with-output-to-string (λ () (system cmd))))))
 
 (define (git-command #:default [default ""] gitcmd . args)
-  (if (directory-exists? ".git")
+  (if (or (directory-exists? ".git") (file-exists? ".git")) ; gitlinks like for worktrees
       (let* ([cmd (format "git ~a ~a" gitcmd (string-join args " "))] [out (run-command cmd)])
         (if (equal? out "") default out))
       default))


### PR DESCRIPTION
It turns out that `.git` can be a file (this is called a "gitlink") and in that case we still need to call `git` to get the current branch.