### PR TITLE
Add manual resetter for `define/reset`

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -180,8 +180,13 @@
   (for ([fn (in-list resetters)])
     (fn)))
 
-(define-syntax-rule (define/reset name value)
-  (define name
-    (let ([param (make-parameter value)])
-      (register-resetter! (λ () (name value)))
-      param)))
+(define-syntax define/reset
+  (syntax-rules ()
+    ; default resetter sets parameter to `value`
+    [(_ name value) (define/reset name value (λ () (name value)))]
+    ; initial value and resetter
+    [(_ name value reset-fn)
+     (define name
+       (let ([param (make-parameter value)])
+         (register-resetter! reset-fn)
+         param))]))

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -20,7 +20,7 @@
 ;; This is a box so we can get a reference outside the engine, and so
 ;; access its value even in a timeout.
 ;; Important: Use 'eq?' based hash tables, process may freeze otherwise
-(define/reset *timeline* (box '()))
+(define/reset *timeline* (box '()) (lambda () (set-box! (*timeline*) '())))
 
 (define *timeline-active-key* #f)
 (define *timeline-active-value* #f)


### PR DESCRIPTION
Extends `define/reset` to support a manual reset. By default,
```
(define/reset name value)
```
installs a resetter that sets the parameter `name` to `value`. The timeline is the only resettable parameter where we want to keep the current value of the parameter, which is a box, but mutate the value in the box. For this, the option
```
(define/reset name value reset-fn)
```
has been added and the timeline parameter is now defined as
```
(define/reset *timeline* (box '()) (lambda () (set-box! (*timeline*) '())))
```