### PR TITLE
Simplify the "reset" mechanism

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -262,7 +262,7 @@
   (define (compute-result test)
     (parameterize ([*timeline-disabled* timeline-disabled?] [*warnings-disabled* false])
       (define start-time (current-inexact-milliseconds))
-      (rollback-improve!)
+      (reset!)
       (*context* (test-context test))
       (*active-platform* (get-platform (*platform-name*)))
       (activate-platform! (*active-platform*))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -172,22 +172,10 @@
 
 (define resetters '())
 
-(define (register-reset! fn #:priority [priority 0])
-  (set! resetters (cons (cons priority fn) resetters)))
-
-;; Defines a resetter as a parameter
-;; An initialize and reset function must be provided
-;; A finializer may be optionally specified
-(define-syntax define-resetter
-  (syntax-rules ()
-    [(_ name init-fn reset-fn) (define-resetter name init-fn reset-fn (λ _ (void)))]
-    [(_ name init-fn reset-fn finalize-fn)
-     (begin
-       (define name (make-parameter (init-fn)))
-       (register-reset! (λ ()
-                          (finalize-fn (name))
-                          (name (reset-fn)))))]))
+(define-syntax-rule (define/reset name value)
+  (define name (make-parameter value))
+  (set! resetters (cons (λ () (name value)) resetters)))
 
 (define (reset!)
-  (for ([fn-rec (sort resetters < #:key car)])
-    ((cdr fn-rec))))
+  (for ([fn (in-list resetters)])
+    (fn)))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -171,13 +171,15 @@
 ;;; The "reset" mechanism for clearing caches and such
 
 (define resetters '())
-
-(define-syntax-rule (define/reset name value)
-  (define name
-    (let ([param (make-parameter value)])
-      (set! resetters (cons (λ () (name value)) resetters))
-      param)))
+(define (register-resetter! fn)
+  (set! resetters (cons fn resetters)))
 
 (define (reset!)
   (for ([fn (in-list resetters)])
     (fn)))
+
+(define-syntax-rule (define/reset name value)
+  (define name
+    (let ([param (make-parameter value)])
+      (register-resetter! (λ () (name value)))
+      param)))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -173,8 +173,10 @@
 (define resetters '())
 
 (define-syntax-rule (define/reset name value)
-  (define name (make-parameter value))
-  (set! resetters (cons (λ () (name value)) resetters)))
+  (define name
+    (let ([param (make-parameter value)])
+      (set! resetters (cons (λ () (name value)) resetters))
+      param)))
 
 (define (reset!)
   (for ([fn (in-list resetters)])

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -101,7 +101,7 @@
     (cons val (random-ref pts)))
   (apply mk-pcontext (cdr (batch-prepare-points evaluator new-sampler))))
 
-(define-resetter *prepend-arguement-cache* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *prepend-arguement-cache* (make-hash))
 (define (cache-get-prepend v expr macro)
   (define key (cons expr v))
   (define value (hash-ref! (*prepend-arguement-cache*) key (lambda () (macro v))))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -438,11 +438,11 @@
     [else (list (rule->egg-rule ru))]))
 
 ;; egg rule cache
-(define-resetter *egg-rule-cache* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *egg-rule-cache* (make-hash))
 
 ;; Cache mapping name to its canonical rule name
 ;; See `*egg-rules*` for details
-(define-resetter *canon-names* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *canon-names* (make-hash))
 
 ;; Tries to look up the canonical name of a rule using the cache.
 ;; Obviously dangerous if the cache is invalid.

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -22,7 +22,7 @@
          "../utils/timeline.rkt"
          "sampling.rkt"
          "soundiness.rkt")
-(provide sample-pcontext run-improve! rollback-improve!)
+(provide sample-pcontext run-improve!)
 
 ;; I'm going to use some global state here to make the shell more
 ;; friendly to interact with without having to store your own global
@@ -138,12 +138,6 @@
   (define new-alts (list (make-alt expr)))
   (define-values (errss costs) (atab-eval-altns (^table^) new-alts (*context*)))
   (^table^ (atab-add-altns (^table^) new-alts errss costs))
-  (void))
-
-(define (rollback-improve!)
-  (rollback-iter!)
-  (reset!)
-  (^table^ #f)
   (void))
 
 ;; The rest of the file is various helper / glue functions used by

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -32,7 +32,7 @@
 ;; head at once, because then global state is going to mess you up.
 
 (struct shellstate (table next-alts locs patched) #:mutable)
-(define-resetter ^shell-state^ (λ () (shellstate #f #f #f #f)) (λ () (shellstate #f #f #f #f)))
+(define/reset ^shell-state^ (shellstate #f #f #f #f))
 
 (define (^locs^ [newval 'none])
   (when (not (equal? newval 'none))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -22,7 +22,8 @@
          "../utils/timeline.rkt"
          "sampling.rkt"
          "soundiness.rkt")
-(provide sample-pcontext run-improve!)
+(provide sample-pcontext
+         run-improve!)
 
 ;; I'm going to use some global state here to make the shell more
 ;; friendly to interact with without having to store your own global

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -19,7 +19,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Patch table ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-resetter *patch-table* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *patch-table* (make-hash))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Simplify ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -9,9 +9,9 @@
 ;; It uses commutativity, identities, inverses, associativity,
 ;; distributativity, and function inverses.
 
-(define-resetter simplify-cache (λ () (make-hash)) (λ () (make-hash)))
+(define/reset simplify-cache (make-hash))
 
-(define-resetter simplify-node-cache (λ () (make-hash)) (λ () (make-hash)))
+(define/reset simplify-node-cache (make-hash))
 
 ;; This is a transcription of egg-herbie/src/math.rs, lines 97-149
 (define (eval-application op . args)

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -49,13 +49,11 @@
     [(positive? power) `(pow ,var ,power)]
     [(negative? power) `(pow ,var ,power)]))
 
-(define-resetter n-sum-to-cache (λ () (make-hash)) (λ () (make-hash)))
+(define/reset n-sum-to-cache (make-hash))
 
-(define-resetter log-cache
-                 (λ () (make-hash '((1 . ((1 -1 1))))))
-                 (λ () (make-hash '((1 . ((1 -1 1)))))))
+(define/reset log-cache (make-hash '((1 . ((1 -1 1))))))
 
-(define-resetter series-cache (λ () (make-hash)) (λ () (make-hash)))
+(define/reset series-cache (make-hash))
 
 (define (n-sum-to n k)
   (hash-ref! (n-sum-to-cache)

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -412,10 +412,10 @@
          (apply cost-proc (map loop args itypes))]))))
 
 ;; Rules from impl to spec (fixed for a particular platform)
-(define-resetter *lifting-rules* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *lifting-rules* (make-hash))
 
 ;; Rules from spec to impl (fixed for a particular platform)
-(define-resetter *lowering-rules* (λ () (make-hash)) (λ () (make-hash)))
+(define/reset *lowering-rules* (make-hash))
 
 ;; Synthesizes the LHS and RHS of lifting/lowering rules.
 (define (impl->rule-parts impl)

--- a/src/utils/errors.rkt
+++ b/src/utils/errors.rkt
@@ -91,9 +91,8 @@
 
 (define *warnings-disabled* (make-parameter false))
 
-(define-resetter warnings (λ () (mutable-set)) (λ () (mutable-set)))
-
-(define-resetter warning-log (λ () '()) (λ () '()))
+(define/reset warnings (mutable-set))
+(define/reset warning-log '())
 
 (define (warn type message #:url [url #f] #:extra [extra '()] . args)
   (unless (or (*warnings-disabled*) (set-member? (warnings) type))

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -20,11 +20,7 @@
 ;; This is a box so we can get a reference outside the engine, and so
 ;; access its value even in a timeout.
 ;; Important: Use 'eq?' based hash tables, process may freeze otherwise
-(define-resetter *timeline*
-                 (λ () (box '()))
-                 (λ ()
-                   (set-box! (*timeline*) '())
-                   (*timeline*)))
+(define/reset *timeline* (box '()))
 
 (define *timeline-active-key* #f)
 (define *timeline-active-value* #f)


### PR DESCRIPTION
We use the "reset" mechanism to flush caches between benchmarks (to make sure we don't unfairly credit one benchmark for work done in another). Over time the reset mechanism accumulated various hacks; there are separate "initialize", "reset", and "finalize" methods, and resetters have priorities. But we don't use any of these features!

This PR basically throws away all the gunk and, in the process, simplifies the syntax a bit. You now write:

```
(define/reset *foo* val)
```

This then re-evaluates `val` when it needs to be reset. Order of resets no longer guaranteed.