### PR TITLE
Add bogosity to alternatives timeline.

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -172,6 +172,14 @@
   (define test-pcontext* (preprocess-pcontext (*context*) test-pcontext preprocessing))
   (when seed
     (set-seed! seed))
+  (define repr (test-output-repr test))
+  (match-define (cons domain-stats joint-pcontext)
+    (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
+      (setup-context! (test-vars test)
+                      (prog->spec (or (test-spec test) (test-input test)))
+                      (prog->spec (test-pre test))
+                      repr)))
+  (timeline-push! 'bogosity domain-stats)
   (list alternatives test-pcontext test-pcontext*))
 
 ;; Improvement backend for generating reports


### PR DESCRIPTION
This PR adds the `bogosity` info to the `/timeline.json` file that can be requested after a `/alternatives` API request is made from say Odyessy. This information could be used to surface a warning similar to the one that we print out to the console today. 
`Warning: 45.2% of points produce a very large (infinite) output. You may want to add a precondition.`
