### PR TITLE
Fix body limit for det44 benchmark.

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -11,7 +11,8 @@
          web-server/dispatch/extend
          web-server/http/bindings
          web-server/configuration/responders
-         web-server/managers/none)
+         web-server/managers/none
+         web-server/safety-limits)
 
 (require "../utils/common.rkt"
          "../config.rkt"
@@ -603,6 +604,9 @@
   (serve/servlet dispatch
                  #:listen-ip (if public #f "127.0.0.1")
                  #:port port
+                 #:safety-limits
+                 (make-safety-limits #:max-request-body-length
+                                     (* 5 1024 1024)) ; 5 mb body size for det44 bench mark.
                  #:servlet-current-directory (current-directory)
                  #:manager (create-none-manager #f)
                  #:command-line? true


### PR DESCRIPTION
This PR fixes an [Issue](https://github.com/herbie-fp/odyssey/issues/94) in Odyessy. Which causes submitting the det44 benchmark to fail with `Connection error: read-bindings: body length exceeds limit`. 

I have bumped the [max body size ](https://docs.racket-lang.org/web-server-internal/dispatch-server-unit.html#%28def._%28%28lib._web-server%2Fsafety-limits..rkt%29._safety-limits~3f%29%29)to 5mb. I don't know if this is a good long-term decision but it allows Odyessy to work on expressions like det44 which uses 3.3mb for a `/alternatives` request.



