### PR TITLE
Faster e-graph serialization strategy and refactors

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -242,9 +242,12 @@
                         (destroy_string p)
                         (cons (or (string->number s) (string->symbol s)) v))))
 
-; egraph -> id -> (listof (cons symbol u32vector))
+; egraph -> id -> (vectorof (cons symbol u32vector))
 (define (egraph_get_eclass egg-ptr id)
-  (build-list (egraph_eclass_size egg-ptr id) (lambda (i) (egraph_get_node egg-ptr id i))))
+  (define n (egraph_eclass_size egg-ptr id))
+  (for/vector #:length n
+              ([i (in-range n)])
+    (egraph_get_node egg-ptr id i)))
 
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -231,23 +231,31 @@
  egraph_get_eclasses
  (_fun [e : _egraph-pointer] [v : _u32vector = (make-u32vector (egraph_size e))] -> _void -> v))
 
-;; egraph -> id -> u32 -> (values (or symbol number) u32vector)
+;; egraph -> id -> u32 -> (or symbol? number? (cons symbol u32vector))
+;; UNSAFE: `v` must be large enough to contain the child ids
 (define-eggmath egraph_get_node
                 (_fun [e : _egraph-pointer]
                       [id : _uint32]
                       [idx : _uint32]
-                      [v : _u32vector = (make-u32vector (egraph_enode_size e id idx))]
+                      [v : _u32vector]
                       ->
                       [f : _rust/string]
                       ->
-                      (cons (or (string->number f) (string->symbol f)) v)))
+                      (if (zero? (u32vector-length v))
+                          (or (string->number f) (string->symbol f))
+                          (cons (string->symbol f) v))))
+; u32vector
+(define empty-u32vec (make-u32vector 0))
 
-; egraph -> id -> (vectorof (cons symbol u32vector))
+; egraph -> id -> (vectorof (or symbol? number? (cons symbol u32vector)))
 (define (egraph_get_eclass egg-ptr id)
   (define n (egraph_eclass_size egg-ptr id))
   (for/vector #:length n
               ([i (in-range n)])
-    (egraph_get_node egg-ptr id i)))
+    (define node-size (egraph_enode_size egg-ptr id i))
+    (if (zero? node-size)
+        (egraph_get_node egg-ptr id i empty-u32vec)
+        (egraph_get_node egg-ptr id i (make-u32vector node-size)))))
 
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -238,11 +238,9 @@
                       [idx : _uint32]
                       [v : _u32vector = (make-u32vector (egraph_enode_size e id idx))]
                       ->
-                      [p : _pointer]
+                      [f : _rust/string]
                       ->
-                      (let ([s (cast p _pointer _string*/utf-8)])
-                        (destroy_string p)
-                        (cons (or (string->number s) (string->symbol s)) v))))
+                      (cons (or (string->number f) (string->symbol f)) v)))
 
 ; egraph -> id -> (vectorof (cons symbol u32vector))
 (define (egraph_get_eclass egg-ptr id)

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -223,6 +223,9 @@
 ;; egraph -> id -> uint
 (define-eggmath egraph_eclass_size (_fun _egraph-pointer _uint -> _uint))
 
+;; egraph -> id -> idx -> uint
+(define-eggmath egraph_enode_size (_fun _egraph-pointer _uint _uint -> _uint))
+
 ;; egraph -> u32vector
 (define-eggmath
  egraph_get_eclasses
@@ -233,8 +236,7 @@
                 (_fun [e : _egraph-pointer]
                       [id : _uint32]
                       [idx : _uint32]
-                      [len : (_ptr o _uint32)]
-                      [v : (_ptr o (_u32vector o len))]
+                      [v : _u32vector = (make-u32vector (egraph_enode_size e id idx))]
                       ->
                       [p : _pointer]
                       ->

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -268,10 +268,14 @@ pub unsafe extern "C" fn egraph_find(ptr: *mut Context, id: usize) -> u32 {
 pub unsafe extern "C" fn egraph_serialize(ptr: *mut Context) -> *const c_char {
     // Safety: `ptr` was box allocated by `egraph_create`
     let context = ManuallyDrop::new(Box::from_raw(ptr));
+    let mut ids: Vec<Id> = context.runner.egraph.classes().map(|c| c.id).collect();
+    ids.sort();
+
     // Iterate through the eclasses and print each eclass
     let mut s = String::from("(");
-    for c in context.runner.egraph.classes() {
-        s.push_str(&format!("({}", c.id));
+    for id in ids {
+        let c = &context.runner.egraph[id];
+        s.push_str(&format!("({}", id));
         for node in &c.nodes {
             if matches!(node, Math::Symbol(_) | Math::Constant(_)) {
                 s.push_str(&format!(" {}", node));

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -320,7 +320,12 @@ pub unsafe extern "C" fn egraph_enode_size(ptr: *mut Context, id: u32, idx: u32)
 #[no_mangle]
 pub unsafe extern "C" fn egraph_get_eclasses(ptr: *mut Context, ids_ptr: *mut u32) {
     let context = ManuallyDrop::new(Box::from_raw(ptr));
-    let mut ids: Vec<u32> = context.runner.egraph.classes().map(|c| usize::from(c.id) as u32).collect();
+    let mut ids: Vec<u32> = context
+        .runner
+        .egraph
+        .classes()
+        .map(|c| usize::from(c.id) as u32)
+        .collect();
     ids.sort();
 
     for (i, id) in ids.iter().enumerate() {

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -314,10 +314,13 @@ pub unsafe extern "C" fn egraph_enode_size(ptr: *mut Context, id: u32, idx: u32)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_get_eclasses(ptr: *mut Context, ids: *mut u32) {
+pub unsafe extern "C" fn egraph_get_eclasses(ptr: *mut Context, ids_ptr: *mut u32) {
     let context = ManuallyDrop::new(Box::from_raw(ptr));
-    for (i, c) in context.runner.egraph.classes().enumerate() {
-        std::ptr::write(ids.offset(i as isize), usize::from(c.id) as u32);
+    let mut ids: Vec<u32> = context.runner.egraph.classes().map(|c| usize::from(c.id) as u32).collect();
+    ids.sort();
+
+    for (i, id) in ids.iter().enumerate() {
+        std::ptr::write(ids_ptr.offset(i as isize), *id);
     }
 }
 

--- a/infra/convert-demo.rkt
+++ b/infra/convert-demo.rkt
@@ -34,7 +34,10 @@
   (define exprs-unfiltered
     (for/list ([test tests])
       (read-expr (hash-ref test 'input) is-version-10)))
-  (define exprs (for/set ([expr exprs-unfiltered] #:when (not (set-member? existing-set expr))) expr))
+  (define exprs
+    (for/set ([expr exprs-unfiltered]
+              #:when (not (set-member? existing-set expr)))
+      expr))
   (for ([expr (in-set exprs)])
     (fprintf output-file "~a\n" (make-fpcore expr)))
   exprs)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -566,7 +566,17 @@
      (list 'if (lookup cond cond-type) (lookup ift type) (lookup iff type))]
     [else
      (define itypes (if (impl-exists? f) (impl-info f 'itype) (operator-info f 'itype)))
-     (cons f (map lookup (u32vector->list ids) itypes))]))
+     ; unsafe since we don't check that |itypes| = |ids|
+     ; optimize for common cases to avoid extra allocations
+     (cons f
+           (match itypes
+             [(list t1) (list (lookup (u32vector-ref ids 0) t1))]
+             [(list t1 t2) (list (lookup (u32vector-ref ids 0) t1) (lookup (u32vector-ref ids 1) t2))]
+             [(list t1 t2 t3)
+              (list (lookup (u32vector-ref ids 0) t1)
+                    (lookup (u32vector-ref ids 1) t2)
+                    (lookup (u32vector-ref ids 2) t3))]
+             [_ (map lookup (u32vector->list ids) itypes)]))]))
 
 ;; Splits untyped eclasses into typed eclasses.
 ;; Nodes are duplicated across their possible types.

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -606,11 +606,13 @@
     (hash-ref! type->id type (lambda () (new-eclass eid type))))
 
   ;; extract (untyped) eclass ids as u32vector
-  ;; for each eclass, extract the enodes
-  ;;  <enode> ::= <symbol>
-  ;;            | <number>
-  ;;            | (<symbol> . <u32vector>)
   (for ([eid (in-u32vector (egraph-eclasses egraph-data))])
+    ;; for each eclass, extract the enodes
+    ;;  <enode> ::= <symbol>
+    ;;            | <number>
+    ;;            | (<symbol> . <u32vector>)
+    ;; NOTE: nodes in typed eclasses are reversed relative
+    ;; to their position in untyped eclasses
     (for ([enode (in-vector (egraph-get-eclass egraph-data eid))])
       ; get all possible types for the enode
       ; lookup its correct eclass and add the rebuilt node
@@ -621,7 +623,7 @@
         (define eclass (hash-ref id->eclass id))
         (set-box! eclass (cons enode* (unbox eclass))))))
 
-  (define eclasses (list->vector (map (compose reverse unbox) (reverse eclass-boxes))))
+  (define eclasses (list->vector (map unbox (reverse eclass-boxes))))
   (define types (list->vector (reverse eclass-types)))
   (values eclasses types egg-id->id))
 

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -210,14 +210,11 @@
   (define ptr (egraph-data-egraph-pointer egraph-data))
   (define egg->herbie (egraph-data-egg->herbie-dict egraph-data))
   (define eclass (egraph_get_eclass ptr id))
+  ; need to fix up any constant operators
   (for ([enode (in-vector eclass)]
         [i (in-naturals)])
-    (match enode
-      [(cons (? number? n) _) (vector-set! eclass i n)] ; number
-      [(cons (? symbol? x) (? u32vector-empty?))
-       (when (hash-has-key? egg->herbie x) ; variable
-         (vector-set! eclass i x))]
-      [_ (void)])) ; everything else
+    (when (and (symbol? enode) (not (hash-has-key? egg->herbie enode)))
+      (vector-set! eclass i (cons enode (make-u32vector 0)))))
   eclass)
 
 (define (egraph-find egraph-data id)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1,7 +1,13 @@
 #lang racket
 
 (require egg-herbie
-         (only-in ffi/vector make-u32vector u32vector-set! list->u32vector))
+         (only-in ffi/vector
+                  make-u32vector
+                  u32vector-length
+                  u32vector-set!
+                  u32vector-ref
+                  list->u32vector
+                  u32vector->list))
 
 (require "programs.rkt"
          "rules.rkt"
@@ -612,13 +618,13 @@
     (hash-ref! type->id type (lambda () (new-eclass eid type))))
 
   ;; extract (untyped) eclass ids as u32vector
+  ;; for each eclass, extract the enodes
+  ;;  <enode> ::= <symbol>
+  ;;            | <number>
+  ;;            | (<symbol> . <u32vector>)
+  ;; NOTE: nodes in typed eclasses are reversed relative
+  ;; to their position in untyped eclasses
   (for ([eid (in-u32vector (egraph-eclasses egraph-data))])
-    ;; for each eclass, extract the enodes
-    ;;  <enode> ::= <symbol>
-    ;;            | <number>
-    ;;            | (<symbol> . <u32vector>)
-    ;; NOTE: nodes in typed eclasses are reversed relative
-    ;; to their position in untyped eclasses
     (for ([enode (in-vector (egraph-get-eclass egraph-data eid))])
       ; get all possible types for the enode
       ; lookup its correct eclass and add the rebuilt node

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -547,8 +547,8 @@
 (define (enode-type enode egg->herbie)
   (match enode
     [(? number?) (cons 'real (platform-reprs (*active-platform*)))] ; number
-    [(? symbol? x) ; variable
-     (match-define (cons _ repr) (hash-ref egg->herbie x))
+    [(? symbol?) ; variable
+     (match-define (cons _ repr) (hash-ref egg->herbie enode))
      (list repr (representation-type repr))]
     [(cons f _) ; application
      (cond

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -454,12 +454,11 @@
     ; non-expansive rule
     [else (list (rule->egg-rule ru))]))
 
-;; egg rule cache
-(define/reset *egg-rule-cache* (make-hash))
+;; egg rule cache: rule -> (cons/c rule FFI-rule)
+(define/reset *egg-rule-cache* (make-hasheq))
 
-;; Cache mapping name to its canonical rule name
-;; See `*egg-rules*` for details
-(define/reset *canon-names* (make-hash))
+;; Cache mapping (expanded) rule name to its canonical rule name
+(define/reset *canon-names* (make-hasheq))
 
 ;; Tries to look up the canonical name of a rule using the cache.
 ;; Obviously dangerous if the cache is invalid.
@@ -473,7 +472,7 @@
         (for ([rule (in-list rules)])
           (define egg&ffi-rules
             (hash-ref! (*egg-rule-cache*)
-                       (cons (*active-platform*) rule)
+                       rule
                        (lambda ()
                          (for/list ([egg-rule (in-list (rule->egg-rules rule))])
                            (define name (rule-name egg-rule))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -672,10 +672,7 @@
 
   ;; is the e-node well-typed?
   (define (enode-typed? enode)
-    (or (number? enode)
-        (symbol? enode)
-        (and (list? enode)
-             (andmap eclass-well-typed? (cdr enode)))))
+    (or (number? enode) (symbol? enode) (and (list? enode) (andmap eclass-well-typed? (cdr enode)))))
 
   (define (check-typed! dirty?-vec)
     (define dirty? #f)

--- a/src/reports/plot.rkt
+++ b/src/reports/plot.rkt
@@ -20,7 +20,9 @@
          splitpoints->json)
 
 (define (all-same? pts idx)
-  (= 1 (set-count (for/set ([pt pts]) (list-ref pt idx)))))
+  (= 1
+     (set-count (for/set ([pt pts])
+                  (list-ref pt idx)))))
 
 (define (ulps->bits-tenths x)
   (string->number (real->decimal-string (ulps->bits x) 1)))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -26,7 +26,8 @@
 (define (type-name? x)
   (hash-has-key? type-dict x))
 
-(define-syntax-rule (define-type name _ ...) (hash-set! type-dict 'name #t))
+(define-syntax-rule (define-type name _ ...)
+  (hash-set! type-dict 'name #t))
 
 (define-type real)
 (define-type bool)


### PR DESCRIPTION
This PR primarily contributes a new e-graph serialization method. Rather than serialize the entire e-graph as a string, the new strategy is to first extract the e-class ids in a `u32vector`. Then we iterate through each e-class id and serialize the e-class itself where
```
<eclass> ::= #(<enode> ...)
<enode> ::= <symbol>
          | <number>
          | (<symbol> . <u32vector>)
```
Overall, the idea is to have less allocation, at any given time, and less pointer chasing, overall. Local testing using Hamming shows that serialization time decreased from ~90 seconds to ~40 seconds. Across the benchmark suite, `egg-herbie` takes about 30% of total run time.

The PR also includes other small changes for performance, cleanliness, or profiling reasons.