### PR TITLE
Throw `error` when attempting to push to an empty timeline.

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -255,6 +255,7 @@
       (when seed
         (set-seed! seed))
       (with-handlers ([exn? (curry on-exception start-time)])
+        (timeline-event! 'start) ; Prevents the timeline from being empty.
         (define result
           (match command
             ['alternatives (get-alternatives test pcontext seed)]

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -35,11 +35,14 @@
 
 (define (timeline-event! type)
   (when *timeline-active-key*
-    (hash-update! (car (unbox (*timeline*)))
-                  *timeline-active-key*
-                  (curry append *timeline-active-value*)
-                  '())
-    (set! *timeline-active-key* #f))
+    (if (pair? (unbox (*timeline*)))
+        (lambda ()
+          (hash-update! (car (unbox (*timeline*)))
+                        *timeline-active-key*
+                        (curry append *timeline-active-value*)
+                        '())
+          (set! *timeline-active-key* #f))
+        (error 'timeline "Cannot push to an empty timeline")))
 
   (unless (*timeline-disabled*)
     (when (pair? (unbox (*timeline*)))

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -61,7 +61,7 @@
        (set! *timeline-active-value* (cons val *timeline-active-value*))]
       [(not *timeline-active-key*)
        (unless (pair? (unbox (*timeline*)))
-         (error 'timeline "Cannot push ~a to an empty timeline" *timeline-active-key*))
+         (error 'timeline "Cannot push '~a to an empty timeline." key))
        (set! *timeline-active-key* key)
        (set! *timeline-active-value* (list val))]
       [else

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -35,14 +35,11 @@
 
 (define (timeline-event! type)
   (when *timeline-active-key*
-    (if (pair? (unbox (*timeline*)))
-        (lambda ()
-          (hash-update! (car (unbox (*timeline*)))
-                        *timeline-active-key*
-                        (curry append *timeline-active-value*)
-                        '())
-          (set! *timeline-active-key* #f))
-        (error 'timeline "Cannot push to an empty timeline")))
+    (hash-update! (car (unbox (*timeline*)))
+                  *timeline-active-key*
+                  (curry append *timeline-active-value*)
+                  '())
+    (set! *timeline-active-key* #f))
 
   (unless (*timeline-disabled*)
     (when (pair? (unbox (*timeline*)))
@@ -63,6 +60,8 @@
       [(eq? *timeline-active-key* key)
        (set! *timeline-active-value* (cons val *timeline-active-value*))]
       [(not *timeline-active-key*)
+       (unless (pair? (unbox (*timeline*)))
+         (error 'timeline "Cannot push ~a to an empty timeline" *timeline-active-key*))
        (set! *timeline-active-key* key)
        (set! *timeline-active-value* (list val))]
       [else


### PR DESCRIPTION
This PR fixes an invariant in `timeline` pointed out by @pavpanchekha  well we were working on #940. 

When enabling `timeline` on commands that don't actually submit any timeline events like `'sample` for example. This would cause the following crash to happen when `(timeline-event! 'end)` fires after the command is run. 
```
car: contract violation
  expected: pair?
  given: '()
```
At: `timeline.rkt` ~ line 36
```
(define (timeline-event! type)
  (when *timeline-active-key*
    (hash-update! (car (unbox (*timeline*)))
                  *timeline-active-key*
                  (curry append *timeline-active-value*)
                  '())
    (set! *timeline-active-key* #f))
```

This PR fixes that in two ways. Propagating a less opaque error message `'timeline "Cannot push to an empty timeline"` as well as pushing a `'start` event on the timeline before any commands are run to assert the timeline isn't empty.