### PR TITLE
Enable profiling for all API endpoints.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -312,7 +312,7 @@
                      test
                      #:seed (get-seed)
                      #:pcontext #f
-                     #:profile? #f
+                     #:profile? #t
                      #:timeline-disabled? #f))
        (body command))]
     [_
@@ -420,7 +420,7 @@
      (define seed* (hash-ref post-data 'seed))
      (define test (parse-test formula))
      (define command
-       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+       (create-job 'sample test #:seed seed* #:pcontext #f #:profile? #t #:timeline-disabled? #f))
      (define id (start-job command))
      (wait-for-job id))))
 
@@ -437,8 +437,8 @@
                                            test
                                            #:seed seed
                                            #:pcontext pcontext
-                                           #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:profile? #t
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (wait-for-job id))))
 
@@ -455,8 +455,8 @@
                                            test
                                            #:seed seed
                                            #:pcontext pcontext
-                                           #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:profile? #t
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (wait-for-job id))))
 
@@ -492,8 +492,8 @@
                                            test
                                            #:seed seed
                                            #:pcontext pcontext
-                                           #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:profile? #t
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (wait-for-job id))))
 
@@ -511,8 +511,8 @@
                                            test
                                            #:seed seed
                                            #:pcontext pcontext
-                                           #:profile? #f
-                                           #:timeline-disabled? #t))
+                                           #:profile? #t
+                                           #:timeline-disabled? #f))
                              (define id (start-job command))
                              (wait-for-job id))))
 
@@ -549,7 +549,7 @@
      (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
      (define test (parse-test formula))
      (define command
-       (create-job 'cost test #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #f))
+       (create-job 'cost test #:seed #f #:pcontext #f #:profile? #t #:timeline-disabled? #f))
      (define id (start-job command))
      (wait-for-job id))))
 

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -114,6 +114,7 @@
 
 (define (wrapper-run-herbie cmd job-id)
   (print-job-message (herbie-command-command cmd) job-id (test-name (herbie-command-test cmd)))
+  (define profile? (herbie-command-profile? cmd))
   (define result
     (run-herbie (herbie-command-command cmd)
                 (herbie-command-test cmd)


### PR DESCRIPTION
This PR enables profiling for all API endpoints.

Motivation:
This allows for better insight well working on Odyessy and not just for the nightly runs of Herbie currently done with `thread-pool.rkt`. This should allow us to fix potential hot spots in Herbie that until now could only be observed from being noticeably slow to the end user or showing up during the nightly run which has similar but not the same code paths as the APIs that Odyessy currently uses.