### PR TITLE
Add "async" API's for Odyssey to test out.

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -17,6 +17,9 @@ const alternativesBody = JSON.stringify({
     14.97651307489794
   ], 0.12711304680349078]]
 })
+const exactsBody = JSON.stringify({
+  formula: FPCoreFormula2, sample: eval_sample
+})
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
@@ -39,9 +42,16 @@ const localerrorStartData = await testAsyncAPI("localerror-start", analyzeBody)
 assertIdAndPath(localerrorStartData)
 assert.equal(localerrorStartData.tree['avg-error'] > 0, true)
 
+// Alternatives
 const alternativesStartData = await testAsyncAPI("alternatives-start", alternativesBody)
 assertIdAndPath(alternativesStartData)
 assert.equal(Array.isArray(alternativesStartData.alternatives), true)
+
+// Exacts endpoint
+const exactsStartData =  await testAsyncAPI("exacts-start", exactsBody)
+assertIdAndPath(exactsStartData)
+assert.deepEqual(exactsStartData.points, [[[1], -1.4142135623730951]])
+
 
 // --------------------------------------
 // END ASYNC APIS

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -20,6 +20,9 @@ const alternativesBody = JSON.stringify({
 const exactsBody = JSON.stringify({
   formula: FPCoreFormula2, sample: eval_sample
 })
+const calculateBody = JSON.stringify({
+  formula: FPCoreFormula2, sample: eval_sample
+})
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
@@ -51,6 +54,11 @@ assert.equal(Array.isArray(alternativesStartData.alternatives), true)
 const exactsStartData =  await testAsyncAPI("exacts-start", exactsBody)
 assertIdAndPath(exactsStartData)
 assert.deepEqual(exactsStartData.points, [[[1], -1.4142135623730951]])
+
+// Calculate endpoint
+const calculateStartData = await testAsyncAPI("calculate-start", calculateBody)
+assertIdAndPath(calculateStartData)
+assert.deepEqual(calculateStartData.points, [[[1], -1.4142135623730951]])
 
 
 // --------------------------------------

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -12,7 +12,6 @@ const analyzeBody = JSON.stringify({
     14.97651307489794
   ], 0.12711304680349078]]
 })
-
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
@@ -26,6 +25,14 @@ assert.equal(sampleStartData.points.length, SAMPLE_SIZE, `sample size should be 
 const analyzeStartData = await testAsyncAPI("analyze-start", analyzeBody)
 assertIdAndPath(analyzeStartData)
 assert.deepEqual(analyzeStartData.points, [[[14.97651307489794], "2.3"]])
+
+// Localerror
+const localErrorBody = JSON.stringify({
+  formula: FPCoreFormula, sample: sampleStartData.points
+})
+const localerrorStartData = await testAsyncAPI("localerror-start", analyzeBody)
+assertIdAndPath(localerrorStartData)
+assert.equal(localerrorStartData.tree['avg-error'] > 0, true)
 
 // --------------------------------------
 // END ASYNC APIS
@@ -98,9 +105,7 @@ assert.deepEqual(errors.points, [[[14.97651307489794], "2.3"]])
 
 // Local error endpoint
 const localError = await callHerbie("/api/localerror", {
-  method: 'POST', body: JSON.stringify({
-    formula: FPCoreFormula, sample: sample2.points
-  })
+  method: 'POST', body: localErrorBody
 })
 assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -23,6 +23,9 @@ const exactsBody = JSON.stringify({
 const calculateBody = JSON.stringify({
   formula: FPCoreFormula2, sample: eval_sample
 })
+const costBody = JSON.stringify({
+  formula: FPCoreFormula2, sample: eval_sample
+})
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
@@ -60,6 +63,10 @@ const calculateStartData = await testAsyncAPI("calculate-start", calculateBody)
 assertIdAndPath(calculateStartData)
 assert.deepEqual(calculateStartData.points, [[[1], -1.4142135623730951]])
 
+// Cost endpoint
+const costStartData = await testAsyncAPI("cost-start", costBody)
+assertIdAndPath(costStartData)
+assert.equal(costStartData.cost > 0, true)
 
 // --------------------------------------
 // END ASYNC APIS

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -12,6 +12,11 @@ const analyzeBody = JSON.stringify({
     14.97651307489794
   ], 0.12711304680349078]]
 })
+const alternativesBody = JSON.stringify({
+  formula: FPCoreFormula, sample: [[[
+    14.97651307489794
+  ], 0.12711304680349078]]
+})
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
@@ -33,6 +38,10 @@ const localErrorBody = JSON.stringify({
 const localerrorStartData = await testAsyncAPI("localerror-start", analyzeBody)
 assertIdAndPath(localerrorStartData)
 assert.equal(localerrorStartData.tree['avg-error'] > 0, true)
+
+const alternativesStartData = await testAsyncAPI("alternatives-start", alternativesBody)
+assertIdAndPath(alternativesStartData)
+assert.equal(Array.isArray(alternativesStartData.alternatives), true)
 
 // --------------------------------------
 // END ASYNC APIS

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -7,15 +7,25 @@ const SAMPLE_SIZE = 8000
 const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
 const eval_sample = [[[1], -1.4142135623730951]]
+const analyzeBody = JSON.stringify({
+  formula: FPCoreFormula, sample: [[[
+    14.97651307489794
+  ], 0.12711304680349078]]
+})
 
 // --------------------------------------
 // TEST ASYNC APIs
 // --------------------------------------
 
+// Sample
 const sampleStartData = await testAsyncAPI("sample-start", JSON.stringify({ formula: FPCoreFormula2, seed: 5 }))
-
 assert.ok(sampleStartData.points)
 assert.equal(sampleStartData.points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
+
+// Analyze
+const analyzeStartData = await testAsyncAPI("analyze-start", analyzeBody)
+assertIdAndPath(analyzeStartData)
+assert.deepEqual(analyzeStartData.points, [[[14.97651307489794], "2.3"]])
 
 // --------------------------------------
 // END ASYNC APIS
@@ -81,11 +91,7 @@ assert.deepEqual(points[1], points2[1])
 
 // Analyze endpoint
 const errors = await callHerbie("/api/analyze", {
-  method: 'POST', body: JSON.stringify({
-    formula: FPCoreFormula, sample: [[[
-      14.97651307489794
-    ], 0.12711304680349078]]
-  })
+  method: 'POST', body: analyzeBody
 })
 assertIdAndPath(errors)
 assert.deepEqual(errors.points, [[[14.97651307489794], "2.3"]])

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -68,6 +68,10 @@ const costStartData = await testAsyncAPI("cost-start", costBody)
 assertIdAndPath(costStartData)
 assert.equal(costStartData.cost > 0, true)
 
+const explainStartData = await testAsyncAPI("explanations-start",localErrorBody)
+assertIdAndPath(explainStartData)
+assert.equal(explainStartData.explanation.length > 0, true, 'explanation should not be empty');
+
 // --------------------------------------
 // END ASYNC APIS
 // --------------------------------------

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -68,6 +68,7 @@
                   [("api" "calculate") #:method "post" calculate-endpoint]
                   [("api" "calculate-start") #:method "post" calculate-start-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
+                  [("api" "cost-start") #:method "post" cost-start-endpoint]
                   [("api" "mathjs") #:method "post" ->mathjs-endpoint]
                   [("api" "translate") #:method "post" translate-endpoint]
                   [("api" "explanations") #:method "post" explanations-endpoint]
@@ -635,6 +636,16 @@
        (create-job 'cost test #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #f))
      (define id (start-job command))
      (wait-for-job id))))
+
+(define cost-start-endpoint
+  (post-with-json-response
+   (lambda (post-data)
+     (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+     (define test (parse-test formula))
+     (define command
+       (create-job 'cost test #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #f))
+     (define job-id (start-job command))
+     (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -72,6 +72,7 @@
                   [("api" "mathjs") #:method "post" ->mathjs-endpoint]
                   [("api" "translate") #:method "post" translate-endpoint]
                   [("api" "explanations") #:method "post" explanations-endpoint]
+                  [("api" "explanations-start") #:method "post" explanations-start-endpoint]
                   [((hash-arg) (string-arg)) generate-page]
                   [("results.json") generate-report]))
 
@@ -434,6 +435,24 @@
                                            #:timeline-disabled? #t))
                              (define id (start-job command))
                              (wait-for-job id))))
+
+(define explanations-start-endpoint
+  (post-with-json-response (lambda (post-data)
+                             (define formula-str (hash-ref post-data 'formula))
+                             (define formula (read-syntax 'web (open-input-string formula-str)))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (define test (parse-test formula))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'explanations
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define job-id (start-job command))
+                             (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define analyze-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -66,6 +66,7 @@
                   [("api" "exacts") #:method "post" exacts-endpoint]
                   [("api" "exacts-start") #:method "post" exacts-start-endpoint]
                   [("api" "calculate") #:method "post" calculate-endpoint]
+                  [("api" "calculate-start") #:method "post" calculate-start-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
                   [("api" "mathjs") #:method "post" ->mathjs-endpoint]
                   [("api" "translate") #:method "post" translate-endpoint]
@@ -523,6 +524,24 @@
                                            #:timeline-disabled? #t))
                              (define id (start-job command))
                              (wait-for-job id))))
+
+(define calculate-start-endpoint
+  (post-with-json-response (lambda (post-data)
+                             (define formula
+                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (define test (parse-test formula))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'evaluate
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define job-id (start-job command))
+                             (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define local-error-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -60,6 +60,7 @@
                   [("api" "analyze") #:method "post" analyze-endpoint]
                   [("api" "analyze-start") #:method "post" analyze-start-endpoint]
                   [("api" "localerror") #:method "post" local-error-endpoint]
+                  [("api" "localerror-start") #:method "post" local-error-start-endpoint]
                   [("api" "alternatives") #:method "post" alternatives-endpoint]
                   [("api" "exacts") #:method "post" exacts-endpoint]
                   [("api" "calculate") #:method "post" calculate-endpoint]
@@ -521,6 +522,25 @@
                                            #:timeline-disabled? #t))
                              (define id (start-job command))
                              (wait-for-job id))))
+
+(define local-error-start-endpoint
+  (post-with-json-response (lambda (post-data)
+                             (define formula
+                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (define test (parse-test formula))
+                             (define expr (prog->fpcore (test-input test)))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'local-error
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define job-id (start-job command))
+                             (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define alternatives-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -62,6 +62,7 @@
                   [("api" "localerror") #:method "post" local-error-endpoint]
                   [("api" "localerror-start") #:method "post" local-error-start-endpoint]
                   [("api" "alternatives") #:method "post" alternatives-endpoint]
+                  [("api" "alternatives-start") #:method "post" alternatives-start-endpoint]
                   [("api" "exacts") #:method "post" exacts-endpoint]
                   [("api" "calculate") #:method "post" calculate-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
@@ -559,6 +560,24 @@
                                            #:timeline-disabled? #t))
                              (define id (start-job command))
                              (wait-for-job id))))
+
+(define alternatives-start-endpoint
+  (post-with-json-response (lambda (post-data)
+                             (define formula
+                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (define test (parse-test formula))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'alternatives
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define job-id (start-job command))
+                             (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -64,6 +64,7 @@
                   [("api" "alternatives") #:method "post" alternatives-endpoint]
                   [("api" "alternatives-start") #:method "post" alternatives-start-endpoint]
                   [("api" "exacts") #:method "post" exacts-endpoint]
+                  [("api" "exacts-start") #:method "post" exacts-start-endpoint]
                   [("api" "calculate") #:method "post" calculate-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
                   [("api" "mathjs") #:method "post" ->mathjs-endpoint]
@@ -486,6 +487,24 @@
                                            #:timeline-disabled? #t))
                              (define id (start-job command))
                              (wait-for-job id))))
+
+(define exacts-start-endpoint
+  (post-with-json-response (lambda (post-data)
+                             (define formula
+                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                             (define sample (hash-ref post-data 'sample))
+                             (define seed (hash-ref post-data 'seed #f))
+                             (define test (parse-test formula))
+                             (define pcontext (json->pcontext sample (test-context test)))
+                             (define command
+                               (create-job 'exacts
+                                           test
+                                           #:seed seed
+                                           #:pcontext pcontext
+                                           #:profile? #f
+                                           #:timeline-disabled? #t))
+                             (define job-id (start-job command))
+                             (hasheq 'job job-id 'path (make-path job-id)))))
 
 (define calculate-endpoint
   (post-with-json-response (lambda (post-data)


### PR DESCRIPTION
This PR duplicates the API's Currently used by Odyessey to have a different async calling pattern. Where you start the job and then can use `check-status` to see if the job has been completed then use a new `results` API to retrieve the information. 

While I'm not sure if the async version of the API is a value add this didn't take long to add and allows for flexibility to experiment with how Odyessy manages jobs sent to Herbie as this has been talked about as one possible advantage of the new server design. However, I do think the `results` API could be useful for re-retrieving information from a job you know has been completed.

An example of how to call these new API's can be found in the `testAsyncAPI` function in the updated `testApi.mjs` file.

Very open to different API names as I just copied the convention that `improve` and `improve-start` used. 

Let me know your thoughts and if I should make a PR in Odyessy using these new APIs.