### PR TITLE
Fix graph.html page not being available for all commands.

### DIFF
--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -17,7 +17,8 @@
          "../syntax/sugar.rkt"
          "timeline.rkt")
 
-(provide make-graph)
+(provide make-graph
+         dummy-graph)
 
 (define/contract (regime-info altn)
   (-> alt? (or/c (listof sp?) #f))
@@ -34,6 +35,19 @@
   (match expr
     [(list op args ...) (ormap list? args)]
     [_ #f]))
+
+(define (dummy-graph command out)
+  (write-html
+   `(html (head (meta ([charset "utf-8"]))
+                (title "Result page for the " ,(~a command) " command is not available right now.")
+                ,@js-tex-include
+                (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"]))
+                (script ([src "https://unpkg.com/d3@6.7.0/dist/d3.min.js"]))
+                (script ([src "https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"]))
+                (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
+                (script ([src "../report.js"])))
+          (body (h2 "Result page for the " ,(~a command) " command is not available right now.")))
+   out))
 
 (define (make-graph result out output? profile?)
   (match-define (job-result _ test _ time _ warnings backend) result)

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -44,7 +44,11 @@
   (match page
     ["graph.html"
      (match status
-       ['success (make-graph result out output? profile?)]
+       ['success
+        (define command (job-result-command result))
+        (match command
+          ['improve (make-graph result out output? profile?)]
+          [else (dummy-graph command out)])]
        ['timeout (make-traceback result out profile?)]
        ['failure (make-traceback result out profile?)]
        [_ (error 'make-page "unknown result type ~a" status)])]


### PR DESCRIPTION
This PR fixes a bug when trying to view the `graph.html` page for example an `/alternatives` request from Odyessy. Currently `make-graph` only supports `'improve` commands. I think some sort of result page could be made for the other commands though I think Odyessy might be a better route here.