### PR TITLE
Add --no-browser flag.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -581,6 +581,7 @@
 
 (define (run-demo #:quiet [quiet? #f]
                   #:threads [threads #f]
+                  #:browser [browser? #t]
                   #:output output
                   #:demo? demo?
                   #:prefix prefix
@@ -605,7 +606,7 @@
                  #:servlet-current-directory (current-directory)
                  #:manager (create-none-manager #f)
                  #:command-line? true
-                 #:launch-browser? (not quiet?)
+                 #:launch-browser? (and browser? (not quiet?))
                  #:banner? (not quiet?)
                  #:servlets-root (web-resource)
                  #:server-root-path (web-resource)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -158,7 +158,7 @@
      num
      "How many jobs to run in parallel: Processor count is the default."
      (set! threads (string->thread-count num))]
-    [("--no-broswer") "Run the web demo but don't start a browser." (set! browser? false)]
+    [("--no-browser") "Run the web demo but don't start a browser." (set! browser? false)]
     #:args ()
     (run-demo #:quiet quiet?
               #:threads threads

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -49,6 +49,7 @@
 
 (module+ main
   (define quiet? #f)
+  (define browser? #t)
   (define demo-output #f)
   (define demo-log #f)
   (define demo-prefix "/")
@@ -157,9 +158,9 @@
      num
      "How many jobs to run in parallel: Processor count is the default."
      (set! threads (string->thread-count num))]
+    [("--no-broswer") "Run the web demo but don't start a browser." (set! browser? false)]
     #:args ()
     (run-demo #:quiet quiet?
-              #:threads threads
               #:output demo-output
               #:log demo-log
               #:prefix demo-prefix

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -161,6 +161,7 @@
     [("--no-broswer") "Run the web demo but don't start a browser." (set! browser? false)]
     #:args ()
     (run-demo #:quiet quiet?
+              #:threads threads
               #:output demo-output
               #:log demo-log
               #:prefix demo-prefix

--- a/www/doc/2.1/options.html
+++ b/www/doc/2.1/options.html
@@ -151,6 +151,9 @@
     automatically started to show the Herbie page. This option also
     shrinks the text printed on start up.</dd>
 
+    <dt><code>--no-browser</code></dt>
+    <dd>This flag disables the default behavior of opening the Herbie page in the users default browser.</dd>
+
     <dt><code>--public</code></dt>
     <dd>When set, users on other computers can connect to the demo and
     use it. (In other words, the server listens

--- a/www/doc/2.1/options.html
+++ b/www/doc/2.1/options.html
@@ -152,7 +152,7 @@
     shrinks the text printed on start up.</dd>
 
     <dt><code>--no-browser</code></dt>
-    <dd>This flag disables the default behavior of opening the Herbie page in the users default browser.</dd>
+    <dd>This flag disables the default behavior of opening the Herbie page in your default browser.</dd>
 
     <dt><code>--public</code></dt>
     <dd>When set, users on other computers can connect to the demo and


### PR DESCRIPTION
This PR adds a `--no-browser` flag to the web demo. Which disables the default browser from being opened and has no other side effects like `--quite`.

Motivation:
When personally working on Herbie I prefer to use Firefox or Brave well my default browser is set to Safari for personal reasons. I used to use `--quite` but this disables most output which I find unhelpful as I can't distinguish whether the server has started or racket is still compiling Herbie. I also prefer to have all output logged when working on Herbie to understand what path was taken through the code base.

Currently, I have been manually setting `#:launch-browser?` in `run.rkt` to `#f` but I often forget to leave this out of commits. I would very much appreciate a flag to do this for me.