### PR TITLE
Fix pcontext bug in rendering alternatives for `graph.html`

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -392,7 +392,7 @@
   (define pcontext (improve-result-pctxs backend))
 
   (define preprocessing (improve-result-preprocess backend))
-  (define end-hash-table (end-hash (improve-result-end backend) repr preprocessing pcontext test))
+  (define end-hash-table (end-hash (improve-result-end backend) repr pcontext test))
 
   (hasheq 'preprocessing
           preprocessing
@@ -407,13 +407,7 @@
           'bogosity
           (improve-result-bogosity backend)))
 
-(define (end-hash end repr preprocessing pcontexts test)
-  (define ctx (test-context test))
-  (define-values (processed test-pctx)
-    (for/lists (l1 l2)
-               ([pctx pcontexts])
-               (define-values (train-pcontext test-pcontext) (partition-pcontext pctx))
-               (values (preprocess-pcontext ctx test-pcontext preprocessing) test-pcontext)))
+(define (end-hash end repr pcontexts test)
   (define-values (end-alts train-errors end-errors end-costs)
     (for/lists (l1 l2 l3 l4)
                ([analysis end])
@@ -423,11 +417,8 @@
     (for/list ([altn end-alts])
       (~a (program->fpcore (alt-expr altn) (test-context test)))))
   (define alts-histories
-    (for/list ([alt end-alts]
-               [ppctx processed]
-               [tpctx test-pctx])
-      (render-history alt ppctx tpctx (test-context test))))
-
+    (for/list ([alt end-alts])
+      (render-history alt (first pcontexts) (second pcontexts) (test-context test))))
   (define vars (test-vars test))
   (define end-alt (alt-analysis-alt (car end)))
   (define splitpoints

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -89,9 +89,6 @@
                     (/ start-cost cost))])
       (and (not (null? better)) (apply max better))))
 
-  (match-define (list train-pctx test-pctx) pctxs)
-
-  (define end-alt (car end-alts))
   (define end-error (car end-errors))
 
   (write-html


### PR DESCRIPTION
This PR fixes a bug where `graph.html` would only render the first two alts due to an error in my logic for generating `history` in `server.rkt`.


When running the demo for the default `sqrt(x + 1) - sqrt(x)` Accuracy vs Speed display 9 `alts` available but when you scroll down only the first two `alts` are displayed.