### PR TITLE
Remove the actual patch table and associated code

### DIFF
--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -34,7 +34,8 @@
       (append-map load-tests bench-dirs)))
   (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
   (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
-  (for/and ([the-test tests] [i (in-naturals)])
+  (for/and ([the-test tests]
+            [i (in-naturals)])
     (printf "~a/~a\t" (~a (+ 1 i) #:width 3 #:align 'right) (length tests))
     (define the-test* (if (*precision*) (override-test-precision the-test (*precision*)) the-test))
     (define result (run-herbie 'improve the-test* #:seed seed))

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -28,7 +28,8 @@
 
 (define (get-options ri)
   (define flags
-    (for*/list ([(cat flags) (in-dict (or (report-info-flags ri) '()))] [fl flags])
+    (for*/list ([(cat flags) (in-dict (or (report-info-flags ri) '()))]
+                [fl flags])
       (string->symbol (format "~a:~a" cat fl))))
   (if (equal? (report-info-iterations ri) 2) (cons 'fuel:2 flags) flags))
 
@@ -51,7 +52,8 @@
 (define cache-row?
   (apply and/c
          hash?
-         (for*/list ([(valid? keys) (in-hash key-contracts)] [key keys])
+         (for*/list ([(valid? keys) (in-hash key-contracts)]
+                     [key keys])
            (make-flat-contract #:name `(hash-has-key/c ,key)
                                #:first-order
                                (λ (x) (and (hash-has-key? x key) (valid? (hash-ref x key))))))))
@@ -73,7 +75,9 @@
     info)
 
   (define-values (total-start total-end)
-    (for/fold ([start 0] [end 0]) ([row (or tests '())])
+    (for/fold ([start 0]
+               [end 0])
+              ([row (or tests '())])
       (values (+ start (or (table-row-start row) 0)) (+ end (or (table-row-result row) 0)))))
 
   (define statuses (map table-row-status (or tests '())))
@@ -248,7 +252,8 @@
        (hash-set (compute-row folder) 'folder (path->string (simplify-path path* false))))]
     [(file-exists? file)
      (define cached-info (call-with-input-file file read-json))
-     (for ([v (in-list cached-info)] #:unless (cache-row? v))
+     (for ([v (in-list cached-info)]
+           #:unless (cache-row? v))
        (raise-user-error 'make-index "Invalid cache row ~a" v))
      cached-info]))
 

--- a/infra/survey.rkt
+++ b/infra/survey.rkt
@@ -36,7 +36,8 @@ section > div { width: 500; float: left; margin-right: 20px; }
      (body
       (h1 ,(format "Seed survey for ~a benchmarks" (hash-count results)))
       ,@
-      (for/list ([(name metrics) (in-dict results)] [n (in-naturals)])
+      (for/list ([(name metrics) (in-dict results)]
+                 [n (in-naturals)])
         `(section
           (h2 ,(~a name))
           ,@

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -72,7 +72,8 @@
           (exact->inexact (- 1 (/ initial-accuracies-sum maximum-accuracy)))
           1.0)))
   (define rescaled
-    (for/list ([cost-accuracy (in-list cost-accuracies)] #:unless (null? cost-accuracy))
+    (for/list ([cost-accuracy (in-list cost-accuracies)]
+               #:unless (null? cost-accuracy))
       (match-define (list (and initial-point (list initial-cost _)) best-point other-points)
         cost-accuracy)
       ;; Has to be floating point so serializing to JSON doesn't complain
@@ -180,7 +181,8 @@
       (call-with-atomic-output-file file (λ (p name) (write-json data p)))))
 
 (define (flags->list flags)
-  (for*/list ([rec (hash->list flags)] [fl (cdr rec)])
+  (for*/list ([rec (hash->list flags)]
+              [fl (cdr rec)])
     (format "~a:~a" (car rec) fl)))
 
 (define (list->flags list)
@@ -194,7 +196,8 @@
   (define (parse-string s)
     (if s (call-with-input-string s read) #f))
 
-  (let* ([json (call-with-input-file file read-json)] [get (λ (field) (hash-ref json field))])
+  (let* ([json (call-with-input-file file read-json)]
+         [get (λ (field) (hash-ref json field))])
     (report-info
      (seconds->date (get 'date))
      (get 'commit)
@@ -205,7 +208,8 @@
      (get 'points)
      (get 'iterations)
      (hash-ref json 'note #f)
-     (for/list ([test (get 'tests)] #:when (hash-has-key? test 'vars))
+     (for/list ([test (get 'tests)]
+                #:when (hash-has-key? test 'vars))
        (let ([get (λ (field) (hash-ref test field))])
          (define vars
            (match (hash-ref test 'vars)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -527,7 +527,8 @@
                              (define local-error (job-result-backend result))
                              ;; TODO: potentially unsafe if resugaring changes the AST
                              (define tree
-                               (let loop ([expr expr] [err local-error])
+                               (let loop ([expr expr]
+                                          [err local-error])
                                  (match expr
                                    [(list op args ...)
                                     ;; err => (List (listof Integer) List ...)

--- a/src/api/improve.rkt
+++ b/src/api/improve.rkt
@@ -9,7 +9,9 @@
 (define (print-outputs tests results p #:seed [seed #f])
   (when seed
     (fprintf p ";; seed: ~a\n\n" seed))
-  (for ([res results] [test tests] #:when res)
+  (for ([res results]
+        [test tests]
+        #:when res)
     (define name (table-row-name res))
     (match (table-row-status res)
       ["error"

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -100,7 +100,8 @@
 
   (define-values (_ test-pcontext) (partition-pcontext pcontext))
   (define errs (errors (test-input test) test-pcontext (*context*)))
-  (for/list ([(pt _) (in-pcontext test-pcontext)] [err (in-list errs)])
+  (for/list ([(pt _) (in-pcontext test-pcontext)]
+             [err (in-list errs)])
     (list pt err)))
 
 ;; Given a test and a sample of points, the ground truth of each point
@@ -211,7 +212,8 @@
   ;; optionally compute error/cost for input expression
   (define target-alt-data
     ;; When in platform, evaluate error
-    (for/list ([(expr is-valid?) (in-dict (test-output test))] #:when is-valid?)
+    (for/list ([(expr is-valid?) (in-dict (test-output test))]
+               #:when is-valid?)
       (define target-expr (fpcore->prog expr ctx))
       (define target-train-errs (errors target-expr train-pcontext ctx))
       (define target-test-errs (errors target-expr test-pcontext* ctx))
@@ -265,7 +267,8 @@
         [_ (error 'run-herbie "command ~a timed out" command)])))
 
   (define (compute-result test)
-    (parameterize ([*timeline-disabled* timeline-disabled?] [*warnings-disabled* false])
+    (parameterize ([*timeline-disabled* timeline-disabled?]
+                   [*warnings-disabled* false])
       (define start-time (current-inexact-milliseconds))
       (reset!)
       (*context* (test-context test))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -34,7 +34,8 @@
 
 ; I don't like how specific this function is but it keeps the API boundary.
 (define (get-improve-job-data)
-  (for/list ([(k v) (in-hash *completed-jobs*)] #:when (equal? (job-result-command v) 'improve))
+  (for/list ([(k v) (in-hash *completed-jobs*)]
+             #:when (equal? (job-result-command v) 'improve))
     (get-table-data v (make-path k))))
 
 (define (job-count)

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -27,7 +27,8 @@
              ['windows "Ctrl-Z Enter"]
              [_ "Ctrl-D"]))
   (with-handlers ([exn:break? (λ (e) (exit 0))])
-    (for ([test (in-producer get-input eof-object?)] [idx (in-naturals)])
+    (for ([test (in-producer get-input eof-object?)]
+          [idx (in-naturals)])
       (define result (run-herbie 'improve test #:seed seed))
       (define status (job-result-status result))
       (define time (job-result-time result))

--- a/src/api/thread-pool.rkt
+++ b/src/api/thread-pool.rkt
@@ -100,7 +100,8 @@
       (place-dead-evt worker)))
 
   (define work
-    (for/list ([id (in-naturals)] [prog progs])
+    (for/list ([id (in-naturals)]
+               [prog progs])
       (list id prog)))
 
   (eprintf "Starting ~a Herbie workers on ~a problems (seed: ~a)...\n" threads (length progs) seed)
@@ -135,7 +136,8 @@
                                 (eprintf "Terminating after ~a problem~a!\n"
                                          (length outs)
                                          (if (= (length outs) 1) "s" "")))])
-    (for ([test progs] [i (in-naturals)])
+    (for ([test progs]
+          [i (in-naturals)])
       (define tr (run-test i test #:seed seed #:profile profile? #:dir dir))
       (print-test-result (+ 1 i) (length progs) tr)
       (set! outs (cons tr outs))))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -81,7 +81,8 @@
 
 (define (changed-flags)
   (filter identity
-          (for*/list ([(class flags) all-flags] [flag flags])
+          (for*/list ([(class flags) all-flags]
+                      [flag flags])
             (match* ((flag-set? class flag) (parameterize ([*flags* default-flags])
                                               (flag-set? class flag)))
               [(#t #t) #f]
@@ -156,7 +157,8 @@
 
 (define (git-command #:default [default ""] gitcmd . args)
   (if (or (directory-exists? ".git") (file-exists? ".git")) ; gitlinks like for worktrees
-      (let* ([cmd (format "git ~a ~a" gitcmd (string-join args " "))] [out (run-command cmd)])
+      (let* ([cmd (format "git ~a ~a" gitcmd (string-join args " "))]
+             [out (run-command cmd)])
         (if (equal? out "") default out))
       default))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -90,7 +90,8 @@
   (match-define (alt-table pnts->alts alts->pnts alt->done? alt->cost _ _) atab)
   (define tied (list->mutable-seteq (hash-keys alts->pnts)))
   (define coverage '())
-  (for* ([pcurve (in-hash-values pnts->alts)] [ppt (in-list pcurve)])
+  (for* ([pcurve (in-hash-values pnts->alts)]
+         [ppt (in-list pcurve)])
     (match (pareto-point-data ppt)
       [(list) (error "This point has no alts which are best at it!" ppt)]
       [(list altn) (set-remove! tied altn)]
@@ -100,10 +101,14 @@
 (define (set-cover-remove! sc altn)
   (match-define (set-cover removable coverage) sc)
   (set-remove! removable altn)
-  (for ([j (in-naturals)] [s (in-vector coverage)] #:when s)
+  (for ([j (in-naturals)]
+        [s (in-vector coverage)]
+        #:when s)
     (define count 0)
     (define last #f)
-    (for ([i (in-naturals)] [a (in-vector s)] #:when a)
+    (for ([i (in-naturals)]
+          [a (in-vector s)]
+          #:when a)
       (cond
         [(eq? a altn) (vector-set! s i #f)]
         [a
@@ -161,8 +166,11 @@
 
 (define (atab-add-altns atab altns errss costs)
   (define-values (atab* progs*)
-    (for/fold ([atab atab] [progs (list->set (map alt-expr (alt-table-all atab)))])
-              ([altn (in-list altns)] [errs (in-list errss)] [cost (in-list costs)])
+    (for/fold ([atab atab]
+               [progs (list->set (map alt-expr (alt-table-all atab)))])
+              ([altn (in-list altns)]
+               [errs (in-list errss)]
+               [cost (in-list costs)])
       ;; this is subtle, we actually want to check for duplicates
       ;; in terms of expressions, not alts: the default `equal?`
       ;; returns #f for the same expression with different derivations.
@@ -180,7 +188,9 @@
 
 (define (invert-index idx)
   (define alt->points* (make-hasheq))
-  (for* ([(pt curve) (in-hash idx)] [ppt (in-list curve)] [alt (in-list (pareto-point-data ppt))])
+  (for* ([(pt curve) (in-hash idx)]
+         [ppt (in-list curve)]
+         [alt (in-list (pareto-point-data ppt))])
     (hash-set! alt->points* alt (cons pt (hash-ref alt->points* alt '()))))
   (make-immutable-hash (hash->list alt->points*)))
 
@@ -188,7 +198,8 @@
   (match-define (alt-table point->alts alt->points alt->done? alt->cost pcontext all-alts) atab)
 
   (define point->alts*
-    (for/hash ([(pt ex) (in-pcontext pcontext)] [err (in-list errs)])
+    (for/hash ([(pt ex) (in-pcontext pcontext)]
+               [err (in-list errs)])
       (define ppt (pareto-point cost err (list altn)))
       (values pt (pareto-union (list ppt) (hash-ref point->alts pt)))))
 

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -56,7 +56,9 @@
      (alt expr* (list 'regimes splitpoints*) alts* '())]))
 
 (define (remove-unused-alts alts splitpoints)
-  (for/fold ([alts* '()] [splitpoints* '()]) ([splitpoint splitpoints])
+  (for/fold ([alts* '()]
+             [splitpoints* '()])
+            ([splitpoint splitpoints])
     (define alt (list-ref alts (sp-cidx splitpoint)))
     ;; It's important to snoc the alt in order for the indices not to change
     (define alts** (remove-duplicates (append alts* (list alt))))
@@ -146,7 +148,8 @@
     (left-point p1 p2))
 
   (define (left-point p1 p2)
-    (let ([left ((representation-repr->bf repr) p1)] [right ((representation-repr->bf repr) p2)])
+    (let ([left ((representation-repr->bf repr) p1)]
+          [right ((representation-repr->bf repr) p2)])
       (define out
         (if (bfnegative? left)
             (bigfloat-interval-shortest left (bfmin (bf/ left 2.bf) right))
@@ -159,7 +162,8 @@
          ;; Binary search is only valid if we correctly extracted the branch expression
          (andmap identity (cons start-prog progs))))
 
-  (append (for/list ([si1 sindices] [si2 (cdr sindices)])
+  (append (for/list ([si1 sindices]
+                     [si2 (cdr sindices)])
             (define prog1 (list-ref progs (si-cidx si1)))
             (define prog2 (list-ref progs (si-cidx si2)))
 
@@ -182,7 +186,8 @@
   (define ctx* (struct-copy context ctx [repr (repr-of bexpr ctx)]))
   (define prog (compile-prog bexpr ctx*))
 
-  (for/list ([i (in-naturals)] [alt alts]) ;; alts necessary to terminate loop
+  (for/list ([i (in-naturals)]
+             [alt alts]) ;; alts necessary to terminate loop
     (λ (pt)
       (define val (apply prog pt))
       (for/first ([right splitpoints]

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -23,9 +23,11 @@
   (define varc (length vars))
   (define vregs (make-vector (+ varc iveclen)))
   (define (compiled-prog . args)
-    (for ([arg (in-list args)] [n (in-naturals)])
+    (for ([arg (in-list args)]
+          [n (in-naturals)])
       (vector-set! vregs n arg))
-    (for ([instr (in-vector ivec)] [n (in-naturals varc)])
+    (for ([instr (in-vector ivec)]
+          [n (in-naturals varc)])
       (vector-set! vregs n (apply-instruction instr vregs)))
     (for/vector #:length rootlen
                 ([root (in-vector rootvec)])
@@ -51,7 +53,8 @@
 (define (progs->batch exprs vars)
   (define icache (reverse vars))
   (define exprhash
-    (make-hash (for/list ([var vars] [i (in-naturals)])
+    (make-hash (for/list ([var vars]
+                          [i (in-naturals)])
                  (cons var i))))
   ; Counts
   (define size 0)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -236,11 +236,15 @@
       [(list op args ...) (cons op (map loop args))])))
 
 (define (flatten-let expr)
-  (let loop ([expr expr] [env (hash)])
+  (let loop ([expr expr]
+             [env (hash)])
     (match expr
       [(? number?) expr]
       [(? symbol?) (hash-ref env expr expr)]
-      [`(let (,var ,term) ,body) (loop body (hash-set env var (loop term env)))]
+      [`(let (,var
+              ,term)
+          ,body)
+       (loop body (hash-set env var (loop term env)))]
       [`(,op ,args ...) (cons op (map (curryr loop env) args))])))
 
 ;; Converts an S-expr from egg into one Herbie understands
@@ -248,7 +252,8 @@
 ;; we may process mixed spec/impl expressions;
 ;; only need `type` to correctly interpret numbers
 (define (egg-parsed->expr expr rename-dict type)
-  (let loop ([expr expr] [type type])
+  (let loop ([expr expr]
+             [type type])
     (match expr
       [(? number?) (if (representation? type) (literal expr (representation-name type)) expr)]
       [(? symbol?)
@@ -426,7 +431,8 @@
      (define itype (dict-ref (rule-itypes ru) input))
      (unless (type-name? itype)
        (error 'rule->egg-rules "expansive rules over impls is unsound ~a" input))
-     (for/list ([op (all-operators)] #:when (eq? (operator-info op 'otype) itype))
+     (for/list ([op (all-operators)]
+                #:when (eq? (operator-info op 'otype) itype))
        (define itypes (operator-info op 'itype))
        (define vars (map (lambda (_) (gensym)) itypes))
        (rule (sym-append (rule-name ru) '-expand- op)
@@ -571,7 +577,8 @@
     (define dirty? #f)
     (define dirty?-vec* (make-vector n #f))
     (define changed?-vec* (make-vector n #f))
-    (for ([id (in-range n)] #:when (vector-ref dirty?-vec id))
+    (for ([id (in-range n)]
+          #:when (vector-ref dirty?-vec id))
       (define eclass (vector-ref eclasses id))
       (when (eclass-proc analysis changed?-vec iter eclass id)
         ; eclass analysis was updated: need to revisit the parents
@@ -771,7 +778,9 @@
 (define (type/intersect ty1 ty2)
   (match* (ty1 ty2)
     [((list 'or tys1 ...) (list 'or tys2 ...))
-     (match (for/fold ([tys '()]) ([ty (in-list tys1)] #:when (member ty tys2))
+     (match (for/fold ([tys '()])
+                      ([ty (in-list tys1)]
+                       #:when (member ty tys2))
               (cons ty tys))
        ['() #f]
        [(list ty) ty]
@@ -790,7 +799,9 @@
       [(? number?)
        ; NOTE: a number by itself is untyped, but we can constrain
        ; the type of the number by the platform
-       (for/fold ([ty #f]) ([repr (in-list reprs)] #:when (eq? (representation-type repr) 'real))
+       (for/fold ([ty #f])
+                 ([repr (in-list reprs)]
+                  #:when (eq? (representation-type repr) 'real))
          (type/union ty repr (representation-type repr)))]
       [(? symbol?)
        (define repr (cdr (hash-ref egg->herbie node)))
@@ -813,7 +824,9 @@
     (define ty*
       (if (= iter 0)
           ; first iteration: only run analysis on leaves
-          (for/fold ([ty ty]) ([node (in-vector eclass)] #:unless (node-has-children? node))
+          (for/fold ([ty ty])
+                    ([node (in-vector eclass)]
+                     #:unless (node-has-children? node))
             (type/union ty (node->type analysis node)))
           ; other iterations: run only on non-leaves with updated children
           (for/fold ([ty ty])
@@ -842,7 +855,9 @@
       [(? number?)
        ; NOTE: a number by itself is untyped, but we can constrain
        ; the type of the number by the platform
-       (for/fold ([ty #f]) ([repr (in-list reprs)] #:when (eq? (representation-type repr) 'real))
+       (for/fold ([ty #f])
+                 ([repr (in-list reprs)]
+                  #:when (eq? (representation-type repr) 'real))
          (type/union ty repr (representation-type repr)))]
       [(? symbol?)
        (define repr (cdr (hash-ref egg->herbie node)))
@@ -885,7 +900,8 @@
       (for ([ty (in-vector node-types)])
         (match ty
           [(list 'or tys ...)
-           (for ([ty (in-list tys)] #:when (representation? ty))
+           (for ([ty (in-list tys)]
+                 #:when (representation? ty))
              (hash-set! table ty #f))]
           [(? representation?) (hash-set! table ty #f)]
           [(? type-name?) (void)]
@@ -980,10 +996,13 @@
           (= iter 0)))
 
     ; Iterate over the nodes
-    (for ([node (in-vector eclass)] [ty (in-vector node-types)] [ready? (in-vector ready?/node)])
+    (for ([node (in-vector eclass)]
+          [ty (in-vector node-types)]
+          [ready? (in-vector ready?/node)])
       (match ty
         [(list 'or tys ...) ; node is a union type (only for some `if` nodes)
-         (for ([ty (in-list tys)] [ready? (in-list ready?)])
+         (for ([ty (in-list tys)]
+               [ready? (in-list ready?)])
            (when (and (representation? ty) (node-requires-update? node))
              (define new-cost (node-cost node ty ready?))
              (update-cost! ty new-cost node)))]
@@ -1009,7 +1028,8 @@
   (define (build-expr id type)
     (let/ec
      return
-     (let loop ([id id] [type type])
+     (let loop ([id id]
+                [type type])
        (match (unsafe-best-node id type)
          [(? number? n) n] ; number
          [(? symbol? s) s] ; variable
@@ -1118,7 +1138,8 @@
               [(list (? impl-exists? impl) ids ...)
                (when (equal? (impl-info impl 'otype) type)
                  (define args
-                   (for/list ([id (in-list ids)] [itype (in-list (impl-info impl 'itype))])
+                   (for/list ([id (in-list ids)]
+                              [itype (in-list (impl-info impl 'itype))])
                      (match-define (cons _ expr) (extract id itype))
                      expr))
                  (when (andmap identity args) ; guard against failed extraction
@@ -1126,7 +1147,8 @@
               [(list (? operator-exists? op) ids ...)
                (when (equal? (operator-info op 'otype) type)
                  (define args
-                   (for/list ([id (in-list ids)] [itype (in-list (operator-info op 'itype))])
+                   (for/list ([id (in-list ids)]
+                              [itype (in-list (operator-info op 'itype))])
                      (match-define (cons _ expr) (extract id itype))
                      expr))
                  (when (andmap identity args) ; guard against failed extraction
@@ -1186,7 +1208,9 @@
       (define-values (egg-graph* iteration-data) (egraph-run-rules egg-graph egg-rules params))
 
       ; get cost statistics
-      (for/fold ([time 0]) ([iter (in-list iteration-data)] [i (in-naturals)])
+      (for/fold ([time 0])
+                ([iter (in-list iteration-data)]
+                 [i (in-naturals)])
         (define cnt (iteration-data-num-nodes iter))
         (define cost (apply + (map (λ (id) (egraph-get-cost egg-graph* id i)) root-ids)))
         (define new-time (+ time (iteration-data-time iter)))
@@ -1276,16 +1300,19 @@
      (define regraph (make-regraph egg-graph))
      (define extract-id (extractor regraph))
      (define reprs (egg-runner-reprs runner))
-     (for/list ([id (in-list root-ids)] [repr (in-list reprs)])
+     (for/list ([id (in-list root-ids)]
+                [repr (in-list reprs)])
        (regraph-extract-best regraph extract-id id repr))]
     [`(multi . ,extractor) ; multi expression extraction
      (define regraph (make-regraph egg-graph))
      (define extract-id (extractor regraph))
      (define reprs (egg-runner-reprs runner))
-     (for/list ([id (in-list root-ids)] [repr (in-list reprs)])
+     (for/list ([id (in-list root-ids)]
+                [repr (in-list reprs)])
        (regraph-extract-variants regraph extract-id id repr))]
     [`(proofs . ((,start-exprs . ,end-exprs) ...)) ; proof extraction
-     (for/list ([start (in-list start-exprs)] [end (in-list end-exprs)])
+     (for/list ([start (in-list start-exprs)]
+                [end (in-list end-exprs)])
        (unless (egraph-expr-equal? egg-graph start end ctx)
          (error 'run-egg
                 "cannot find proof; start and end are not equal.\n start: ~a \n end: ~a"
@@ -1296,6 +1323,7 @@
          (error 'run-egg "proof extraction failed between`~a` and `~a`" start end))
        proof)]
     [`(equal? . ((,start-exprs . ,end-exprs) ...)) ; term equality?
-     (for/list ([start (in-list start-exprs)] [end (in-list end-exprs)])
+     (for/list ([start (in-list start-exprs)]
+                [end (in-list end-exprs)])
        (egraph-expr-equal? egg-graph start end ctx))]
     [_ (error 'run-egg "unknown command `~a`\n" cmd)]))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -40,7 +40,8 @@
 
   (define pt-worst-subexpr
     (append* (reap [sow]
-                   (for ([pt-errors (in-list pt-errorss)] [(pt _) (in-pcontext pcontext)])
+                   (for ([pt-errors (in-list pt-errorss)]
+                         [(pt _) (in-pcontext pcontext)])
                      (define sub-error (map cons subexprs pt-errors))
                      (define filtered-sub-error (filter (lambda (p) (> (cdr p) 16)) sub-error))
                      (define mapped-sub-error (map (lambda (p) (cons (car p) pt)) filtered-sub-error))
@@ -83,7 +84,9 @@
   (for ([(pt _) (in-pcontext pctx)])
     (define (silence expr)
       (define subexprs (all-subexpressions expr #:reverse? #t))
-      (for* ([subexpr (in-list subexprs)] #:when (list? subexpr) [expl (in-list all-explanations)])
+      (for* ([subexpr (in-list subexprs)]
+             #:when (list? subexpr)
+             [expl (in-list all-explanations)])
         (define key (cons subexpr expl))
         (when (hash-has-key? expls->points key)
           (hash-update! expls->points key (lambda (x) (set-remove x pt))))
@@ -517,11 +520,13 @@
             (and (not (empty? upred)) (values->json (first upred) repr)))))
 
   (define true-error-hash
-    (for/hash ([(key _) (in-pcontext pctx)] [value (in-list (errors expr pctx ctx))])
+    (for/hash ([(key _) (in-pcontext pctx)]
+               [value (in-list (errors expr pctx ctx))])
       (values key value)))
 
   (define explanations-table
-    (for/list ([(key val) (in-dict expls->points)] #:unless (zero? (length val)))
+    (for/list ([(key val) (in-dict expls->points)]
+               #:unless (zero? (length val)))
       (define expr (car key))
       (define expl (cdr key))
       (define err-count (length val))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -102,7 +102,8 @@
   (define subexprss (map all-subexpressions exprs))
   (define errss (compute-local-errors subexprss ctx))
 
-  (for/list ([_ (in-list exprs)] [errs (in-list errss)])
+  (for/list ([_ (in-list exprs)]
+             [errs (in-list errss)])
     (sort (sort (for/list ([(subexpr err) (in-hash errs)]
                            #:when (or (list? subexpr) (approx? subexpr)))
                   (cons err subexpr))
@@ -114,23 +115,27 @@
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors subexprss ctx)
   (define spec-list
-    (for*/list ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
+    (for*/list ([subexprs (in-list subexprss)]
+                [subexpr (in-list subexprs)])
       (prog->spec subexpr)))
   (define ctx-list
-    (for*/list ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
+    (for*/list ([subexprs (in-list subexprss)]
+                [subexpr (in-list subexprs)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
 
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
 
   ; Mutable error hack, this is bad
   (define errs
-    (make-hash (for*/list ([subexprs (in-list subexprss)] [subexpr (in-list subexprs)])
+    (make-hash (for*/list ([subexprs (in-list subexprss)]
+                           [subexpr (in-list subexprs)])
                  (cons subexpr '()))))
 
   (for ([(pt ex) (in-pcontext (*pcontext*))])
     (define exacts (apply subexprs-fn pt))
     (define exacts-hash (make-immutable-hash (map cons (apply append subexprss) exacts)))
-    (for* ([subexprs (in-list subexprss)] [expr (in-list subexprs)])
+    (for* ([subexprs (in-list subexprss)]
+           [expr (in-list subexprs)])
       (define err
         (match expr
           [(? literal?) 1]

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -70,7 +70,7 @@
 
   (choose-alts!)
   (localize!)
-  (reconstruct! (patch-table-run (^locs^)))
+  (reconstruct! (generate-candidates (^locs^)))
   (finalize-iter!))
 
 (define (extract!)
@@ -295,7 +295,7 @@
     (choose-alts!))
   (unless (^locs^)
     (localize!))
-  (reconstruct! (patch-table-run (^locs^)))
+  (reconstruct! (generate-candidates (^locs^)))
   (finalize-iter!)
   (void))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -180,12 +180,7 @@
                  #:when true
                  [(cost-diff expr) (in-dict loc-costs)]
                  [_ (in-range (*localize-expressions-limit*))])
-        (timeline-push! 'locations
-                        (~a expr)
-                        "cost-diff"
-                        cost-diff
-                        (not (patch-table-has-expr? expr))
-                        (~a (representation-name repr)))
+        (timeline-push! 'locations (~a expr) "cost-diff" cost-diff)
         expr))
     (set! localized-exprs (remove-duplicates (append localized-exprs cost-localized))))
 
@@ -198,12 +193,7 @@
                  #:when true
                  [(err expr) (in-dict loc-errs)]
                  [_ (in-range (*localize-expressions-limit*))])
-        (timeline-push! 'locations
-                        (~a expr)
-                        "accuracy"
-                        (errors-score err)
-                        (not (patch-table-has-expr? expr))
-                        (~a (representation-name repr)))
+        (timeline-push! 'locations (~a expr) "accuracy" (errors-score err))
         expr))
     (set! localized-exprs (remove-duplicates (append localized-exprs error-localized))))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -49,7 +49,8 @@
   (*pcontext* pcontext*)
   (initialize-alt-table! simplified context pcontext*)
 
-  (for ([iteration (in-range (*num-iterations*))] #:break (atab-completed? (^table^)))
+  (for ([iteration (in-range (*num-iterations*))]
+        #:break (atab-completed? (^table^)))
     (run-iter!))
   (define alternatives (extract!))
 
@@ -90,7 +91,8 @@
 (define (list-alts)
   (printf "Key: [.] = done, [>] = chosen\n")
   (let ([ndone-alts (atab-not-done-alts (^table^))])
-    (for ([alt (atab-active-alts (^table^))] [n (in-naturals)])
+    (for ([alt (atab-active-alts (^table^))]
+          [n (in-naturals)])
       (printf "~a ~a ~a\n"
               (cond
                 [(set-member? (^next-alts^) alt) ">"]
@@ -203,14 +205,16 @@
 ;; Returns the locations of `subexpr` within `expr`
 (define (get-locations expr subexpr)
   (reap [sow]
-        (let loop ([expr expr] [loc '()])
+        (let loop ([expr expr]
+                   [loc '()])
           (match expr
             [(== subexpr) (sow (reverse loc))]
             [(? literal?) (void)]
             [(? symbol?) (void)]
             [(approx _ impl) (loop impl (cons 2 loc))]
             [(list _ args ...)
-             (for ([arg (in-list args)] [i (in-naturals 1)])
+             (for ([arg (in-list args)]
+                   [i (in-naturals 1)])
                (loop arg (cons i loc)))]))))
 
 ;; Converts a patch to full alt with valid history
@@ -378,7 +382,8 @@
                                                      default-egg-cost-proc)))))
 
      ; de-duplication
-     (remove-duplicates (for/list ([altn (in-list alts)] [prog (in-list simplified)])
+     (remove-duplicates (for/list ([altn (in-list alts)]
+                                   [prog (in-list simplified)])
                           (if (equal? (alt-expr altn) prog)
                               altn
                               (alt prog 'final-simplify (list altn) (alt-preprocessing altn))))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -13,12 +13,7 @@
          "simplify.rkt"
          "taylor.rkt")
 
-(provide patch-table-has-expr?
-         patch-table-run)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;; Patch table ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define/reset *patch-table* (make-hash))
+(provide generate-candidates)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Simplify ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -145,10 +140,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Public API ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (patch-table-has-expr? expr)
-  (hash-has-key? (*patch-table*) expr))
-
-(define (patch-table-run exprs)
+(define (generate-candidates exprs)
   ; Starting alternatives
   (define start-altns
     (for/list ([expr (in-list exprs)])

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -48,7 +48,8 @@
   ; convert to altns
   (define simplified
     (reap [sow]
-          (for ([altn (in-list approxs)] [outputs (in-list simplification-options)])
+          (for ([altn (in-list approxs)]
+                [outputs (in-list simplification-options)])
             (match-define (cons _ simplified) outputs)
             (define prev (hash-ref approx->prev altn))
             (for ([expr (in-list simplified)])
@@ -73,7 +74,8 @@
 (define (taylor-alt altn)
   (define expr (prog->spec (alt-expr altn)))
   (reap [sow]
-        (for* ([var (free-variables expr)] [transform-type transforms-to-try])
+        (for* ([var (free-variables expr)]
+               [transform-type transforms-to-try])
           (match-define (list name f finv) transform-type)
           (define timeline-stop! (timeline-start! 'series (~a expr) (~a var) (~a name)))
           (define genexpr (approximate expr var #:transform (cons f finv)))
@@ -130,7 +132,8 @@
   ; apply changelists
   (define rewritten
     (reap [sow]
-          (for ([variants (in-list variantss)] [altn (in-list altns)])
+          (for ([variants (in-list variantss)]
+                [altn (in-list altns)])
             (for ([variant (in-list (remove-duplicates variants))])
               (sow (alt variant (list 'rr runner #f #f) (list altn) '()))))))
 

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -113,7 +113,9 @@
   (define abs-instrs '())
   (define negabs-instrs '())
   (define swaps '())
-  (for ([ident (in-list identities)] [expr-equal? (in-list equal?-lst)] #:when expr-equal?)
+  (for ([ident (in-list identities)]
+        [expr-equal? (in-list equal?-lst)]
+        #:when expr-equal?)
     (match ident
       [(list 'even var _) (set! abs-instrs (cons (list 'abs var) abs-instrs))]
       [(list 'odd var _) (set! negabs-instrs (cons (list 'negabs var) negabs-instrs))]
@@ -121,7 +123,8 @@
 
   (define components (connected-components (context-vars ctx) swaps))
   (define sort-instrs
-    (for/list ([component (in-list components)] #:when (> (length component) 1))
+    (for/list ([component (in-list components)]
+               #:when (> (length component) 1))
       (cons 'sort component)))
 
   (define instrs (append abs-instrs negabs-instrs sort-instrs))
@@ -160,7 +163,8 @@
        (error 'instruction->operator "component should always be a subsequence of variables"))
      (define indices (indexes-where variables (curryr member component)))
      (lambda (x y)
-       (let* ([subsequence (map (curry list-ref x) indices)] [sorted (sort* subsequence)])
+       (let* ([subsequence (map (curry list-ref x) indices)]
+              [sorted (sort* subsequence)])
          (values (list-set* x indices sorted) y)))]
     [(list 'abs variable)
      (define index (index-of variables variable))
@@ -185,7 +189,9 @@
                                           preprocessing
                                           #:removed [removed empty])
   (define-values (result newly-removed)
-    (let loop ([preprocessing preprocessing] [i 0] [removed removed])
+    (let loop ([preprocessing preprocessing]
+               [i 0]
+               [removed removed])
       (cond
         [(>= i (length preprocessing)) (values preprocessing removed)]
         [(preprocessing-<=? expression context pcontext (drop-at preprocessing i) preprocessing)

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -91,7 +91,8 @@
        [(< len-a len-b) -1]
        [(> len-a len-b) 1]
        [else
-        (let loop ([a a] [b b])
+        (let loop ([a a]
+                   [b b])
           (if (null? a)
               0
               (let ([cmp (expr-cmp (car a) (car b))])
@@ -147,7 +148,8 @@
   (define (invalid! where loc)
     (error 'location-do "invalid location `~a` for `~a` in `~a`" loc where prog))
 
-  (let loop ([prog prog] [loc loc])
+  (let loop ([prog prog]
+             [loc loc])
     (match* (prog loc)
       [(_ (? null?)) (f prog)]
       [((or (? literal?) (? number?) (? symbol?)) _) (invalid! prog loc)]
@@ -157,7 +159,8 @@
          [(2) (approx spec (loop impl rest))]
          [else (invalid! prog loc)])]
       [((list op args ...) (cons idx rest)) ; operator
-       (let seek ([elts (cons op args)] [idx idx])
+       (let seek ([elts (cons op args)]
+                  [idx idx])
          (cond
            [(= idx 0) (cons (loop (car elts) rest) (cdr elts))]
            [(null? elts) (invalid! prog loc)]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -29,7 +29,8 @@
        [(and (not (zero? a)) (integer? b)) (expt a b)]
        [else #f])]
     [(list 'sqrt (? exact-value? a))
-     (let ([s1 (sqrt (numerator a))] [s2 (sqrt (denominator a))])
+     (let ([s1 (sqrt (numerator a))]
+           [s2 (sqrt (denominator a))])
        (and (real? s1) (real? s2) (exact? s1) (exact? s2) (/ s1 s2)))]
     [(list 'cbrt (? exact-value? a))
      (define inexact-num (inexact->exact (expt (numerator a) 1/3)))
@@ -175,7 +176,8 @@
      (let ([terms (gather-multiplicative-terms arg)])
        (cons (if (member (car terms) '(0 NAN)) 'NAN (/ (car terms))) (map negate-term (cdr terms))))]
     [`(/ ,arg ,args ...)
-     (let ([num (gather-multiplicative-terms arg)] [dens (map gather-multiplicative-terms args)])
+     (let ([num (gather-multiplicative-terms arg)]
+           [dens (map gather-multiplicative-terms args)])
        (cons (if (or (eq? (car num) 'NAN) (ormap (compose (curryr member '(0 NAN)) car) dens))
                  'NAN
                  (apply / (car num) (map car dens)))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -38,7 +38,9 @@
   (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))
   (define branches (if (null? sorted) '() (exprs-to-branch-on sorted ctx)))
   (define branch-exprs (if (flag-set? 'reduce 'branch-expressions) branches (context-vars ctx)))
-  (let loop ([alts sorted] [errs (hash)] [err-lsts err-lsts])
+  (let loop ([alts sorted]
+             [errs (hash)]
+             [err-lsts err-lsts])
     (cond
       [(null? alts) '()]
       ; Only return one option if not pareto mode
@@ -61,7 +63,10 @@
   ;; invariant:
   ;; errs[bexpr] is some best option on branch expression bexpr computed on more alts than we have right now.
   (define-values (best best-err errs)
-    (for/fold ([best '()] [best-err +inf.0] [errs cerrs] #:result (values best best-err errs))
+    (for/fold ([best '()]
+               [best-err +inf.0]
+               [errs cerrs]
+               #:result (values best best-err errs))
               ([bexpr sorted-bexprs]
                ;; stop if we've computed this (and following) branch-expr on more alts and it's still worse
                #:break (> (hash-ref cerrs bexpr -1) best-err))
@@ -125,7 +130,8 @@
     (for/list ([pt pts])
       (apply fn pt)))
   (define big-table ; val and errors for each alt, per point
-    (for/list ([(pt ex) (in-pcontext (*pcontext*))] [err-lst err-lsts])
+    (for/list ([(pt ex) (in-pcontext (*pcontext*))]
+               [err-lst err-lsts])
       (list* pt (apply fn pt) err-lst)))
   (match-define (list pts* splitvals* err-lsts* ...)
     (flip-lists (sort big-table (curryr </total repr) #:key second)))
@@ -134,7 +140,8 @@
 
   (define can-split?
     (append (list #f)
-            (for/list ([val (cdr splitvals*)] [prev splitvals*])
+            (for/list ([val (cdr splitvals*)]
+                       [prev splitvals*])
               (</total prev val repr))))
   (define split-indices (err-lsts->split-indices bit-err-lsts* can-split?))
   (define out (option split-indices alts pts* expr (pick-errors split-indices pts* err-lsts* repr)))
@@ -151,8 +158,11 @@
                            [errss (listof (listof real?))]
                            [r representation?])
        [idxs (listof nonnegative-integer?)])
-  (for/list ([i (in-naturals)] [pt pts] [errs (flip-lists err-lsts)])
-    (for/first ([si split-indices] #:when (< i (si-pidx si)))
+  (for/list ([i (in-naturals)]
+             [pt pts]
+             [errs (flip-lists err-lsts)])
+    (for/first ([si split-indices]
+                #:when (< i (si-pidx si)))
       (list-ref errs (si-cidx si)))))
 
 (module+ test
@@ -219,7 +229,8 @@
   (define result-alt-idxs (make-vector number-of-points 0))
   (define result-prev-idxs (make-vector number-of-points number-of-points))
 
-  (for ([alt-idx (in-naturals)] [alt-errors (in-vector flvec-psums)])
+  (for ([alt-idx (in-naturals)]
+        [alt-errors (in-vector flvec-psums)])
     (for ([point-idx (in-range number-of-points)]
           [err (in-flvector alt-errors)]
           #:when (< err (flvector-ref result-error-sums point-idx)))
@@ -244,7 +255,8 @@
     (set! best-alt-costs (make-flvector number-of-points +inf.0))
 
     ;; For each alt loop over its vector of errors
-    (for ([alt-idx (in-naturals)] [alt-error-sums (in-vector flvec-psums)])
+    (for ([alt-idx (in-naturals)]
+          [alt-error-sums (in-vector flvec-psums)])
       ;; Loop over the points up to our current point
       (for ([prev-split-idx (in-range 0 point-idx)]
             [prev-alt-error-sum (in-flvector alt-error-sums)]
@@ -296,7 +308,8 @@
   ;; Loop over results vectors in reverse and build the output split index list
   (define next number-of-points)
   (define split-idexs #f)
-  (for ([i (in-range (- number-of-points 1) -1 -1)] #:when (= (+ i 1) next))
+  (for ([i (in-range (- number-of-points 1) -1 -1)]
+        #:when (= (+ i 1) next))
     (define alt-idx (vector-ref result-alt-idxs i))
     (define split-idx (vector-ref result-prev-idxs i))
     (set! next (+ split-idx 1))

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -69,17 +69,20 @@
   (define start (current-inexact-milliseconds))
   (define pt*
     (for/vector #:length (length vars)
-                ([val (in-list pt)] [repr (in-list var-reprs)])
+                ([val (in-list pt)]
+                 [repr (in-list var-reprs)])
       ((representation-repr->bf repr) val)))
   (define-values (status value)
     (with-handlers ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
                     [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])
-      (parameterize ([*rival-max-precision* (*max-mpfr-prec*)] [*rival-max-iterations* 5])
+      (parameterize ([*rival-max-precision* (*max-mpfr-prec*)]
+                     [*rival-max-iterations* 5])
         (values 'valid (rest (vector->list (rival-apply machine pt*))))))) ; rest = drop precondition
   (when (> (rival-profile machine 'bumps) 0)
     (warn 'ground-truth
           "Could not converge on a ground truth"
-          #:extra (for/list ([var (in-list vars)] [val (in-list pt)])
+          #:extra (for/list ([var (in-list vars)]
+                             [val (in-list pt)])
                     (format "~a = ~a" var val))))
   (define executions (rival-profile machine 'executions))
   (when (>= (vector-length executions) (*rival-profile-executions*))

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -112,7 +112,8 @@
 ;;
 
 (define ((type/repr-of-rule op-info name) input output ctx)
-  (let loop ([input input] [output output])
+  (let loop ([input input]
+             [output output])
     (match* (input output)
       ; first, try the input expression
       ; special case for `if` expressions

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -24,7 +24,8 @@
   ;; FPBench needs unparameterized operators
   (define range-table (condition->range-table pre))
   (apply cartesian-product
-         (for/list ([var-name vars] [var-repr var-reprs])
+         (for/list ([var-name vars]
+                    [var-repr var-reprs])
            (map (lambda (interval) (fpbench-ival->ival var-repr interval))
                 (range-table-ref range-table var-name)))))
 
@@ -52,7 +53,8 @@
 ;; we want a index i such that vector[i] > num and vector[i-1] <= num
 ;; assumes vector strictly increasing
 (define (binary-search vector num)
-  (let loop ([left 0] [right (- (vector-length vector) 1)])
+  (let loop ([left 0]
+             [right (- (vector-length vector) 1)])
     (cond
       [(>= left right) (min left (- (vector-length vector) 1))]
       [else
@@ -80,12 +82,14 @@
   (define lo-ends
     (for/vector #:length (vector-length hyperrects)
                 ([hyperrect (in-vector hyperrects)])
-      (for/list ([interval (in-list hyperrect)] [repr (in-list reprs)])
+      (for/list ([interval (in-list hyperrect)]
+                 [repr (in-list reprs)])
         ((representation-repr->ordinal repr) ((representation-bf->repr repr) (ival-lo interval))))))
   (define hi-ends
     (for/vector #:length (vector-length hyperrects)
                 ([hyperrect (in-vector hyperrects)])
-      (for/list ([interval (in-list hyperrect)] [repr (in-list reprs)])
+      (for/list ([interval (in-list hyperrect)]
+                 [repr (in-list reprs)])
         (+ 1
            ((representation-repr->ordinal repr)
             ((representation-bf->repr repr) (ival-hi interval)))))))
@@ -96,7 +100,9 @@
     (define idx (binary-search weights rand-ordinal))
     (define los (vector-ref lo-ends idx))
     (define his (vector-ref hi-ends idx))
-    (for/list ([lo (in-list los)] [hi (in-list his)] [repr (in-list reprs)])
+    (for/list ([lo (in-list los)]
+               [hi (in-list his)]
+               [repr (in-list reprs)])
       ((representation-ordinal->repr repr) (random-integer lo hi)))))
 
 #;(module+ test
@@ -143,7 +149,10 @@
 
   (real-compiler-clear! compiler) ; Clear profiling vector
   (define-values (points exactss)
-    (let loop ([sampled 0] [skipped 0] [points '()] [exactss '()])
+    (let loop ([sampled 0]
+               [skipped 0]
+               [points '()]
+               [exactss '()])
       (define pt (sampler))
 
       (define-values (status exs) (real-apply compiler pt))
@@ -152,10 +161,12 @@
          (warn 'ground-truth
                #:url "faq.html#ground-truth"
                "could not determine a ground truth"
-               #:extra (for/list ([var vars] [val pt])
+               #:extra (for/list ([var vars]
+                                  [val pt])
                          (format "~a = ~a" var val)))]
         [(valid)
-         (for ([ex (in-list exs)] [repr (in-list reprs)])
+         (for ([ex (in-list exs)]
+               [repr (in-list reprs)])
            ; The `bool` representation does not produce bigfloats
            (define maybe-bf ((representation-repr->bf repr) ex))
            (when (and (bigfloat? maybe-bf) (bfinfinite? maybe-bf))
@@ -164,7 +175,8 @@
       (hash-update! outcomes status (curry + 1) 0)
 
       (define is-bad?
-        (for/or ([input (in-list pt)] [repr (in-list var-reprs)])
+        (for/or ([input (in-list pt)]
+                 [repr (in-list var-reprs)])
           ((representation-special-value? repr) input)))
 
       (cond

--- a/src/core/searchreals.rkt
+++ b/src/core/searchreals.rkt
@@ -27,7 +27,8 @@
 
 (define (hyperrect-weight hyperrect reprs)
   (apply *
-         (for/list ([interval (in-list hyperrect)] [repr (in-list reprs)])
+         (for/list ([interval (in-list hyperrect)]
+                    [repr (in-list reprs)])
            (define ->ordinal
              (compose (representation-repr->ordinal repr) (representation-bf->repr repr)))
            (+ 1 (- (->ordinal (ival-hi interval)) (->ordinal (ival-lo interval)))))))
@@ -49,13 +50,18 @@
   (define reprs (real-compiler-var-reprs compiler))
   (match-define (search-space true false other) space)
   (define-values (true* false* other*)
-    (for/fold ([true* true] [false* false] [other* '()]) ([rect (in-list other)])
+    (for/fold ([true* true]
+               [false* false]
+               [other* '()])
+              ([rect (in-list other)])
       (match-define (ival err err?) (real-compiler-analyze compiler (list->vector rect)))
       (when (eq? err 'unsamplable)
         (warn 'ground-truth
               #:url "faq.html#ground-truth"
               "could not determine a ground truth"
-              #:extra (for/list ([var vars] [repr reprs] [ival rect])
+              #:extra (for/list ([var vars]
+                                 [repr reprs]
+                                 [ival rect])
                         (define val
                           (value->string ((representation-bf->repr repr)
                                           (bigfloat-pick-point (ival-lo ival) (ival-hi ival)))
@@ -92,7 +98,8 @@
   (define var-reprs (real-compiler-var-reprs compiler))
   (if (or (null? rects) (null? (first rects)))
       (map (curryr cons 'other) rects)
-      (let loop ([space (apply make-search-space rects)] [n 0])
+      (let loop ([space (apply make-search-space rects)]
+                 [n 0])
         (match-define (search-space true false other) space)
         (timeline-push! 'sampling n (make-sampling-table var-reprs true false other))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -25,7 +25,8 @@
 
   (define simplifieds (run-egg runner (cons 'single extractor)))
   (define out
-    (for/list ([simplified simplifieds] [expr (egg-runner-exprs runner)])
+    (for/list ([simplified simplifieds]
+               [expr (egg-runner-exprs runner)])
       (remove-duplicates (cons expr simplified))))
 
   (timeline-push! 'outputs (map ~a (apply append out)))
@@ -76,7 +77,8 @@
 
   (*timeline-disabled* true)
   (define outputs (apply test-simplify (dict-keys test-exprs)))
-  (for ([(original target) (in-dict test-exprs)] [output outputs])
+  (for ([(original target) (in-dict test-exprs)]
+        [output outputs])
     (with-check-info (['original original]) (check-equal? output target)))
 
   (check set-member? '((* x 6) (* 6 x)) (first (test-simplify '(+ (+ (+ (+ (+ x x) x) x) x) x))))

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -22,7 +22,8 @@
   (define errss (batch-errors proof-progs pcontext ctx))
 
   (define prog->errs
-    (for/hash ([prog (in-list proof-progs)] [errs (in-list errss)])
+    (for/hash ([prog (in-list proof-progs)]
+               [errs (in-list errss)])
       (values prog errs)))
 
   (define proof-errors
@@ -31,7 +32,8 @@
 
   (define proof-diffs
     (cons (list 0 0)
-          (for/list ([prev proof-errors] [current (rest proof-errors)])
+          (for/list ([prev proof-errors]
+                     [current (rest proof-errors)])
             (and prev
                  current
                  (list (count > current prev) ; num points where error increased

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -266,27 +266,29 @@
     (hash-set! hash 0 (simplify `(sqrt ,(coeffs* 0))))
     (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 2 (sqrt ,(coeffs* 0))))))
     (letrec ([f (λ (n)
-                  (hash-ref!
-                   hash
-                   n
-                   (λ ()
-                     (simplify (cond
-                                 [(even? n)
-                                  `(/ (- ,(coeffs* n)
-                                         (pow ,(f (/ n 2)) 2)
-                                         (+ ,@(for/list ([k (in-naturals 1)] #:break (>= k (- n k)))
-                                                `(* 2 (* ,(f k) ,(f (- n k)))))))
-                                      (* 2 ,(f 0)))]
-                                 [(odd? n)
-                                  `(/ (- ,(coeffs* n)
-                                         (+ ,@(for/list ([k (in-naturals 1)] #:break (>= k (- n k)))
-                                                `(* 2 (* ,(f k) ,(f (- n k)))))))
-                                      (* 2 ,(f 0)))])))))])
+                  (hash-ref! hash
+                             n
+                             (λ ()
+                               (simplify (cond
+                                           [(even? n)
+                                            `(/ (- ,(coeffs* n)
+                                                   (pow ,(f (/ n 2)) 2)
+                                                   (+ ,@(for/list ([k (in-naturals 1)]
+                                                                   #:break (>= k (- n k)))
+                                                          `(* 2 (* ,(f k) ,(f (- n k)))))))
+                                                (* 2 ,(f 0)))]
+                                           [(odd? n)
+                                            `(/ (- ,(coeffs* n)
+                                                   (+ ,@(for/list ([k (in-naturals 1)]
+                                                                   #:break (>= k (- n k)))
+                                                          `(* 2 (* ,(f k) ,(f (- n k)))))))
+                                                (* 2 ,(f 0)))])))))])
       (cons (/ offset* 2) f))))
 
 (define (taylor-cbrt var num)
   (match-define (cons offset* coeffs*) (modulo-series var 3 num))
-  (let* ([f0 (simplify `(cbrt ,(coeffs* 0)))] [hash (make-hash)])
+  (let* ([f0 (simplify `(cbrt ,(coeffs* 0)))]
+         [hash (make-hash)])
     (hash-set! hash 0 f0)
     (hash-set! hash 1 (simplify `(/ ,(coeffs* 1) (* 3 (cbrt (* ,f0 ,f0))))))
     (letrec ([f (λ (n)
@@ -348,53 +350,57 @@
 (define (taylor-sin coeffs)
   (let ([hash (make-hash)])
     (hash-set! hash 0 0)
-    (cons
-     0
-     (λ (n)
-       (hash-ref!
-        hash
-        n
-        (λ ()
-          (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
-          (define nums
-            (for/list ([i (in-range 1 (+ n 1))] [coeff (in-vector coeffs*)] #:unless (equal? coeff 0))
-              i))
-          (simplify `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
-                            (if (= (modulo (apply + (map car p)) 2) 1)
-                                `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
-                                    ,@(for/list ([(count num) (in-dict p)])
-                                        `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                            ,(factorial count))))
-                                0))))))))))
+    (cons 0
+          (λ (n)
+            (hash-ref! hash
+                       n
+                       (λ ()
+                         (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
+                         (define nums
+                           (for/list ([i (in-range 1 (+ n 1))]
+                                      [coeff (in-vector coeffs*)]
+                                      #:unless (equal? coeff 0))
+                             i))
+                         (simplify `(+ ,@
+                                       (for/list ([p (all-partitions n (sort nums >))])
+                                         (if (= (modulo (apply + (map car p)) 2) 1)
+                                             `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
+                                                 ,@(for/list ([(count num) (in-dict p)])
+                                                     `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                                         ,(factorial count))))
+                                             0))))))))))
 
 (define (taylor-cos coeffs)
   (let ([hash (make-hash)])
     (hash-set! hash 0 1)
-    (cons
-     0
-     (λ (n)
-       (hash-ref!
-        hash
-        n
-        (λ ()
-          (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
-          (define nums
-            (for/list ([i (in-range 1 (+ n 1))] [coeff (in-vector coeffs*)] #:unless (equal? coeff 0))
-              i))
-          (simplify `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
-                            (if (= (modulo (apply + (map car p)) 2) 0)
-                                `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
-                                    ,@(for/list ([(count num) (in-dict p)])
-                                        `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                            ,(factorial count))))
-                                0))))))))))
+    (cons 0
+          (λ (n)
+            (hash-ref! hash
+                       n
+                       (λ ()
+                         (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
+                         (define nums
+                           (for/list ([i (in-range 1 (+ n 1))]
+                                      [coeff (in-vector coeffs*)]
+                                      #:unless (equal? coeff 0))
+                             i))
+                         (simplify `(+ ,@
+                                       (for/list ([p (all-partitions n (sort nums >))])
+                                         (if (= (modulo (apply + (map car p)) 2) 0)
+                                             `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
+                                                 ,@(for/list ([(count num) (in-dict p)])
+                                                     `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                                         ,(factorial count))))
+                                             0))))))))))
 
 ;; This is a hyper-specialized symbolic differentiator for log(f(x))
 
 (define initial-logtable '((1 -1 1)))
 
 (define (list-setinc l i)
-  (let loop ([i i] [l l] [rest '()])
+  (let loop ([i i]
+             [l l]
+             [rest '()])
     (if (= i 0)
         (if (null? (cdr l))
             (append (reverse rest) (list (- (car l) 1) 1))
@@ -407,7 +413,8 @@
            (match term
              [`(,coeff ,ps ...)
               (filter identity
-                      (for/list ([i (in-naturals)] [p ps])
+                      (for/list ([i (in-naturals)]
+                                 [p ps])
                         (if (zero? p) #f `(,(* coeff p) ,@(list-setinc ps i)))))]))))
 
 (define (lognormalize table)
@@ -439,7 +446,8 @@
                             (match term
                               [`(,coeff ,k ,ps ...)
                                `(* ,coeff
-                                   (/ (* ,@(for/list ([i (in-naturals 1)] [p ps])
+                                   (/ (* ,@(for/list ([i (in-naturals 1)]
+                                                      [p ps])
                                              (if (= p 0) 1 `(pow (* ,(factorial i) ,(coeffs i)) ,p))))
                                       (pow ,(coeffs 0) ,(- k))))])))
                        ,(factorial n)))))))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -47,11 +47,13 @@
   (define ctx (env->ctx env out))
 
   (match-define (list pts exs)
-    (parameterize ([*num-points* (num-test-points)] [*max-find-range-depth* 0])
+    (parameterize ([*num-points* (num-test-points)]
+                   [*max-find-range-depth* 0])
       (cdr (sample-points '(TRUE) (list p1) (list ctx)))))
 
   (define compiler (make-real-compiler (list p2) (list ctx)))
-  (for ([pt (in-list pts)] [v1 (in-list exs)])
+  (for ([pt (in-list pts)]
+        [v1 (in-list exs)])
     (with-check-info* (map make-check-info (context-vars ctx) pt)
                       (λ ()
                         (define-values (status v2) (real-apply compiler pt))
@@ -67,10 +69,13 @@
 
   (define pre (dict-ref *conditions* name '(TRUE)))
   (match-define (list pts exs1 exs2)
-    (parameterize ([*num-points* (num-test-points)] [*max-find-range-depth* 0])
+    (parameterize ([*num-points* (num-test-points)]
+                   [*max-find-range-depth* 0])
       (cdr (sample-points pre (list p1 p2) (list ctx ctx)))))
 
-  (for ([pt (in-list pts)] [v1 (in-list exs1)] [v2 (in-list exs2)])
+  (for ([pt (in-list pts)]
+        [v1 (in-list exs1)]
+        [v2 (in-list exs2)])
     (with-check-info* (map make-check-info (context-vars ctx) pt)
                       (λ ()
                         (with-check-info (['lhs v1] ['rhs v2])
@@ -107,7 +112,8 @@
 (module+ test
   (define _ (*simplify-rules*)) ; force an update
 
-  (for* ([(_ test-ruleset) (in-dict (*rulesets*))] [test-rule (first test-ruleset)])
+  (for* ([(_ test-ruleset) (in-dict (*rulesets*))]
+         [test-rule (first test-ruleset)])
     (test-case (~a (rule-name test-rule))
       (check-rule-correct test-rule)))
 

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -232,7 +232,8 @@
                              #:before-last ", and "))])]))
 
 (define (format-less-than-condition variables)
-  (string-join (for/list ([a (in-list variables)] [b (in-list (cdr variables))])
+  (string-join (for/list ([a (in-list variables)]
+                          [b (in-list (cdr variables))])
                  (format "~a < ~a" a b))
                " && "))
 

--- a/src/reports/core2mathjs.rkt
+++ b/src/reports/core2mathjs.rkt
@@ -50,7 +50,8 @@
     [(list (or '+ '- '* '/) a b) (format "(~a ~a ~a)" a op b)]
     [(list (or '== '< '> '<= '>=) arg args ...)
      (format "(~a)"
-             (string-join (for/list ([a (cons arg args)] [b args])
+             (string-join (for/list ([a (cons arg args)]
+                                     [b args])
                             (format "~a ~a ~a" a op b))
                           " && "))]
     [(list '!= args ...)
@@ -76,7 +77,9 @@
 
 (define (visit-let_/mathjs vtor let_ vars vals body #:ctx ctx)
   (define ctx*
-    (for/fold ([ctx* ctx]) ([var (in-list vars)] [val (in-list vals)])
+    (for/fold ([ctx* ctx])
+              ([var (in-list vars)]
+               [val (in-list vals)])
       (define val*
         (visit/ctx vtor
                    val
@@ -125,8 +128,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;; public ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (expr->mathjs prog [name ""])
-  (parameterize
-      ([*gensym-used-names* (mutable-set)] [*gensym-collisions* 1] [*gensym-fix-name* fix-name])
+  (parameterize ([*gensym-used-names* (mutable-set)]
+                 [*gensym-collisions* 1]
+                 [*gensym-fix-name* fix-name])
     ; make compiler context
     (define ctx
       (ctx-update-props (make-compiler-ctx) (append '(:precision binary64 :round nearestEven))))
@@ -141,8 +145,9 @@
     (format "~a~a" body* ret)))
 
 (define (core->mathjs prog [name ""])
-  (parameterize
-      ([*gensym-used-names* (mutable-set)] [*gensym-collisions* 1] [*gensym-fix-name* fix-name])
+  (parameterize ([*gensym-used-names* (mutable-set)]
+                 [*gensym-collisions* 1]
+                 [*gensym-fix-name* fix-name])
     ; decompose FPCore
     (define-values (args props body)
       (match prog

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -43,7 +43,8 @@
 
 (define (splice-proof-step step)
   (let/ec k
-          (let loop ([expr step] [loc '()])
+          (let loop ([expr step]
+                     [loc '()])
             (match expr
               [(list 'Rewrite=> rule sub)
                (define loc* (reverse loc))
@@ -52,7 +53,8 @@
                (define loc* (reverse loc))
                (k 'Rewrite<= rule loc* (location-do loc* step (λ _ sub)))]
               [(list op args ...)
-               (for ([arg (in-list args)] [i (in-naturals 1)])
+               (for ([arg (in-list args)]
+                     [i (in-naturals 1)])
                  (loop arg (cons i loc)))]
               [_ (void)]))
           (k 'Goal #f '() step)))
@@ -104,7 +106,8 @@
 
     [(alt _ `(regimes ,splitpoints) prevs _)
      (define intervals
-       (for/list ([start-sp (cons (sp -1 -1 #f) splitpoints)] [end-sp splitpoints])
+       (for/list ([start-sp (cons (sp -1 -1 #f) splitpoints)]
+                  [end-sp splitpoints])
          (interval (sp-cidx end-sp) (sp-point start-sp) (sp-point end-sp) (sp-bexpr end-sp))))
      (define repr (context-repr ctx))
 
@@ -160,7 +163,8 @@
 (define (render-proof proof soundiness pcontext ctx)
   `(div ((class "proof"))
         (details (summary "Step-by-step derivation")
-                 (ol ,@(for/list ([step proof] [sound soundiness])
+                 (ol ,@(for/list ([step proof]
+                                  [sound soundiness])
                          (define-values (dir rule loc expr) (splice-proof-step step))
                          ;; need to handle mixed real/float expressions
                          (define-values (err prog)
@@ -205,12 +209,14 @@
 
     [(alt prog `(regimes ,splitpoints) prevs _)
      (define intervals
-       (for/list ([start-sp (cons (sp -1 -1 #f) splitpoints)] [end-sp splitpoints])
+       (for/list ([start-sp (cons (sp -1 -1 #f) splitpoints)]
+                  [end-sp splitpoints])
          (interval (sp-cidx end-sp) (sp-point start-sp) (sp-point end-sp) (sp-bexpr end-sp))))
 
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "regimes")
-            (conditions . ,(for/list ([entry prevs] [idx (in-naturals)])
+            (conditions . ,(for/list ([entry prevs]
+                                      [idx (in-naturals)])
                              (let ([entry-ivals (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx))
                                                         intervals)])
                                (map (curryr interval->string repr) entry-ivals))))
@@ -270,7 +276,8 @@
             (preprocessing . ,(map (curry map symbol->string) preprocessing)))]))
 
 (define (render-proof-json proof soundiness pcontext ctx)
-  (for/list ([step proof] [sound soundiness])
+  (for/list ([step proof]
+             [sound soundiness])
     (define-values (dir rule loc expr) (splice-proof-step step))
     (define err (if (impl-prog? expr) (errors-score (errors expr pcontext ctx)) "N/A"))
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -166,7 +166,10 @@
                        ,dropdown
                        ,(render-help "report.html#alternatives"))
                    ,body))
-      ,@(for/list ([i (in-naturals 1)] [alt end-alts] [errs end-errors] [cost end-costs])
+      ,@(for/list ([i (in-naturals 1)]
+                   [alt end-alts]
+                   [errs end-errors]
+                   [cost end-costs])
           (define-values (dropdown body)
             (render-program (alt-expr alt) ctx #:ident identifier #:instructions preprocessing))
           `(section ([id ,(format "alternative~a" i)] (class "programs"))

--- a/src/reports/plot.rkt
+++ b/src/reports/plot.rkt
@@ -58,14 +58,17 @@
   (define end-error (map ulps->bits-tenths (car end-errors)))
 
   (define target-error-entries
-    (for/list ([i (in-naturals)] [error-value (in-list target-error)])
+    (for/list ([i (in-naturals)]
+               [error-value (in-list target-error)])
       (cons (format "target~a" (+ i 1)) error-value)))
 
   (define error-entries
     (list* (cons "start" start-error) (cons "end" end-error) target-error-entries))
 
   (define ticks
-    (for/list ([var (in-list vars)] [idx (in-naturals)] #:unless (all-same? newpoints idx))
+    (for/list ([var (in-list vars)]
+               [idx (in-naturals)]
+               #:unless (all-same? newpoints idx))
       ; We want to bail out since choose-ticks will crash otherwise
       (define points-at-idx (map (curryr list-ref idx) points))
       (define real-ticks (choose-ticks (apply min points-at-idx) (apply max points-at-idx) repr))
@@ -141,7 +144,9 @@
         [(< (- (cadr necessary) (car necessary)) sub-range) (loop (cdr necessary))]
         [else (cons (car necessary) (loop (cdr necessary)))])))
   (define all
-    (let loop ([necessary necessary*] [min* min] [start 0])
+    (let loop ([necessary necessary*]
+               [min* min]
+               [start 0])
       (cond
         [(>= start number) '()]
         [(empty? necessary) (choose-between min* max (- number start) repr)]

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -115,19 +115,13 @@
                                                                   total))])))))))
 
 (define (render-phase-locations locations)
-  `((dt "Localize:")
-    (dd (p "Found " ,(~a (length locations)) " expressions of interest:")
-        (table ((class "times"))
-               (thead (tr (th "New") (th "Metric") (th "Score") (th "Program")))
-               ,@(for/list ([rec (in-list locations)])
-                   (match-define (list expr metric score new? repr-name) rec)
-                   (define repr (get-representation (read (open-input-string repr-name))))
-                   `(tr (td ,(if new? "✓" ""))
-                        (td ,(~a metric))
-                        (td ,(if (equal? metric "accuracy")
-                                 (format-accuracy score (representation-total-bits repr) #:unit "%")
-                                 (~a score)))
-                        (td (pre ,(~a expr)))))))))
+  `((dt "Localize:") (dd (p "Found " ,(~a (length locations)) " expressions of interest:")
+                         (table ((class "times"))
+                                (thead (tr (th "New") (th "Metric") (th "Score") (th "Program")))
+                                ,@
+                                (for/list ([rec (in-list locations)])
+                                  (match-define (list expr metric score) rec)
+                                  `(tr (td ,(~a metric)) (td ,(~a score)) (td (pre ,(~a expr)))))))))
 
 (define (format-value v)
   (cond

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -37,12 +37,14 @@
     ([id "process-info"])
     (p ((class "header")) "Time bar (total: " (span ((class "number")) ,(format-time time)) ")")
     (div ((class "timeline"))
-         ,@(for/list ([n (in-naturals)] [curr timeline])
+         ,@(for/list ([n (in-naturals)]
+                      [curr timeline])
              `(div ((class ,(format "timeline-phase timeline-~a" (dict-ref curr 'type)))
                     [data-id ,(format "timeline~a" n)]
                     [data-type ,(~a (dict-ref curr 'type))]
                     [data-timespan ,(~a (dict-ref curr 'time))]))))
-    ,@(for/list ([phase timeline] [n (in-naturals)])
+    ,@(for/list ([phase timeline]
+                 [n (in-naturals)])
         (render-phase phase n time))))
 
 (define/contract (render-phase curr n total-time)
@@ -158,7 +160,8 @@
 (define (render-phase-stop data)
   (match-define (list (list reasons counts) ...) (sort data > #:key second))
   `((dt "Stop Event") (dd (table ((class "times"))
-                                 ,@(for/list ([reason reasons] [count counts])
+                                 ,@(for/list ([reason reasons]
+                                              [count counts])
                                      `(tr (td ,(~r count #:group-sep " ") "×") (td ,(~a reason))))))))
 
 (define (format-percent num den)
@@ -239,7 +242,11 @@
 
 (define (render-phase-accuracy accuracy oracle baseline name link repr-name)
   (define rows
-    (sort (for/list ([acc accuracy] [ora oracle] [bas baseline] [name name] [link link])
+    (sort (for/list ([acc accuracy]
+                     [ora oracle]
+                     [bas baseline]
+                     [name name]
+                     [link link])
             (list (- acc ora) (- bas acc) link name))
           >
           #:key first))
@@ -262,7 +269,8 @@
                               ")")
                            ,@(if (> (length rows) 1)
                                  `((table ((class "times"))
-                                          ,@(for/list ([rec (in-list rows)] [_ (in-range 5)])
+                                          ,@(for/list ([rec (in-list rows)]
+                                                       [_ (in-range 5)])
                                               (match-define (list left gained link name) rec)
                                               `(tr (td ,(format-bits left #:unit #t))
                                                    (td ,(format-percent gained (+ left gained)))
@@ -315,7 +323,8 @@
 
 (define (render-phase-rules rules)
   `((dt "Rules") (dd (table ((class "times"))
-                            ,@(for/list ([rec (in-list (sort rules > #:key second))] [_ (in-range 5)])
+                            ,@(for/list ([rec (in-list (sort rules > #:key second))]
+                                         [_ (in-range 5)])
                                 (match-define (list rule count) rec)
                                 `(tr (td ,(~r count #:group-sep " ") "×")
                                      (td (code ,(~a rule) " "))))))))
@@ -443,7 +452,8 @@
                   "Weighted histogram; height corresponds to percentage of runtime in that bucket."]))
         (script "histogram(\"" ,(format "calls-~a" n) "\", " ,(jsexpr->string (map first times)) ")")
         (table ((class "times"))
-               ,@(for/list ([rec (in-list (sort times > #:key first))] [_ (in-range 5)])
+               ,@(for/list ([rec (in-list (sort times > #:key first))]
+                            [_ (in-range 5)])
                    (match-define (list time expr) rec)
                    `(tr (td ,(format-time time)) (td (pre ,(~a expr)))))))))
 
@@ -459,7 +469,8 @@
       ((class "times"))
       (thead (tr (th "Time") (th "Variable") (th) (th "Point") (th "Expression")))
       ,@
-      (for/list ([rec (in-list (sort times > #:key first))] [_ (in-range 5)])
+      (for/list ([rec (in-list (sort times > #:key first))]
+                 [_ (in-range 5)])
         (match-define (list time expr var transform) rec)
         `(tr (td ,(format-time time)) (td (pre ,var)) (td "@") (td ,transform) (td (pre ,expr))))))))
 
@@ -497,7 +508,9 @@
                                        (td ,(~a category))))))))
 
 (define (render-phase-inputs inputs outputs)
-  `((dt "Calls") (dd ,@(for/list ([call inputs] [output outputs] [n (in-naturals 1)])
+  `((dt "Calls") (dd ,@(for/list ([call inputs]
+                                  [output outputs]
+                                  [n (in-naturals 1)])
                          `(details (summary "Call " ,(~a n))
                                    (table (thead (tr (th "Inputs")))
                                           ,@(for/list ([arg call])
@@ -537,7 +550,8 @@
           (tr (th "Flags:")
               (td ((id "flag-list"))
                   (div ((id "all-flags"))
-                       ,@(for*/list ([(class flags) (*flags*)] [flag flags])
+                       ,@(for*/list ([(class flags) (*flags*)]
+                                     [flag flags])
                            `(kbd ,(~a class) ":" ,(~a flag))))
                   (div ((id "changed-flags"))
                        ,@(if (null? (changed-flags))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -184,8 +184,14 @@
     (raise-syntax-error 'platform why stx sub-stx))
   (syntax-case stx ()
     [(_ id cs ...)
-     (let ([if-cost #f] [default-cost #f] [optional? #f])
-       (let loop ([cs #'(cs ...)] [impls '()] [costs '()] [reprs '()] [repr-costs '()])
+     (let ([if-cost #f]
+           [default-cost #f]
+           [optional? #f])
+       (let loop ([cs #'(cs ...)]
+                  [impls '()]
+                  [costs '()]
+                  [reprs '()]
+                  [repr-costs '()])
          (syntax-case cs ()
            [()
             (let ([platform-id #'id])
@@ -317,10 +323,13 @@
     (raise-syntax-error 'platform why stx sub-stx))
   (syntax-case stx ()
     [(_ cs ... pform)
-     (let loop ([clauses (syntax->list #'(cs ...))] [repr-filter #f] [op-filter #f])
+     (let loop ([clauses (syntax->list #'(cs ...))]
+                [repr-filter #f]
+                [op-filter #f])
        (syntax-case clauses ()
          [()
-          (with-syntax ([repr-filter repr-filter] [op-filter op-filter])
+          (with-syntax ([repr-filter repr-filter]
+                        [op-filter op-filter])
             #'((make-platform-filter (or repr-filter (const #t)) (or op-filter (const #t))) pform))]
          [(#:representations [reprs ...] rest ...)
           (begin
@@ -398,7 +407,8 @@
   (define bool-repr (get-representation 'bool))
   (define node-cost-proc (platform-node-cost-proc pform))
   (λ (expr repr)
-    (let loop ([expr expr] [repr repr])
+    (let loop ([expr expr]
+               [repr repr])
       (match expr
         [(? literal?) ((node-cost-proc expr repr))]
         [(? symbol?) ((node-cost-proc expr repr))]
@@ -466,7 +476,8 @@
 ;; All possible assignments of implementations.
 (define (impl-combinations ops impls)
   (reap [sow]
-        (let loop ([ops ops] [assigns '()])
+        (let loop ([ops ops]
+                   [assigns '()])
           (match ops
             [(? null?) (sow assigns)]
             [(list 'if rest ...) (loop rest assigns)]
@@ -483,7 +494,8 @@
   (let/ec k
           (define env '())
           (define expr*
-            (let loop ([expr expr] [repr repr])
+            (let loop ([expr expr]
+                       [repr repr])
               (match expr
                 [(? symbol? x) ; variable
                  (match (dict-ref env x #f)

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -48,14 +48,16 @@
     [#`(let* ([#,vars #,vals] ...) #,body)
      (datum->syntax #f
                     (list 'let*
-                          (for/list ([var (in-list vars)] [val (in-list vals)])
+                          (for/list ([var (in-list vars)]
+                                     [val (in-list vals)])
                             (list var (expand val)))
                           (expand body))
                     stx)]
     [#`(let ([#,vars #,vals] ...) #,body)
      (datum->syntax #f
                     (list 'let
-                          (for/list ([var (in-list vars)] [val (in-list vals)])
+                          (for/list ([var (in-list vars)]
+                                     [val (in-list vals)])
                             (list var (expand val)))
                           (expand body))
                     stx)]
@@ -84,7 +86,8 @@
      (unless (null? rest)
        (warn 'variary-operator "~a is deprecated as a variary operator" op))
      (define prev (datum->syntax #f (list op (expand arg1) (expand arg2)) stx))
-     (let loop ([prev prev] [rest rest])
+     (let loop ([prev prev]
+                [rest rest])
        (match rest
          [(list) prev]
          [(list next rest ...)
@@ -93,7 +96,9 @@
     [#`(,(and (or '< '<= '> '>= '=) op) #,args ...)
      (define args* (map expand args))
      (define out
-       (for/fold ([out #f]) ([term args*] [next (cdr args*)])
+       (for/fold ([out #f])
+                 ([term args*]
+                  [next (cdr args*)])
          (datum->syntax #f (if out (list 'and out (list op term next)) (list op term next)) term)))
      (or out (datum->syntax #f 'TRUE stx))]
     [#`(!= #,args ...)
@@ -155,7 +160,8 @@
   (define default-prec (dict-ref prop-dict ':precision (*default-precision*)))
   (define default-repr (get-representation default-prec))
   (define var-reprs
-    (for/list ([arg args] [arg-name arg-names])
+    (for/list ([arg args]
+               [arg-name arg-names])
       (if (and (list? arg) (set-member? args ':precision))
           (get-representation (cadr (member ':precision args)))
           default-repr)))
@@ -173,7 +179,8 @@
   (define pre* (fpcore->prog (dict-ref prop-dict ':pre 'TRUE) ctx))
 
   (define targets
-    (for/list ([(key val) (in-dict prop-dict)] #:when (eq? key ':alt))
+    (for/list ([(key val) (in-dict prop-dict)]
+               #:when (eq? key ':alt))
       (match (parse-platform-name val) ; plat-name is symbol or #f
         ; If plat-name extracted, check if name matches
         [(? symbol? plat-name) (cons val (equal? plat-name (*platform-name*)))]
@@ -198,7 +205,8 @@
         pre*
         (dict-ref prop-dict ':herbie-preprocess empty)
         (representation-name default-repr)
-        (for/list ([var arg-names] [repr var-reprs])
+        (for/list ([var arg-names]
+                   [repr var-reprs])
           (cons var (representation-name repr)))))
 
 (define (check-unused-variables vars precondition expr)
@@ -217,7 +225,8 @@
           (string-join (map ~a unused) ", "))))
 
 (define (check-weird-variables vars)
-  (for* ([var vars] [const (all-constants)])
+  (for* ([var vars]
+         [const (all-constants)])
     (when (string-ci=? (symbol->string var) (symbol->string const))
       (warn 'strange-variable
             #:url "faq.html#strange-variable"

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -8,7 +8,8 @@
 (provide assert-program!)
 
 (define (check-expression* stx vars error! deprecated-ops)
-  (let loop ([stx stx] [vars vars])
+  (let loop ([stx stx]
+             [vars vars])
     (match stx
       [#`,(? number?) (void)]
       [#`,(? constant-operator?) (void)]
@@ -17,7 +18,9 @@
          (error! stx "Unknown variable ~a" var))]
       [#`(let* ([#,vars* #,vals] ...) #,body)
        (define bindings
-         (for/fold ([vars vars]) ([var vars*] [val vals])
+         (for/fold ([vars vars])
+                   ([var vars*]
+                    [val vals])
            (unless (identifier? var)
              (error! var "Invalid variable name ~a" var))
            (loop val vars)
@@ -25,7 +28,8 @@
        (loop body bindings)]
       [#`(let ([#,vars* #,vals] ...) #,body)
        ;; These are unfolded by desugaring
-       (for ([var vars*] [val vals])
+       (for ([var vars*]
+             [val vals])
          (unless (identifier? var)
            (error! var "Invalid variable name ~a" var))
          (loop val vars))
@@ -90,7 +94,8 @@
 
 (define (check-properties* props vars error! deprecated-ops)
   (define prop-dict
-    (let loop ([props props] [out '()])
+    (let loop ([props props]
+               [out '()])
       (match props
         [(list (? identifier? prop-name) value rest ...)
          (check-property* prop-name error!)
@@ -120,7 +125,8 @@
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))
     (if (list? (syntax-e cite))
-        (for ([citation (syntax-e cite)] #:unless (identifier? citation))
+        (for ([citation (syntax-e cite)]
+              #:unless (identifier? citation))
           (error! citation "Invalid citation ~a; must be a variable name" citation))
         (error! cite "Invalid :cite ~a; must be a list" cite)))
 
@@ -137,7 +143,8 @@
     (error! stx "Invalid arguments list ~a; must be a list" stx))
   (define vars* (filter identifier? vars))
   (when (list? vars)
-    (for ([var vars] #:unless (identifier? var))
+    (for ([var vars]
+          #:unless (identifier? var))
       (error! stx "Argument ~a is not a variable name" var))
     (when (check-duplicate-identifier vars*)
       (error! stx "Duplicate argument name ~a" (check-duplicate-identifier vars*))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -85,13 +85,15 @@
 
 ;; Returns all constant operators (operators with no arguments).
 (define (all-constants)
-  (sort (for/list ([(name rec) (in-hash operators)] #:when (null? (operator-itype rec)))
+  (sort (for/list ([(name rec) (in-hash operators)]
+                   #:when (null? (operator-itype rec)))
           name)
         symbol<?))
 
 ;; Returns all "accelerator" operators
 (define (all-accelerators)
-  (sort (for/list ([(name rec) (in-hash operators)] #:when (operator-spec rec))
+  (sort (for/list ([(name rec) (in-hash operators)]
+                   #:when (operator-spec rec))
           name)
         symbol<?))
 
@@ -161,7 +163,8 @@
          (unless (operator-exists? op)
            (bad! "expected operator at `~a`, got `~a` in `~a`" expr op))
          (define itypes (operator-info op 'itype))
-         (for ([arg (in-list args)] [itype (in-list itypes)])
+         (for ([arg (in-list args)]
+               [itype (in-list itypes)])
            (define arg-ty (type-of arg))
            (unless (equal? itype arg-ty)
              (type-error! arg arg-ty itype)))
@@ -231,10 +234,13 @@
 
   (syntax-case stx ()
     [(_ (id itype ...) otype [key val] ...)
-     (let ([id #'id] [keys (syntax->list #'(key ...))] [vals (syntax->list #'(val ...))])
+     (let ([id #'id]
+           [keys (syntax->list #'(key ...))]
+           [vals (syntax->list #'(val ...))])
        (unless (identifier? id)
          (bad! "expected identifier" id))
-       (with-syntax ([id id] [(val ...) (map attribute-val keys vals)])
+       (with-syntax ([id id]
+                     [(val ...) (map attribute-val keys vals)])
          #'(register-operator! 'id '(itype ...) 'otype (list (cons 'key val) ...))))]))
 
 (define-syntax define-operators
@@ -338,7 +344,8 @@
   (check-equal? (length (all-operators)) 63)
 
   ; check that Rival supports all non-accelerator operators
-  (for ([op (in-list (all-operators))] #:unless (operator-accelerator? op))
+  (for ([op (in-list (all-operators))]
+        #:unless (operator-accelerator? op))
     (define vars (map (lambda (_) (gensym)) (operator-info op 'itype)))
     (define disc (discretization 64 #f #f)) ; fake arguments
     (rival-compile (list `(,op ,@vars)) vars (list disc)))
@@ -424,7 +431,8 @@
      op
      expect-arity
      actual-arity))
-  (for ([repr (in-list (cons orepr ireprs))] [type (in-list (cons otype itypes))])
+  (for ([repr (in-list (cons orepr ireprs))]
+        [type (in-list (cons otype itypes))])
     (unless (equal? (representation-type repr) type)
       "Cannot register `~a` as implementation of `~a`: ~a is not a representation of ~a"
       name
@@ -472,7 +480,8 @@
 (define (get-parametric-operator #:all? [all? #f] name . ireprs)
   (define get-impls (if all? operator-all-impls operator-active-impls))
   (let/ec k
-          (for/first ([impl (get-impls name)] #:when (equal? (impl-info impl 'itype) ireprs))
+          (for/first ([impl (get-impls name)]
+                      #:when (equal? (impl-info impl 'itype) ireprs))
             (k impl))
           (raise-herbie-missing-error
            "Could not find operator implementation for ~a with ~a"

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -122,12 +122,16 @@
      vtype]
     [#`(let ([,id #,expr] ...) #,body)
      (define env2
-       (for/fold ([env2 env]) ([var id] [val expr])
+       (for/fold ([env2 env])
+                 ([var id]
+                  [val expr])
          (dict-set env2 var (expression->type val env type error!))))
      (expression->type body env2 type error!)]
     [#`(let* ([,id #,expr] ...) #,body)
      (define env2
-       (for/fold ([env2 env]) ([var id] [val expr])
+       (for/fold ([env2 env])
+                 ([var id]
+                  [val expr])
          (dict-set env2 var (expression->type val env2 type error!))))
      (expression->type body env2 type error!)]
     [#`(if #,branch #,ifstmt #,elsestmt)

--- a/src/utils/common.rkt
+++ b/src/utils/common.rkt
@@ -56,10 +56,14 @@
 ;; Utility list functions
 
 (define (argmins f lst)
-  (let loop ([lst lst] [best-score #f] [best-elts '()])
+  (let loop ([lst lst]
+             [best-score #f]
+             [best-elts '()])
     (if (null? lst)
         (reverse best-elts)
-        (let* ([elt (car lst)] [lst* (cdr lst)] [score (f elt)])
+        (let* ([elt (car lst)]
+               [lst* (cdr lst)]
+               [score (f elt)])
           (cond
             [(not best-score) (loop lst* score (list elt))]
             [(< score best-score) (loop lst* score (list elt))]
@@ -129,7 +133,10 @@
   (check-false (subsequence? '(1 2 10) l)))
 
 (define (list-set* l p v)
-  (let loop ([l l] [p p] [v v] [i 0])
+  (let loop ([l l]
+             [p p]
+             [v v]
+             [i 0])
     (cond
       [(empty? l) empty]
       [(and (not (empty? p)) (equal? (first p) i))

--- a/src/utils/multi-command-line.rkt
+++ b/src/utils/multi-command-line.rkt
@@ -16,7 +16,8 @@
           #:program true-name
           #:multi [("-v" "--version") ("Print the version and exit") (printf "~a\n" version) (exit)]
           #:usage-help "This command has subcommands:"
-          #,@(for/list ([name (syntax->list #'(name ...))] [help (syntax->list #'(help ...))])
+          #,@(for/list ([name (syntax->list #'(name ...))]
+                        [help (syntax->list #'(help ...))])
                (datum->syntax name (format "  ~a:\t~a" (syntax->datum name) (syntax->datum help))))
           "Learn more about a subcommand with <subcommand> --help"
           #:args cmdline-args

--- a/src/utils/pareto.rkt
+++ b/src/utils/pareto.rkt
@@ -38,7 +38,8 @@
 ;; and returns the Pareto-optimal subset of their union.
 ;; The curves most be sorted using the same method.
 (define (pareto-union curve1 curve2)
-  (let loop ([curve1 curve1] [curve2 curve2])
+  (let loop ([curve1 curve1]
+             [curve2 curve2])
     ; The curve is sorted so that highest accuracy is first
     (match* (curve1 curve2)
       [('() _) curve2]
@@ -59,7 +60,8 @@
 ;; Takes a Pareto frontier and returns the subset of
 ;; points that are convex.
 (define (pareto-convex ppts)
-  (let loop ([ppts* '()] [ppts ppts])
+  (let loop ([ppts* '()]
+             [ppts ppts])
     (match ppts
       [(list p0 p1 p2 pns ...)
        (match-define (pareto-point p0x p0y _) p0)
@@ -90,10 +92,14 @@
   (define (finalize f)
     (if convex? (pareto-convex f) f))
   (define frontiers* (map (λ (f) (pareto-minimize (map pt->ppt f))) frontiers))
-  (for/fold ([combined (list)] #:result (map ppt->pt combined)) ([frontier (in-list frontiers*)])
+  (for/fold ([combined (list)]
+             #:result (map ppt->pt combined))
+            ([frontier (in-list frontiers*)])
     (if (null? combined)
         (finalize frontier)
-        (for/fold ([combined* (list)] #:result (finalize combined*)) ([ppt (in-list combined)])
+        (for/fold ([combined* (list)]
+                   #:result (finalize combined*))
+                  ([ppt (in-list combined)])
           (let ([ppts (pareto-minimize (pareto-shift ppt frontier))])
             (pareto-union ppts combined*))))))
 

--- a/src/utils/pretty-print.rkt
+++ b/src/utils/pretty-print.rkt
@@ -30,7 +30,8 @@
               (values pre "0" e)
               (values (substring pre 0 1) (substring pre 1) (- (string-length pre) 1)))]
          [(list "0" s)
-          (let loop ([idx 0] [e e])
+          (let loop ([idx 0]
+                     [e e])
             (if (eq? (string-ref s idx) #\0)
                 (loop (+ idx 1) (- e 1))
                 (values (substring s idx (+ idx 1)) (substring s (+ idx 1)) (- e 1))))]
@@ -60,7 +61,8 @@
 
 (define (digit-interval-shortest a b)
   (define digits '(0 5 2 4 6 8 1 3 7 9))
-  (for/first ([d digits] #:when (<= a d b))
+  (for/first ([d digits]
+              #:when (<= a d b))
     d))
 
 (define (string-interval-shortest a b)

--- a/src/utils/profile.rkt
+++ b/src/utils/profile.rkt
@@ -8,9 +8,11 @@
   (define nodes (make-hash))
   (define root-node (node #f #f '() 0 0 '() '()))
   (hash-set! nodes (cons #f #f) root-node)
-  (for* ([p (in-list ps)] [n (profile-nodes p)])
+  (for* ([p (in-list ps)]
+         [n (profile-nodes p)])
     (hash-set! nodes (node-loc n) (node (node-id n) (node-src n) '() 0 0 '() '())))
-  (for* ([p ps] [node (profile-nodes p)])
+  (for* ([p ps]
+         [node (profile-nodes p)])
     (profile-add nodes node))
   (for ([p ps])
     (profile-add nodes (profile-*-node p)))
@@ -56,14 +58,16 @@
 
 (define (merge-thread-times . ts)
   (define h (make-hash))
-  (for* ([t (in-list ts)] [(id time) (in-dict t)])
+  (for* ([t (in-list ts)]
+         [(id time) (in-dict t)])
     (hash-update! h id (curry + time) 0))
   h)
 
 (define (profile->json p)
   (define nodes (cons (profile-*-node p) (profile-nodes p)))
   (define loc-hash
-    (for/hash ([node (in-list nodes)] [n (in-naturals)])
+    (for/hash ([node (in-list nodes)]
+               [n (in-naturals)])
       (values (node-loc node) n)))
   (define node-hash
     (for/hash ([node (in-list nodes)])
@@ -123,7 +127,8 @@
             (hash-ref n 'self)
             '()
             '())))
-  (for ([n (in-list (hash-ref j 'nodes))] [n* (in-vector nodes)])
+  (for ([n (in-list (hash-ref j 'nodes))]
+        [n* (in-vector nodes)])
     (set-node-callees! n*
                        (for/list ([e (hash-ref n 'callees)])
                          (edge (hash-ref e 'total)

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -39,7 +39,8 @@
 
   (unless (*timeline-disabled*)
     (when (pair? (unbox (*timeline*)))
-      (for ([key (in-list always-compact)] #:when (hash-has-key? (car (unbox (*timeline*))) key))
+      (for ([key (in-list always-compact)]
+            #:when (hash-has-key? (car (unbox (*timeline*))) key))
         (timeline-compact! key)))
     (define live-memory (current-memory-use #f))
     (define alloc-memory (current-memory-use 'cumulative))
@@ -71,7 +72,8 @@
 
 (define (timeline-adjust! type key . values)
   (unless (*timeline-disabled*)
-    (for/first ([cell (unbox (*timeline*))] #:when (equal? (hash-ref cell 'type) (~a type)))
+    (for/first ([cell (unbox (*timeline*))]
+                #:when (equal? (hash-ref cell 'type) (~a type)))
       (hash-set! cell key values)
       true)
     (void)))
@@ -129,7 +131,8 @@
             (current-inexact-milliseconds)
             'memory
             (list (list (current-memory-use #f) (current-memory-use 'cumulative)))))
-  (reverse (for/list ([evt (unbox (*timeline*))] [next (cons end (unbox (*timeline*)))])
+  (reverse (for/list ([evt (unbox (*timeline*))]
+                      [next (cons end (unbox (*timeline*)))])
              (define evt* (hash-copy evt))
              (hash-update! evt* 'time (λ (v) (- (hash-ref next 'time) v)))
              (hash-update! evt* 'memory (λ (v) (diff-memory-records (hash-ref next 'memory) v)))
@@ -163,18 +166,22 @@
           (hash-update! groups
                         key
                         (λ (old)
-                          (for/list ([value2 old] [(value1 fn) (in-dict values)])
+                          (for/list ([value2 old]
+                                     [(value1 fn) (in-dict values)])
                             (fn value2 value1))))
           (hash-set! groups key (map car values))))
     (for/list ([(k v) (in-hash groups)])
-      (let loop ([fields fields] [k k] [v v])
+      (let loop ([fields fields]
+                 [k k]
+                 [v v])
         (match* (fields k v)
           [((cons #f f*) (cons k k*) v) (cons k (loop f* k* v))]
           [((cons _ f*) k (cons v v*)) (cons v (loop f* k v*))]
           [('() '() '()) '()])))))
 
 (define (merge-sampling-tables l1 l2)
-  (let loop ([l1 (sort l1 < #:key first)] [l2 (sort l2 < #:key first)])
+  (let loop ([l1 (sort l1 < #:key first)]
+             [l2 (sort l2 < #:key first)])
     (match-define (list n1 t1) (car l1))
     (match-define (list n2 t2) (car l2))
     (define rec (list n1 (hash-union t1 t2 #:combine +)))
@@ -228,9 +235,11 @@
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above
   (define types (make-hash))
-  (for* ([tl (in-list timelines)] [event tl])
+  (for* ([tl (in-list timelines)]
+         [event tl])
     (define data (hash-ref! types (hash-ref event 'type) (make-hash)))
-    (for ([(k v) (in-dict event)] #:when (hash-ref timeline-types k #f))
+    (for ([(k v) (in-dict event)]
+          #:when (hash-ref timeline-types k #f))
       (if (hash-has-key? data k)
           (hash-update! data k (λ (old) ((hash-ref timeline-types k) v old)))
           (hash-set! data k v))))


### PR DESCRIPTION
The patch table (`patch.rkt`) used to be an actual table that functioned as a cache. This was part of a bigger project of changing the main loop in various ways that never really worked out. Well, apparently we stopped actually caching stuff during the platforms push. This PR removes the last vestiges of all that.

I considered actually hooking the cache back up, but I now think there's no point to it. After all—caching egraph stuff makes little sense because that is all already batched (and we're unlikely to have cached everything in the batch, thus skipping an actual egraph build). And caching Taylor stuff isn't too compelling because Taylor is already quite fast. So I figure let's just remove it and have a simpler system.