### PR TITLE
Fix `Warning: unused variable x`.

### DIFF
--- a/infra/convert-demo.rkt
+++ b/infra/convert-demo.rkt
@@ -34,7 +34,10 @@
   (define exprs-unfiltered
     (for/list ([test tests])
       (read-expr (hash-ref test 'input) is-version-10)))
-  (define exprs (for/set ([expr exprs-unfiltered] #:when (not (set-member? existing-set expr))) expr))
+  (define exprs
+    (for/set ([expr exprs-unfiltered]
+              #:when (not (set-member? existing-set expr)))
+      expr))
   (for ([expr (in-set exprs)])
     (fprintf output-file "~a\n" (make-fpcore expr)))
   exprs)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -398,7 +398,7 @@
      (define best-score
        (if (null? target-cost-score) target-cost-score (apply min (map second target-cost-score))))
 
-     (define end-exprs (hash-ref end 'end-alts))
+     (define end-exprs (hash-ref end 'end-exprs))
      (define end-train-scores (map errors-score (hash-ref end 'end-train-scores)))
      (define end-test-scores (map errors-score (hash-ref end 'end-errors)))
      (define end-costs (hash-ref end 'end-costs))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -435,8 +435,7 @@
                   [target target-cost-score]
                   [result-est end-est-score]
                   [result end-score]
-                  [output
-                   (test-input (parse-test (read-syntax 'web (open-input-string (car end-exprs)))))]
+                  [output (car end-exprs)]
                   [cost-accuracy cost&accuracy])]
     ['failure
      (match-define (list 'exn type _ ...) backend)
@@ -507,6 +506,7 @@
              [(< end-score (+ start-test-score fuzz)) "apx-start"]
              [else "uni-start"])))
 
+     (eprintf "Sendable: ~a\n" (place-message-allowed? end-exprs))
      (struct-copy table-row
                   (dummy-table-row result status link)
                   [start-est start-train-score]

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -506,7 +506,6 @@
              [(< end-score (+ start-test-score fuzz)) "apx-start"]
              [else "uni-start"])))
 
-     (eprintf "Sendable: ~a\n" (place-message-allowed? end-exprs))
      (struct-copy table-row
                   (dummy-table-row result status link)
                   [start-est start-train-score]

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -13,7 +13,6 @@
          "../syntax/read.rkt"
          "../syntax/sugar.rkt"
          "../syntax/load-plugin.rkt"
-         "../syntax/platform.rkt"
          "../utils/alternative.rkt"
          "../utils/common.rkt"
          "../utils/errors.rkt"
@@ -411,17 +410,6 @@
 
 (define (end-hash end repr pcontexts test)
 
-  ; analysis of output expressions
-  (define expr-cost (platform-cost-proc (*active-platform*)))
-  (define-values (end-exprs-c end-train-scores-c end-test-scores-c end-costs-c)
-    (for/lists (l1 l2 l3 l4)
-               ([result end])
-               (match-define (alt-analysis alt train-errors test-errors) result)
-               (values (alt-expr alt)
-                       (errors-score train-errors)
-                       (errors-score test-errors)
-                       (expr-cost (alt-expr alt) repr))))
-
   (define-values (end-alts train-errors end-errors end-costs)
     (for/lists (l1 l2 l3 l4)
                ([analysis end])
@@ -441,8 +429,8 @@
             (real->ordinal (repr->real val repr) repr))
           '())))
 
-  (hasheq 'end-alts ; wrong
-          end-exprs-c
+  (hasheq 'end-exprs
+          (map alt-expr end-alts)
           'end-histories
           alts-histories
           'end-train-scores

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -174,10 +174,9 @@
                    [errs end-errors]
                    [cost end-costs]
                    [history (hash-ref end 'end-histories)])
-          (define formula (read-syntax 'web (open-input-string alt-fpcore)))
-          (define expr (parse-test formula))
+
           (define-values (dropdown body)
-            (render-program (test-input expr) ctx #:ident identifier #:instructions preprocessing))
+            (render-program alt-fpcore ctx #:ident identifier #:instructions preprocessing))
           `(section ([id ,(format "alternative~a" i)] (class "programs"))
                     (h2 "Alternative "
                         ,(~a i)

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -77,7 +77,7 @@
     (for/list ([target targets])
       (alt-cost (alt-analysis-alt target) repr)))
 
-  (define end-alts (hash-ref end 'end-alts))
+  (define end-alts (hash-ref end 'end-exprs))
   (define end-errors (hash-ref end 'end-errors))
   (define end-costs (hash-ref end 'end-costs))
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -77,13 +77,12 @@
     (for/list ([target targets])
       (alt-cost (alt-analysis-alt target) repr)))
 
-  (define end-alts (hash-ref end 'end-exprs))
+  (define end-exprs (hash-ref end 'end-exprs))
   (define end-errors (hash-ref end 'end-errors))
   (define end-costs (hash-ref end 'end-costs))
 
   (define speedup
-    (let ([better (for/list ([alt end-alts]
-                             [err end-errors]
+    (let ([better (for/list ([err end-errors]
                              [cost end-costs]
                              #:when (<= (errors-score err) (errors-score start-error)))
                     (/ start-cost cost))])
@@ -117,7 +116,7 @@
                      (format-accuracy (apply max (map ulps->bits start-error)) repr-bits #:unit "%")
                      (format-accuracy (apply max (map ulps->bits end-error)) repr-bits #:unit "%")))
            ,(render-large "Time" (format-time time))
-           ,(render-large "Alternatives" (~a (length end-alts)))
+           ,(render-large "Alternatives" (~a (length end-exprs)))
            ,(if (*pareto-mode*)
                 (render-large "Speedup"
                               (if speedup (~r speedup #:precision '(= 1)) "N/A")
@@ -148,7 +147,7 @@
                       "?"))
                (div ((class "figure-row"))
                     (svg)
-                    (div (p "Herbie found " ,(~a (length end-alts)) " alternatives:")
+                    (div (p "Herbie found " ,(~a (length end-exprs)) " alternatives:")
                          (table (thead (tr (th "Alternative")
                                            (th ((class "numeric")) "Accuracy")
                                            (th ((class "numeric")) "Speedup")))
@@ -170,13 +169,13 @@
                        ,(render-help "report.html#alternatives"))
                    ,body))
       ,@(for/list ([i (in-naturals 1)]
-                   [alt-fpcore end-alts]
+                   [expr end-exprs]
                    [errs end-errors]
                    [cost end-costs]
                    [history (hash-ref end 'end-histories)])
 
           (define-values (dropdown body)
-            (render-program alt-fpcore ctx #:ident identifier #:instructions preprocessing))
+            (render-program expr ctx #:ident identifier #:instructions preprocessing))
           `(section ([id ,(format "alternative~a" i)] (class "programs"))
                     (h2 "Alternative "
                         ,(~a i)

--- a/src/reports/plot.rkt
+++ b/src/reports/plot.rkt
@@ -20,7 +20,9 @@
          splitpoints->json)
 
 (define (all-same? pts idx)
-  (= 1 (set-count (for/set ([pt pts]) (list-ref pt idx)))))
+  (= 1
+     (set-count (for/set ([pt pts])
+                  (list-ref pt idx)))))
 
 (define (ulps->bits-tenths x)
   (string->number (real->decimal-string (ulps->bits x) 1)))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -26,7 +26,8 @@
 (define (type-name? x)
   (hash-has-key? type-dict x))
 
-(define-syntax-rule (define-type name _ ...) (hash-set! type-dict 'name #t))
+(define-syntax-rule (define-type name _ ...)
+  (hash-set! type-dict 'name #t))
 
 (define-type real)
 (define-type bool)


### PR DESCRIPTION
This PR fixes a misuse of the `parse-test` function that I introduced when adding more concurrency to Herbie with the new server implementation. This surfaced as a false positive `Warning: unused variable x` when running herbie on the expression `sqrt(x + 1) - sqrt(x)`. Thanks to @bksaiki for pointing out this bug.

Note:
- An update to `fmt` on CI so some formatting changes are also included in the diff.
- Clean up of a few unused variables and imports that I noticed well working on this.