### PR TITLE
Add `check-status` back.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -339,9 +339,7 @@
    (url main)))
 
 (define (check-status req job-id)
-  (define r (get-results-for job-id))
-  ;; TODO return the current status from the jobs timeline
-  (match r
+  (match (get-timeline-for job-id)
     [#f
      (response 202
                #"Job in progress"

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -340,13 +340,6 @@
 
 (define (check-status req job-id)
   (match (get-timeline-for job-id)
-    [#f
-     (response 202
-               #"Job in progress"
-               (current-seconds)
-               #"text/plain"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
-               (λ (out) (display "Not done!" out)))]
     [(? box? timeline)
      (response 202
                #"Job in progress"

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -249,7 +249,7 @@
           (define requested-timeline (place-channel-get a))
           (place-channel-put handler requested-timeline))
         (when (false? wid)
-          (log "WID = FALSE\n")
+          (log "Job complete, no timeline, send result.\n")
           (place-channel-put handler (hash-ref completed-work job-id #f)))]
        ; Returns the current count of working workers.
        [(list 'count handler) (place-channel-put handler (hash-count busy-workers))]
@@ -319,7 +319,7 @@
         (place-channel-put handler timeline)]))))
 
 (struct work (manager worker-id job-id job))
-
+; Not sure if these are actually needed.
 (define *demo-output* (make-parameter false))
 (define *demo?* (make-parameter false))
 

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -33,7 +33,7 @@
          start-job-server)
 
 ; verbose logging for debugging
-(define verbose #t) ; Maybe change to log-level and use 'verbose?
+(define verbose #f) ; Maybe change to log-level and use 'verbose?
 (define (log msg . args)
   (when verbose
     (apply eprintf msg args)))
@@ -315,8 +315,7 @@
         (log "[~a] working on [~a].\n" job-id (test-name (herbie-command-test command)))
         (thread-send worker-thread (work manager worker-id job-id command))]
        [(list 'timeline handler)
-        (eprintf "[~a]TIMELINE: ~a\n" worker-id (unbox timeline))
-        (eprintf "Timeline requested from worker[~a] for job ~a\n" worker-id current-job-id)
+        (log "Timeline requested from worker[~a] for job ~a\n" worker-id current-job-id)
         (place-channel-put handler timeline)]))))
 
 (struct work (manager worker-id job-id job))
@@ -326,9 +325,7 @@
 
 (define (run-job job-info)
   (match-define (work manager worker-id job-id command) job-info)
-  (eprintf "run-job: ~a, ~a\n" worker-id job-id)
-  ; (timeline-event! 'start)
-  ; (eprintf "TIMELINE HERE: ~a\n" (unbox *timeline*))
+  (log "run-job: ~a, ~a\n" worker-id job-id)
   (define herbie-result (wrapper-run-herbie command job-id))
   (match-define (job-result kind test status time _ _ backend) herbie-result)
   (define out-result


### PR DESCRIPTION
This PR returns previewing the current state of the job view the *time-line* box.

This is done by letting the worker manage a [thread](https://docs.racket-lang.org/reference/threads.html#%28def._%28%28quote._~23~25kernel%29._thread%29%29) to manage which allows us to observe/read the timeline for a given a job. The simplest value of this is the web demo can now display the current state of the job as it did before the use of places.