### PR TITLE
New egg-herbie interface

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -93,7 +93,8 @@
   (define bstr (make-bytes len))
   (memcpy bstr p len)
   (destroy_string p)
-  (sequence->list (in-port read (open-input-bytes bstr))))
+  (for/list ([datum (in-port read (open-input-bytes bstr))])
+    datum))
 
 ;; FFI type that converts Rust-allocated C-style strings
 ;; to Racket strings, automatically freeing the Rust-side allocation.
@@ -167,7 +168,7 @@
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))
 
-;; node number -> s-expr string
+;; egraph -> id -> (listof expr)
 (define-eggmath egraph_get_simplest
                 (_fun _egraph-pointer
                       _uint ;; node id
@@ -175,7 +176,7 @@
                       ->
                       _rust/datum)) ;; expr
 
-;; node number -> (s-expr string) string
+;; egraph -> id -> string -> (listof expr)
 (define-eggmath egraph_get_variants
                 (_fun _egraph-pointer
                       _uint ;; node id
@@ -189,7 +190,7 @@
                       _string/utf-8 ;; expr1
                       _string/utf-8 ;; expr2
                       ->
-                      _rust/data)) ;; listof expr
+                      _rust/string)) ;; string
 
 (define-eggmath egraph_get_cost
                 (_fun _egraph-pointer

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -171,6 +171,7 @@
 
 (define-eggmath egraph_is_unsound_detected (_fun _egraph-pointer -> _stdbool))
 
+;; Runs the egraph with a set of rules, returning the statistics of the run.
 (define-eggmath egraph_run
                 (_fun _egraph-pointer ;; egraph
                       (ffi-rules : (_list i _FFIRule-pointer)) ;; ffi rules
@@ -185,7 +186,15 @@
                       ->
                       (iterations : _EGraphIter-pointer) ;; array of _EgraphIter structs
                       ->
-                      (values iterations iterations-length iterations-ptr)))
+                      (begin
+                        (define iter-data
+                          (for/list ([i (in-range iterations-length)])
+                            (define ptr (ptr-add iterations i _EGraphIter))
+                            (hash 'nodes (EGraphIter-numnodes ptr)
+                                  'eclasses (EGraphIter-numeclasses ptr)
+                                  'time (EGraphIter-time ptr))))
+                        (destroy_egraphiters iterations-ptr)
+                        iter-data)))
 
 ;; gets the stop reason as an integer
 (define-eggmath egraph_get_stop_reason (_fun _egraph-pointer -> _uint))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -190,9 +190,12 @@
                         (define iter-data
                           (for/list ([i (in-range iterations-length)])
                             (define ptr (ptr-add iterations i _EGraphIter))
-                            (hash 'nodes (EGraphIter-numnodes ptr)
-                                  'eclasses (EGraphIter-numeclasses ptr)
-                                  'time (EGraphIter-time ptr))))
+                            (hash 'nodes
+                                  (EGraphIter-numnodes ptr)
+                                  'eclasses
+                                  (EGraphIter-numeclasses ptr)
+                                  'time
+                                  (EGraphIter-time ptr))))
                         (destroy_egraphiters iterations-ptr)
                         iter-data)))
 
@@ -219,7 +222,7 @@
                       _uint ;; node id
                       _rust/datum ;; original expr
                       ->
-                      _rust/datum)) ;; listof expr
+                      _rust/data)) ;; listof expr
 
 ;; egraph -> string -> string -> string
 (define-eggmath egraph_get_proof

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -14,14 +14,15 @@
          egraph_find
          egraph_get_simplest
          egraph_get_variants
-         _EGraphIter
-         destroy_egraphiters
          egraph_get_cost
          egraph_is_unsound_detected
          egraph_get_times_applied
          egraph_get_proof
          (struct-out EGraphIter)
-         (struct-out FFIRule))
+         _EGraphIter
+         destroy_egraphiters
+         (struct-out FFIRule)
+         make-ffi-rule)
 
 (define-runtime-path libeggmath-path
                      (build-path "target/release"
@@ -59,22 +60,21 @@
 ; Checks for a condition on MacOS if x86 Racket is being used on an ARM mac.
 (define-ffi-definer define-eggmath (ffi-lib libeggmath-path #:fail handle-eggmath-import-failure))
 
-; GC'able egraph
-; If Racket GC can prove unreachable, `egraph_destroy` will be called
-(define _egraph-pointer
-  (_cpointer 'egraph
-             #f
-             #f
-             (lambda (p)
-               (register-finalizer p egraph_destroy)
-               p)))
-
 ;; Frees a Rust-allocated C-string
 (define-eggmath destroy_string (_fun _pointer -> _void))
 
 ;; Gets the length of a Rust-allocated C-string in bytes,
 ;; excluding the nul terminator.
 (define-eggmath string_length (_fun _pointer -> _uint32))
+
+;; Converts a Racket string to a C-style string.
+(define (string->_rust/string s #:raw? [raw? #f])
+  (define bstr (string->bytes/utf-8 s))
+  (define n (bytes-length bstr))
+  (define p (malloc (if raw? 'raw 'atomic) (add1 n)))
+  (memcpy p bstr n)
+  (ptr-set! p _byte n 0)
+  p)
 
 ;; Converts a non-NULL, Rust-allocated C-string to a Racket string,
 ;; freeing the Rust string.
@@ -100,14 +100,14 @@
 ;; to Racket strings, automatically freeing the Rust-side allocation.
 (define _rust/string
   (make-ctype _pointer
-              (lambda (x) (and x (string->bytes/utf-8 x)))
+              (lambda (x) (and x (string->_rust/string x)))
               (lambda (x) (and x (_rust/string->string x)))))
 
 ;; FFI type that converts Rust-allocated C-style strings
 ;; to a Racket datum via `read`, automatically freeing the Rust-side allocation.
 (define _rust/datum
   (make-ctype _pointer
-              (lambda (x) (and x (string->bytes/utf-8 (~a x))))
+              (lambda (x) (and x (string->_rust/string (~a x))))
               (lambda (x) (and x (first (_rust/string->data x))))))
 
 ;; FFI type that converts Rust-allocated C-style strings
@@ -115,7 +115,7 @@
 ;; automatically freeing the Rust-side allocation.
 (define _rust/data
   (make-ctype _pointer
-              (lambda (x) (and x (string->bytes/utf-8 (apply string-join (map ~a x)))))
+              (lambda (_) (error '_rust/data "cannot be used as an input type"))
               (lambda (x) (and x (_rust/string->data x)))))
 
 ; Egraph iteration data
@@ -123,20 +123,51 @@
 ; Must call `destroy_egraphiters` to free.
 (define-cstruct _EGraphIter ([numnodes _uint] [numeclasses _uint] [time _double]) #:malloc-mode 'raw)
 
-; Rewrite rule
-; Not managed by Racket GC.
-; Must call `free` on struct and fields
+;; Frees an array of _EgraphIter structs
+(define-eggmath destroy_egraphiters (_fun _pointer -> _void))
+
+;; Rewrite rule that can be passed over the FFI boundary.
+;; Must be manually freed.
 (define-cstruct _FFIRule ([name _pointer] [left _pointer] [right _pointer]) #:malloc-mode 'raw)
 
-;;  -> a pointer to an egraph
+;; Constructs for `_FFIRule` struct.
+(define (make-ffi-rule name lhs rhs)
+  (define name* (string->_rust/string (~a name) #:raw? #t))
+  (define lhs* (string->_rust/string (~a lhs) #:raw? #t))
+  (define rhs* (string->_rust/string (~a rhs) #:raw? #t))
+  (define p (make-FFIRule name* lhs* rhs*))
+  (register-finalizer p free-ffi-rule)
+  p)
+
+;; Frees a `_FFIRule` struct.
+(define (free-ffi-rule rule)
+  (free (FFIRule-name rule))
+  (free (FFIRule-left rule))
+  (free (FFIRule-right rule))
+  (free rule))
+
+; GC'able egraph
+; If Racket GC can prove unreachable, `egraph_destroy` will be called
+(define _egraph-pointer
+  (_cpointer 'egraph
+             #f
+             #f
+             (lambda (p)
+               (register-finalizer p egraph_destroy)
+               p)))
+
+;; Constructs an e-graph instances.
 (define-eggmath egraph_create (_fun -> _egraph-pointer))
 
+;; Frees an e-graph instance.
 (define-eggmath egraph_destroy (_fun _egraph-pointer -> _void))
 
-;; egraph pointer, s-expr string -> node number
-(define-eggmath egraph_add_expr (_fun _egraph-pointer _string/utf-8 -> _uint))
+;; Copies an e-graph instance.
+(define-eggmath egraph_copy (_fun _egraph-pointer -> _egraph-pointer))
 
-(define-eggmath destroy_egraphiters (_fun _pointer -> _void))
+;; Adds an expression to the e-graph.
+;; egraph -> expr -> id
+(define-eggmath egraph_add_expr (_fun _egraph-pointer _rust/datum -> _uint))
 
 (define-eggmath egraph_is_unsound_detected (_fun _egraph-pointer -> _stdbool))
 
@@ -152,12 +183,9 @@
                       _stdbool ;; simple scheduler?
                       _stdbool ;; constant folding enabled?
                       ->
-                      (iterations : _EGraphIter-pointer)
+                      (iterations : _EGraphIter-pointer) ;; array of _EgraphIter structs
                       ->
                       (values iterations iterations-length iterations-ptr)))
-
-;; creates a fresh runner from an existing egraph
-(define-eggmath egraph_copy (_fun _egraph-pointer -> _egraph-pointer))
 
 ;; gets the stop reason as an integer
 (define-eggmath egraph_get_stop_reason (_fun _egraph-pointer -> _uint))
@@ -180,15 +208,15 @@
 (define-eggmath egraph_get_variants
                 (_fun _egraph-pointer
                       _uint ;; node id
-                      _string/utf-8 ;; original expr
+                      _rust/datum ;; original expr
                       ->
-                      _rust/data)) ;; listof expr
+                      _rust/datum)) ;; listof expr
 
 ;; egraph -> string -> string -> string
 (define-eggmath egraph_get_proof
                 (_fun _egraph-pointer ;; egraph
-                      _string/utf-8 ;; expr1
-                      _string/utf-8 ;; expr2
+                      _rust/datum ;; expr1
+                      _rust/datum ;; expr2
                       ->
                       _rust/string)) ;; string
 

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -74,7 +74,6 @@ pub unsafe extern "C" fn egraph_add_expr(ptr: *mut Context, expr: *const c_char)
     let mut context = Box::from_raw(ptr);
 
     assert_eq!(context.iteration, 0);
-
     let rec_expr = CStr::from_ptr(expr).to_str().unwrap().parse().unwrap();
     context.runner = context.runner.with_expr(&rec_expr);
     let id = usize::from(*context.runner.roots.last().unwrap())

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -4,7 +4,7 @@ pub mod math;
 
 use egg::{BackoffScheduler, Extractor, Id, Language, SimpleScheduler, StopReason, Symbol};
 use indexmap::IndexMap;
-use libc::c_void;
+use libc::{c_void, strlen};
 use math::*;
 
 use std::cmp::min;
@@ -45,6 +45,11 @@ pub unsafe extern "C" fn destroy_egraphiters(ptr: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn destroy_string(ptr: *mut c_char) {
     drop(CString::from_raw(ptr))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn string_length(ptr: *const c_char) -> u32 {
+    strlen(ptr) as u32
 }
 
 #[repr(C)]

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -39,9 +39,6 @@
          egg->herbie-dict ; inverse map
          id->spec)) ; map from e-class id to an approx-spec or #f
 
-;; Racket representation of per-iteration runner data
-(struct iteration-data (num-nodes num-eclasses time))
-
 ; Makes a new egraph that is managed by Racket's GC
 (define (make-egraph)
   (egraph-data (egraph_create) (make-hash) (make-hash) (make-hash)))
@@ -85,15 +82,12 @@
       ['backoff #f]
       ['simple #t]
       [_ (error 'egraph-run "unknown scheduler: `~a`" scheduler)]))
-  (define iters
     (egraph_run (egraph-data-egraph-pointer egraph-data)
                 ffi-rules
                 iter_limit
                 node_limit
                 simple_scheduler?
                 const-folding?))
-  (for/list ([data (in-list iters)])
-    (iteration-data (hash-ref data 'nodes) (hash-ref data 'eclasses) (hash-ref data 'time))))
 
 (define (egraph-get-simplest egraph-data node-id iteration ctx)
   (define expr (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -282,19 +282,19 @@
   (*context* (context-extend (*context*) 'z repr))
 
   (define test-exprs
-    (list (cons '(+.f64 y x) (~a '(+.f64 $h0 $h1)))
-          (cons '(+.f64 x y) (~a '(+.f64 $h1 $h0)))
-          (cons '(-.f64 #s(literal 2 binary64) (+.f64 x y)) (~a '(-.f64 2 (+.f64 $h1 $h0))))
+    (list (cons '(+.f64 y x) '(+.f64 $h0 $h1))
+          (cons '(+.f64 x y) '(+.f64 $h1 $h0))
+          (cons '(-.f64 #s(literal 2 binary64) (+.f64 x y)) '(-.f64 2 (+.f64 $h1 $h0)))
           (cons '(-.f64 z (+.f64 (+.f64 y #s(literal 2 binary64)) x))
-                (~a '(-.f64 $h2 (+.f64 (+.f64 $h0 2) $h1))))
-          (cons '(*.f64 x y) (~a '(*.f64 $h1 $h0)))
-          (cons '(+.f64 (*.f64 x y) #s(literal 2 binary64)) (~a '(+.f64 (*.f64 $h1 $h0) 2)))
-          (cons '(cos.f32 (PI.f32)) (~a '(cos.f32 (PI.f32))))
-          (cons '(if (TRUE) x y) (~a '(if (TRUE) $h1 $h0)))))
+                '(-.f64 $h2 (+.f64 (+.f64 $h0 2) $h1)))
+          (cons '(*.f64 x y) '(*.f64 $h1 $h0))
+          (cons '(+.f64 (*.f64 x y) #s(literal 2 binary64)) '(+.f64 (*.f64 $h1 $h0) 2))
+          (cons '(cos.f32 (PI.f32)) '(cos.f32 (PI.f32)))
+          (cons '(if (TRUE) x y) '(if (TRUE) $h1 $h0))))
 
   (let ([egg-graph (make-egraph)])
     (for ([(in expected-out) (in-dict test-exprs)])
-      (define out (~a (expr->egg-expr in egg-graph (*context*))))
+      (define out (expr->egg-expr in egg-graph (*context*)))
       (define computed-in (egg-expr->expr out egg-graph (context-repr (*context*))))
       (check-equal? out expected-out)
       (check-equal? computed-in in)))
@@ -323,7 +323,7 @@
   (let ([egg-graph (make-egraph)])
     (for ([expr extended-expr-list])
       (define egg-expr (expr->egg-expr expr egg-graph (*context*)))
-      (check-equal? (egg-expr->expr (~a egg-expr) egg-graph (context-repr (*context*))) expr))))
+      (check-equal? (egg-expr->expr egg-expr egg-graph (context-repr (*context*))) expr))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Proofs

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -82,12 +82,12 @@
       ['backoff #f]
       ['simple #t]
       [_ (error 'egraph-run "unknown scheduler: `~a`" scheduler)]))
-    (egraph_run (egraph-data-egraph-pointer egraph-data)
-                ffi-rules
-                iter_limit
-                node_limit
-                simple_scheduler?
-                const-folding?))
+  (egraph_run (egraph-data-egraph-pointer egraph-data)
+              ffi-rules
+              iter_limit
+              node_limit
+              simple_scheduler?
+              const-folding?))
 
 (define (egraph-get-simplest egraph-data node-id iteration ctx)
   (define expr (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -127,16 +127,12 @@
   iteration-data)
 
 (define (egraph-get-simplest egraph-data node-id iteration ctx)
-  (define ptr (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))
-  (define str (cast ptr _pointer _string/utf-8))
-  (destroy_string ptr)
+  (define str (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))
   (egg-expr->expr str egraph-data (context-repr ctx)))
 
 (define (egraph-get-variants egraph-data node-id orig-expr ctx)
   (define expr-str (~a (expr->egg-expr orig-expr egraph-data ctx)))
-  (define ptr (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id expr-str))
-  (define str (cast ptr _pointer _string/utf-8))
-  (destroy_string ptr)
+  (define str (egraph_get_variants (egraph-data-egraph-pointer egraph-data) node-id expr-str))
   (egg-exprs->exprs str egraph-data (context-repr ctx)))
 
 (define (egraph-is-unsound-detected egraph-data)
@@ -177,9 +173,7 @@
 (define (egraph-get-proof egraph-data expr goal ctx)
   (define egg-expr (~a (expr->egg-expr expr egraph-data ctx)))
   (define egg-goal (~a (expr->egg-expr goal egraph-data ctx)))
-  (define pointer (egraph_get_proof (egraph-data-egraph-pointer egraph-data) egg-expr egg-goal))
-  (define res (cast pointer _pointer _string/utf-8))
-  (destroy_string pointer)
+  (define res (egraph_get_proof (egraph-data-egraph-pointer egraph-data) egg-expr egg-goal))
   (cond
     [(< (string-length res) 10000)
      (define converted (egg-exprs->exprs res egraph-data (context-repr ctx)))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -172,12 +172,15 @@
 (define (egraph-get-proof egraph-data expr goal ctx)
   (define egg-expr (~a (expr->egg-expr expr egraph-data ctx)))
   (define egg-goal (~a (expr->egg-expr goal egraph-data ctx)))
-  (define exprs (egraph_get_proof (egraph-data-egraph-pointer egraph-data) egg-expr egg-goal))
-  (define converted
-    (for/list ([expr (in-list exprs)])
-      (egg-expr->expr expr egraph-data (context-repr ctx))))
-  (define expanded (expand-proof converted (box (*proof-max-length*))))
-  (if (member #f expanded) #f expanded))
+  (define str (egraph_get_proof (egraph-data-egraph-pointer egraph-data) egg-expr egg-goal))
+  (cond
+    [(<= (string-length str) (*proof-max-string-length*))
+     (define converted
+       (for/list ([expr (in-port read (open-input-string str))])
+         (egg-expr->expr expr egraph-data (context-repr ctx))))
+     (define expanded (expand-proof converted (box (*proof-max-length*))))
+     (if (member #f expanded) #f expanded)]
+    [else #f]))
 
 ;; Racket representation of per-iteration runner data
 (struct iteration-data (num-nodes num-eclasses time))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -93,9 +93,7 @@
                 simple_scheduler?
                 const-folding?))
   (for/list ([data (in-list iters)])
-    (iteration-data (hash-ref data 'nodes)
-                    (hash-ref data 'eclasses)
-                    (hash-ref data 'time))))
+    (iteration-data (hash-ref data 'nodes) (hash-ref data 'eclasses) (hash-ref data 'time))))
 
 (define (egraph-get-simplest egraph-data node-id iteration ctx)
   (define expr (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))
@@ -420,7 +418,8 @@
                        (lambda ()
                          (for/list ([egg-rule (in-list (rule->egg-rules rule))])
                            (define name (rule-name egg-rule))
-                           (define ffi-rule (make-ffi-rule name (rule-input egg-rule) (rule-output egg-rule)))
+                           (define ffi-rule
+                             (make-ffi-rule name (rule-input egg-rule) (rule-output egg-rule)))
                            (hash-set! (*canon-names*) name (rule-name rule))
                            (cons egg-rule ffi-rule)))))
           (for-each sow egg&ffi-rules))))


### PR DESCRIPTION
This PR moves all unsafe FFI code into the `egg-herbie` package and makes a number of improvements. It adds three new FFI types to convert between Rust strings and Racket data more efficiently. In addition, the `egg-herbie` interface accepts Racket data rather than strings.

### New FFI types

| Name             | Racket type  | Rust type          |
| --------------  | -------------- |----------------- |
| `_rust/string`  | `string?`         | `*const c_char`  | 
| `_rust/datum` | `any/c`           | `*const c_char`  |
| `_rust/data`    | `(listof any/c)` | `*const c_char`  |

### `_rust/string`

Rust-to-Racket: converts to a Racket string by first copying the string to a Racket byte string and then converting to a Racket string using `byte->string/utf-8`. Racket-to-Rust: converts to a byte string using `string->bytes/utf-8` and then copies data into a manually allocated array (this is just `make-raw-string`)

### `_rust/datum`

Rust-to-Racket: converts to a Racket string by first copying the string to a Racket byte string. Then interprets the string as Racket data by calling `read` on a byte port created with `open-input-bytes`. Racket-to-Rust: converts to a string via `~a` and then follows the same steps as `_rust/string`.

### `_rust/data`

Rust-to-Racket: same as `_rust/datum` but calls `read` repeatedly, returning a list. Racket-to-Rust: unsupported. 

### Example usage
```
Welcome to Racket v8.13 [cs].
> (require egg-herbie)
> (define e (egraph_create))
> (egraph_add_expr e '(+ x 1))
2
> (egraph_add_expr e '(+ y 2))
5
> (define r (make-ffi-rule 'add-commutes '(+ ?a ?b) '(+ ?b ?a)))
> (egraph_run e (list r) 10 10000 #t #t)
'(#hash((eclasses . 6) (nodes . 6) (time . 4.4839e-5))
  #hash((eclasses . 6) (nodes . 8) (time . 9.432e-6)))
> (egraph_serialize e)
'((0 x) (5 (+ 3 4) (+ 4 3)) (2 (+ 0 1) (+ 1 0)) (4 2) (1 1) (3 y))
> (egraph_get_simplest e 2 1)
'(+ x 1)
```