### PR TITLE
Add `check-status` back.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -339,13 +339,6 @@
 
 (define (check-status req job-id)
   (match (get-timeline-for job-id)
-    [#f
-     (response 202
-               #"Job in progress"
-               (current-seconds)
-               #"text/plain"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
-               (λ (out) (display "Not done!" out)))]
     [(? box? timeline)
      (response 202
                #"Job in progress"

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -338,9 +338,7 @@
    (url main)))
 
 (define (check-status req job-id)
-  (define r (get-results-for job-id))
-  ;; TODO return the current status from the jobs timeline
-  (match r
+  (match (get-timeline-for job-id)
     [#f
      (response 202
                #"Job in progress"

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -249,7 +249,7 @@
           (define requested-timeline (place-channel-get a))
           (place-channel-put handler requested-timeline))
         (when (false? wid)
-          (log "WID = FALSE\n")
+          (log "Job complete, no timeline, send result.\n")
           (place-channel-put handler (hash-ref completed-work job-id #f)))]
        ; Returns the current count of working workers.
        [(list 'count handler) (place-channel-put handler (hash-count busy-workers))]
@@ -319,7 +319,7 @@
         (place-channel-put handler timeline)]))))
 
 (struct work (manager worker-id job-id job))
-
+; Not sure if these are actually needed.
 (define *demo-output* (make-parameter false))
 (define *demo?* (make-parameter false))
 

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -16,7 +16,8 @@
          "../syntax/load-plugin.rkt"
          "../utils/alternative.rkt"
          "../utils/common.rkt"
-         "../utils/float.rkt")
+         "../utils/float.rkt"
+         (submod "../utils/timeline.rkt" debug))
 
 (provide make-path
          get-improve-table-data
@@ -252,26 +253,68 @@
                          *loose-plugins*)
    (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
      (load-herbie-plugins))
+   (define worker-thread
+     (thread (λ ()
+               (let loop ([seed #f])
+                 (match (thread-receive)
+                   [`(init rand
+                           ,vec
+                           flags
+                           ,flag-table
+                           num-iters
+                           ,iterations
+                           points
+                           ,points
+                           timeout
+                           ,timeout
+                           output-dir
+                           ,output
+                           reeval
+                           ,reeval
+                           demo?
+                           ,demo?)
+                    (set! seed vec)
+                    (*flags* flag-table)
+                    (*num-iterations* iterations)
+                    (*num-points* points)
+                    (*timeout* timeout)
+                    (*demo-output* output)
+                    (*reeval-pts* reeval)
+                    (*demo?* demo?)]
+                   [job-info (run-job job-info)])
+                 (loop seed)))))
+   (define timeline (*timeline*))
    (for ([_ (in-naturals)])
      (match (place-channel-get ch)
        [(list 'apply manager command job-id)
+        (set! timeline (*timeline*))
         (log "[~a] working on [~a].\n" job-id (test-name (herbie-command-test command)))
-        (define herbie-result (wrapper-run-herbie command job-id))
-        (match-define (job-result kind test status time _ _ backend) herbie-result)
-        (define out-result
-          (match kind
-            ['alternatives (make-alternatives-result herbie-result test job-id)]
-            ['evaluate (make-calculate-result herbie-result job-id)]
-            ['cost (make-cost-result herbie-result job-id)]
-            ['errors (make-error-result herbie-result job-id)]
-            ['exacts (make-exacts-result herbie-result job-id)]
-            ['improve (make-improve-result herbie-result test job-id)]
-            ['local-error (make-local-error-result herbie-result test job-id)]
-            ['explanations (make-explanation-result herbie-result job-id)]
-            ['sample (make-sample-result herbie-result test job-id)]
-            [_ (error 'compute-result "unknown command ~a" kind)]))
-        (log "Job: ~a finished, returning work to manager\n" job-id)
-        (place-channel-put manager (list 'finished manager worker-id job-id out-result))]))))
+        (thread-send worker-thread (work manager worker-id job-id command))]))))
+
+(struct work (manager worker-id job-id job))
+
+(define *demo-output* (make-parameter false))
+(define *demo?* (make-parameter false))
+
+(define (run-job job-info)
+  (match-define (work manager worker-id job-id command) job-info)
+  (eprintf "run-job: ~a, ~a\n" worker-id job-id)
+  (define herbie-result (wrapper-run-herbie command job-id))
+  (match-define (job-result kind test status time _ _ backend) herbie-result)
+  (define out-result
+    (match kind
+      ['alternatives (make-alternatives-result herbie-result test job-id)]
+      ['evaluate (make-calculate-result herbie-result job-id)]
+      ['cost (make-cost-result herbie-result job-id)]
+      ['errors (make-error-result herbie-result job-id)]
+      ['exacts (make-exacts-result herbie-result job-id)]
+      ['improve (make-improve-result herbie-result test job-id)]
+      ['local-error (make-local-error-result herbie-result test job-id)]
+      ['explanations (make-explanation-result herbie-result job-id)]
+      ['sample (make-sample-result herbie-result test job-id)]
+      [_ (error 'compute-result "unknown command ~a" kind)]))
+  (log "Job: ~a finished, returning work to manager\n" job-id)
+  (place-channel-put manager (list 'finished manager worker-id job-id out-result)))
 
 (define (make-explanation-result herbie-result job-id)
   (define explanations (job-result-backend herbie-result))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -33,7 +33,7 @@
          start-job-server)
 
 ; verbose logging for debugging
-(define verbose #t) ; Maybe change to log-level and use 'verbose?
+(define verbose #f) ; Maybe change to log-level and use 'verbose?
 (define (log msg . args)
   (when verbose
     (apply eprintf msg args)))
@@ -315,8 +315,7 @@
         (log "[~a] working on [~a].\n" job-id (test-name (herbie-command-test command)))
         (thread-send worker-thread (work manager worker-id job-id command))]
        [(list 'timeline handler)
-        (eprintf "[~a]TIMELINE: ~a\n" worker-id (unbox timeline))
-        (eprintf "Timeline requested from worker[~a] for job ~a\n" worker-id current-job-id)
+        (log "Timeline requested from worker[~a] for job ~a\n" worker-id current-job-id)
         (place-channel-put handler timeline)]))))
 
 (struct work (manager worker-id job-id job))
@@ -326,9 +325,7 @@
 
 (define (run-job job-info)
   (match-define (work manager worker-id job-id command) job-info)
-  (eprintf "run-job: ~a, ~a\n" worker-id job-id)
-  ; (timeline-event! 'start)
-  ; (eprintf "TIMELINE HERE: ~a\n" (unbox *timeline*))
+  (log "run-job: ~a, ~a\n" worker-id job-id)
   (define herbie-result (wrapper-run-herbie command job-id))
   (match-define (job-result kind test status time _ _ backend) herbie-result)
   (define out-result

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -17,6 +17,7 @@
          "../utils/alternative.rkt"
          "../utils/common.rkt"
          "../utils/float.rkt"
+         "../utils/timeline.rkt"
          (submod "../utils/timeline.rkt" debug))
 
 (provide make-path
@@ -32,7 +33,7 @@
          start-job-server)
 
 ; verbose logging for debugging
-(define verbose #f) ; Maybe change to log-level and use 'verbose?
+(define verbose #t) ; Maybe change to log-level and use 'verbose?
 (define (log msg . args)
   (when verbose
     (apply eprintf msg args)))
@@ -64,7 +65,7 @@
 (define (get-timeline-for job-id)
   (define-values (a b) (place-channel))
   (place-channel-put manager (list 'timeline job-id b))
-  (log "Getting result for job: ~a.\n" job-id)
+  (log "Getting timeline for job: ~a.\n" job-id)
   (place-channel-get a))
 
 (define (get-improve-table-data)
@@ -245,8 +246,8 @@
           (log "Worker[~a] working on ~a.\n" wid job-id)
           (define-values (a b) (place-channel))
           (place-channel-put (hash-ref busy-workers wid) (list 'timeline b))
-          (define timeline (place-channel-get a))
-          (place-channel-put handler timeline))
+          (define requested-timeline (place-channel-get a))
+          (place-channel-put handler requested-timeline))
         (when (false? wid)
           (log "WID = FALSE\n")
           (place-channel-put handler (hash-ref completed-work job-id #f)))]
@@ -326,6 +327,8 @@
 (define (run-job job-info)
   (match-define (work manager worker-id job-id command) job-info)
   (eprintf "run-job: ~a, ~a\n" worker-id job-id)
+  ; (timeline-event! 'start)
+  ; (eprintf "TIMELINE HERE: ~a\n" (unbox *timeline*))
   (define herbie-result (wrapper-run-herbie command job-id))
   (match-define (job-result kind test status time _ _ backend) herbie-result)
   (define out-result


### PR DESCRIPTION
This PR returns previewing the current state of the job view the `*time-line*` box.

This is done by letting the worker manage a [thread](https://docs.racket-lang.org/reference/threads.html#%28def._%28%28quote._~23~25kernel%29._thread%29%29) to manage which allows us to observe/read the `timeline` for a given a job. The simplest value of this is the web demo can now display the current state of the job as it did before the use of places.