### PR TITLE
Remove the hash table from inside `compute-local-errors`

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -159,8 +159,7 @@
   (define n 0)
   (for/list ([subexprs (in-list subexprss)])
     (for*/hash ([subexpr (in-list subexprs)])
-      (begin0
-          (values subexpr (vector->list (vector-ref errs n)))
+      (begin0 (values subexpr (vector->list (vector-ref errs n)))
         (set! n (add1 n))))))
 
 ;; Compute the local error of every subexpression of `prog`


### PR DESCRIPTION
In days of old, `compute-local-errors` used a hash table to store local error lists; this is wasteful and slow. This PR replaces it with a vector, which should be a lot faster.