### PR TITLE
Enable timeline for `/cost` and `/alternatives` endpoints.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -409,7 +409,7 @@
      (define seed* (hash-ref post-data 'seed))
      (define test (parse-test formula))
      (define command
-       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #f))
+       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #t))
      (define id (start-job command))
      (define result (wait-for-job id))
      (define pctx (job-result-backend result))
@@ -430,7 +430,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #f))
+                                           #:timeline-disabled? #t))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define errs
@@ -455,7 +455,7 @@
                    #:seed seed
                    #:pcontext pcontext
                    #:profile? #f
-                   #:timeline-disabled? #f))
+                   #:timeline-disabled? #t))
      (define id (start-job command))
      (define result (wait-for-job id))
      (hasheq 'points (job-result-backend result) 'job id 'path (make-path id)))))
@@ -474,7 +474,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #f))
+                                           #:timeline-disabled? #t))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define approx (job-result-backend result))
@@ -495,7 +495,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #f))
+                                           #:timeline-disabled? #t))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define local-error (job-result-backend result))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -409,7 +409,7 @@
      (define seed* (hash-ref post-data 'seed))
      (define test (parse-test formula))
      (define command
-       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #f))
      (define id (start-job command))
      (define result (wait-for-job id))
      (define pctx (job-result-backend result))
@@ -430,7 +430,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define errs
@@ -455,7 +455,7 @@
                    #:seed seed
                    #:pcontext pcontext
                    #:profile? #f
-                   #:timeline-disabled? #t))
+                   #:timeline-disabled? #f))
      (define id (start-job command))
      (define result (wait-for-job id))
      (hasheq 'points (job-result-backend result) 'job id 'path (make-path id)))))
@@ -474,7 +474,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define approx (job-result-backend result))
@@ -495,7 +495,7 @@
                                            #:seed seed
                                            #:pcontext pcontext
                                            #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (define result (wait-for-job id))
                              (define local-error (job-result-backend result))
@@ -537,7 +537,7 @@
                    #:seed seed
                    #:pcontext pcontext
                    #:profile? #f
-                   #:timeline-disabled? #t))
+                   #:timeline-disabled? #f))
      (define id (start-job command))
      (define result (wait-for-job id))
      (match-define (list altns test-pcontext processed-pcontext) (job-result-backend result))
@@ -589,7 +589,7 @@
      (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
      (define test (parse-test formula))
      (define command
-       (create-job 'cost test #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+       (create-job 'cost test #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #f))
      (define id (start-job command))
      (define result (wait-for-job id))
      (define cost (job-result-backend result))


### PR DESCRIPTION
This PR enables timeline profiling for all API endpoints. This allows Odyssey to open `/timeline.html` links using the `path` parameter sent over with the majority of API request. 

Note that profiling is still disabled `#:profile? #f` for most of these endpoints so maybe worth enabling or change how the `timeline.html` page renders with no profiling enabled is appropriate.

![Screenshot 2024-08-07 at 1 14 42 PM](https://github.com/user-attachments/assets/de5ee1b9-9881-4537-a8f1-575835d23c1a)
