### PR TITLE
Render exceptions in reports

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -439,8 +439,8 @@
                    (test-input (parse-test (read-syntax 'web (open-input-string (car end-exprs)))))]
                   [cost-accuracy cost&accuracy])]
     ['failure
-     (define exn backend)
-     (define status (if (exn:fail:user:herbie? exn) "error" "crash"))
+     (match-define (list 'exn type _ ...) backend)
+     (define status (if type "error" "crash"))
      (dummy-table-row-from-hash result-hash status link)]
     ['timeout (dummy-table-row-from-hash result-hash "timeout" link)]
     [_ (error 'get-table-data "unknown result type ~a" status)]))
@@ -517,8 +517,8 @@
                   [output (car end-exprs)]
                   [cost-accuracy cost&accuracy])]
     ['failure
-     (define exn backend)
-     (define status (if (exn:fail:user:herbie? exn) "error" "crash"))
+     (match-define (list 'exn type _ ...) backend)
+     (define status (if type "error" "crash"))
      (dummy-table-row result status link)]
     ['timeout (dummy-table-row result "timeout" link)]
     [_ (error 'get-table-data "unknown result type ~a" status)]))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -16,6 +16,7 @@
          "../syntax/load-plugin.rkt"
          "../utils/alternative.rkt"
          "../utils/common.rkt"
+         "../utils/errors.rkt"
          "../utils/float.rkt")
 
 (provide make-path
@@ -365,7 +366,8 @@
   (define backend-hash
     (match (job-result-status herbie-result)
       ['success (backend-improve-result-hash-table backend repr test)]
-      [_ #f]))
+      ['timeout #f]
+      ['failure (exception->datum backend)]))
 
   (hasheq 'command
           (get-command herbie-result)

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -2,11 +2,11 @@
 
 (require json)
 (require "../syntax/read.rkt"
-         "../api/sandbox.rkt"
          "timeline.rkt"
          "plot.rkt"
          "make-graph.rkt"
          "traceback.rkt")
+  
 (provide all-pages
          make-page
          page-error-handler)
@@ -41,8 +41,8 @@
         (match command
           ["improve" (make-graph result-hash out output? profile?)]
           [else (dummy-graph command out)])]
-       ['timeout (make-traceback result-hash out profile?)]
-       ['failure (make-traceback result-hash out profile?)]
+       ['timeout (make-traceback result-hash out)]
+       ['failure (make-traceback result-hash out)]
        [_ (error 'make-page "unknown result type ~a" status)])]
     ["timeline.html"
      (make-timeline (test-name test) (hash-ref result-hash 'timeline) out #:path "..")]

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -6,7 +6,7 @@
          "plot.rkt"
          "make-graph.rkt"
          "traceback.rkt")
-  
+
 (provide all-pages
          make-page
          page-error-handler)

--- a/src/reports/traceback.rkt
+++ b/src/reports/traceback.rkt
@@ -7,13 +7,13 @@
 
 (provide make-traceback)
 
-(define (make-traceback result-hash out profile?)
+(define (make-traceback result-hash out)
   (match (hash-ref result-hash 'status)
-    ['timeout (render-timeout result-hash out profile?)]
-    ['failure (render-failure result-hash out profile?)]
+    ['timeout (render-timeout result-hash out)]
+    ['failure (render-failure result-hash out)]
     [status (error 'make-traceback "unexpected status ~a" status)]))
 
-(define (render-failure result-hash out profile?)
+(define (render-failure result-hash out)
   (define test (hash-ref result-hash 'test))
   (define warnings (hash-ref result-hash 'warnings))
   (define backend (hash-ref result-hash 'backend))
@@ -63,7 +63,7 @@
           `(tr (td ((class "procedure")) ,(~a name)) (td ,(~a file)) (td ,(~a line)) (td ,(~a col)))]
          [#f `(tr (td ((class "procedure")) ,(~a name)) (td ([colspan "3"]) "unknown"))])))))
 
-(define (render-timeout result-hash out profile?)
+(define (render-timeout result-hash out)
   (define test (hash-ref result-hash 'test))
   (define time (hash-ref result-hash 'time))
   (define warnings (hash-ref result-hash 'warnings))

--- a/src/reports/traceback.rkt
+++ b/src/reports/traceback.rkt
@@ -2,20 +2,71 @@
 
 (require (only-in xml write-xexpr xexpr?))
 (require "../utils/common.rkt"
-         "../utils/errors.rkt"
          "../syntax/read.rkt"
-         "../api/sandbox.rkt"
          "common.rkt")
+
 (provide make-traceback)
 
 (define (make-traceback result-hash out profile?)
-  ;; Called with timeout or failure results
+  (match (hash-ref result-hash 'status)
+    ['timeout (render-timeout result-hash out profile?)]
+    ['failure (render-failure result-hash out profile?)]
+    [status (error 'make-traceback "unexpected status ~a" status)]))
+
+(define (render-failure result-hash out profile?)
   (define test (hash-ref result-hash 'test))
-  (define status (hash-ref result-hash 'status))
-  (define time (hash-ref result-hash 'time))
   (define warnings (hash-ref result-hash 'warnings))
   (define backend (hash-ref result-hash 'backend))
-  (define exn (if (eq? status 'failure) backend 'timeout))
+
+  ; unpack the exception
+  (match-define (list 'exn type msg url extra traceback) backend)
+
+  (write-html
+   `(html
+     (head (meta ((charset "utf-8")))
+           (title "Exception for " ,(~a (test-name test)))
+           (link ((rel "stylesheet") (type "text/css") (href "../report.css")))
+           ,@js-tex-include
+           (script ([src "../report.js"])))
+     (body ,(render-menu (~a (test-name test))
+                         (list '("Report" . "../index.html") '("Metrics" . "timeline.html")))
+           ,(render-warnings warnings)
+           ,(render-specification test)
+           ,(if type
+                `(section ([id "user-error"] (class "error"))
+                          (h2 ,(~a msg) " " (a ([href ,url]) "(more)"))
+                          ,(if (eq? type 'syntax) (render-syntax-errors msg extra) ""))
+                "")
+           ,(if type
+                ""
+                `(,@(render-reproduction test #:bug? #t)
+                  (section ([id "backtrace"]) (h2 "Backtrace") ,(render-traceback msg traceback))))))
+   out))
+
+(define (render-syntax-errors msg locations)
+  `(table (thead (th ([colspan "2"]) ,msg) (th "L") (th "C"))
+          (tbody ,@(for/list ([location (in-list locations)])
+                     (match-define (list msg src line col pos) location)
+                     `(tr (td ((class "procedure")) ,(~a msg))
+                          (td ,(~a src))
+                          (td ,(or (~a line "")))
+                          (td ,(or (~a col) (~a pos))))))))
+
+(define (render-traceback msg traceback)
+  `(table
+    (thead (th ([colspan "2"]) ,msg) (th "L") (th "C"))
+    (tbody
+     ,@
+     (for/list ([(name loc) (in-dict traceback)])
+       (match loc
+         [(list file line col)
+          `(tr (td ((class "procedure")) ,(~a name)) (td ,(~a file)) (td ,(~a line)) (td ,(~a col)))]
+         [#f `(tr (td ((class "procedure")) ,(~a name)) (td ([colspan "3"]) "unknown"))])))))
+
+(define (render-timeout result-hash out profile?)
+  (define test (hash-ref result-hash 'test))
+  (define time (hash-ref result-hash 'time))
+  (define warnings (hash-ref result-hash 'warnings))
 
   (write-html
    `(html (head (meta ((charset "utf-8")))
@@ -27,42 +78,7 @@
                               (list '("Report" . "../index.html") '("Metrics" . "timeline.html")))
                 ,(render-warnings warnings)
                 ,(render-specification test)
-                ,(match exn
-                   [(? exn:fail:user:herbie?)
-                    `(section
-                      ([id "user-error"] (class "error"))
-                      (h2 ,(~a (exn-message exn)) " " (a ([href ,(herbie-error-url exn)]) "(more)"))
-                      ,(if (exn:fail:user:herbie:syntax? exn) (render-syntax-errors exn) ""))]
-                   ['timeout
-                    `(section ([id "user-error"] (class "error"))
-                              (h2 "Timeout after " ,(format-time time))
-                              (p "Use the " (code "--timeout") " flag to change the timeout."))]
-                   [_ ""])
-                ,(match exn
-                   [(? exn:fail:user:herbie?) ""]
-                   [(? exn?)
-                    `(,@(render-reproduction test #:bug? #t)
-                      (section ([id "backtrace"]) (h2 "Backtrace") ,(render-traceback exn)))]
-                   [_ ""])))
+                (section ([id "user-error"] (class "error"))
+                         (h2 "Timeout after " ,(format-time time))
+                         (p "Use the " (code "--timeout") " flag to change the timeout."))))
    out))
-
-(define (render-syntax-errors exn)
-  `(table (thead (th ([colspan "2"]) ,(exn-message exn)) (th "L") (th "C"))
-          (tbody ,@(for/list ([(stx msg) (in-dict (exn:fail:user:herbie:syntax-locations exn))])
-                     `(tr (td ((class "procedure")) ,(~a msg))
-                          (td ,(~a (syntax-source stx)))
-                          (td ,(or (~a (syntax-line stx) "")))
-                          (td ,(or (~a (syntax-column stx)) (~a (syntax-position stx)))))))))
-
-(define (render-traceback exn)
-  `(table (thead (th ([colspan "2"]) ,(exn-message exn)) (th "L") (th "C"))
-          (tbody ,@(for/list ([tb (continuation-mark-set->context (exn-continuation-marks exn))])
-                     (match (cdr tb)
-                       [(srcloc file line col _ _)
-                        `(tr (td ((class "procedure")) ,(~a (or (car tb) "(unnamed)")))
-                             (td ,(~a file))
-                             (td ,(~a line))
-                             (td ,(~a col)))]
-                       [#f
-                        `(tr (td ((class "procedure")) ,(~a (or (car tb) "(unnamed)")))
-                             (td ([colspan "3"]) "unknown"))])))))

--- a/src/utils/errors.rkt
+++ b/src/utils/errors.rkt
@@ -80,8 +80,14 @@
     [(? exn:fail:user:herbie:sampling?)
      (list 'exn 'sampling (exn-message exn) (herbie-error-url exn) #f (traceback->datum exn))]
     [(? exn:fail:user:herbie:syntax?)
-     (list 'exn 'syntax (exn-message exn) (herbie-error-url exn) (syntax-locations->datum exn) (traceback->datum exn))]
-    [(? exn:fail:user:herbie?) (list 'exn 'herbie (exn-message exn) (herbie-error-url exn) '() (traceback->datum exn))]
+     (list 'exn
+           'syntax
+           (exn-message exn)
+           (herbie-error-url exn)
+           (syntax-locations->datum exn)
+           (traceback->datum exn))]
+    [(? exn:fail:user:herbie?)
+     (list 'exn 'herbie (exn-message exn) (herbie-error-url exn) '() (traceback->datum exn))]
     [(? exn?) (list 'exn #f (exn-message exn) #f '() (traceback->datum exn))]))
 
 (define (herbie-error->string err)

--- a/src/utils/errors.rkt
+++ b/src/utils/errors.rkt
@@ -5,6 +5,7 @@
          raise-herbie-sampling-error
          raise-herbie-missing-error
          syntax->error-format-string
+         exception->datum
          herbie-error->string
          herbie-error-url
          (struct-out exn:fail:user:herbie)
@@ -59,6 +60,29 @@
           file
           (or (syntax-line stx) "")
           (or (syntax-column stx) (syntax-position stx))))
+
+(define (traceback->datum exn)
+  (define ctx (continuation-mark-set->context (exn-continuation-marks exn)))
+  (for/list ([(name loc) (in-dict ctx)])
+    (define name* (or name "(unnamed)"))
+    (match loc
+      [(srcloc file line col _ _) (cons name* (list file line col))]
+      [#f (cons name* #f)])))
+
+(define (syntax-locations->datum exn)
+  (for/list ([(stx msg) (in-dict (exn:fail:user:herbie:syntax-locations exn))])
+    (list msg (syntax-source stx) (syntax-line stx) (syntax-column stx) (syntax-position stx))))
+
+(define (exception->datum exn)
+  (match exn
+    [(? exn:fail:user:herbie:missing?)
+     (list 'exn 'missing (exn-message exn) (herbie-error-url exn) #f (traceback->datum exn))]
+    [(? exn:fail:user:herbie:sampling?)
+     (list 'exn 'sampling (exn-message exn) (herbie-error-url exn) #f (traceback->datum exn))]
+    [(? exn:fail:user:herbie:syntax?)
+     (list 'exn 'syntax (exn-message exn) (herbie-error-url exn) (syntax-locations->datum exn) (traceback->datum exn))]
+    [(? exn:fail:user:herbie?) (list 'exn 'herbie (exn-message exn) (herbie-error-url exn) '() (traceback->datum exn))]
+    [(? exn?) (list 'exn #f (exn-message exn) #f '() (traceback->datum exn))]))
 
 (define (herbie-error->string err)
   (call-with-output-string


### PR DESCRIPTION
This PR restores rendering of exceptions in reports. To get exceptions through the new server design, exceptions are unpacked into s-expressions that contain enough information for rendering.