### PR TITLE
Remove the `shellstate` struct

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -46,6 +46,11 @@
         (and (= major 8) (< minor 2))
         (and (= major 8) (= minor 2) (zero? (string-length rest))))))
 
+(define (sample-pcontext vars specification precondition)
+  (define sample (sample-points precondition (list specification) (list (*context*))))
+  (match-define (cons domain pts+exs) sample)
+  (cons domain (apply mk-pcontext pts+exs)))
+
 ;; Partitions a joint pcontext into a training and testing set
 (define (partition-pcontext joint-pcontext)
   (define num-points (pcontext-length joint-pcontext))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -34,8 +34,9 @@
 
 (define (actual-errors expr pcontext)
   (match-define (cons subexprs pt-errorss)
-    (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
-                                                         (*context*))))))
+    (parameterize ([*pcontext* pcontext])
+      (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
+                                                           (*context*)))))))
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -25,32 +25,19 @@
 (provide sample-pcontext
          run-improve!)
 
-;; I'm going to use some global state here to make the shell more
-;; friendly to interact with without having to store your own global
-;; state in the repl as you would normally do with debugging. This is
-;; probably a bad idea, and I might change it back later. When
-;; extending, make sure this never gets too complicated to fit in your
-;; head at once, because then global state is going to mess you up.
+;; The Herbie main loop goes through a simple iterative process:
+;;
+;; - Choose a subset of candidates
+;; - Choose a set of subexpressions (locs) in those alts
+;; - Patch (improve) them, generating new candidates
+;; - Evaluate all the new and old candidates and prune to the best
+;;
+;; Each stage is stored in this global variable for REPL debugging.
 
-(struct shellstate (table next-alts locs patched) #:mutable)
-(define/reset ^shell-state^ (shellstate #f #f #f #f))
-
-(define (^locs^ [newval 'none])
-  (when (not (equal? newval 'none))
-    (set-shellstate-locs! (^shell-state^) newval))
-  (shellstate-locs (^shell-state^)))
-(define (^table^ [newval 'none])
-  (when (not (equal? newval 'none))
-    (set-shellstate-table! (^shell-state^) newval))
-  (shellstate-table (^shell-state^)))
-(define (^next-alts^ [newval 'none])
-  (when (not (equal? newval 'none))
-    (set-shellstate-next-alts! (^shell-state^) newval))
-  (shellstate-next-alts (^shell-state^)))
-(define (^patched^ [newval 'none])
-  (when (not (equal? newval 'none))
-    (set-shellstate-patched! (^shell-state^) newval))
-  (shellstate-patched (^shell-state^)))
+(define/reset ^next-alts^ #f)
+(define/reset ^locs^ #f)
+(define/reset ^patched^ #f)
+(define/reset ^table^ #f)
 
 ;; These high-level functions give the high-level workflow of Herbie:
 ;; - First, set up a context by sampling input points

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -41,7 +41,7 @@
 ;; - Final steps: regimes, final simplify, add soundiness, and remove preprocessing
 
 (define (run-improve! initial specification context pcontext)
-  (explain! simplified context pcontext)
+  (explain! initial context pcontext)
   (timeline-event! 'preprocess)
   (define-values (simplified preprocessing) (find-preprocessing initial specification context))
   (timeline-push! 'symmetry (map ~a preprocessing))
@@ -324,9 +324,8 @@
   (timeline-event! 'prune)
   (^table^ (atab-add-altns table simplified errss costs)))
 
-(define (explain! simplified context pcontext)
+(define (explain! expr context pcontext)
   (timeline-event! 'explain)
-  (define expr (alt-expr (car simplified)))
 
   (define-values (fperrors
                   explanations-table
@@ -334,7 +333,7 @@
                   maybe-confusion-matrix
                   total-confusion-matrix
                   freqs)
-    (explain expr (*context*) (*pcontext*)))
+    (explain expr context pcontext))
 
   (for ([fperror (in-list fperrors)])
     (match-define (list expr truth opreds oex upreds uex) fperror)


### PR DESCRIPTION
For mysterious reasons, the Herbie `mainloop.rkt` stores all of its state in a single global struct instead of multiple variables. This seems to carry no benefits whatsoever, since we never make copies of the struct and probably won't. (Maybe this all goes back to the Herbie visualizer?) Anyway, removing this struct and the related code makes the file easier to read with basically no downsides.

Besides this one change it inlines a bunch of code in `mainloop.rkt` to try to simplify that file.