### PR TITLE
Prune explicitly uses `eq?`-based hash tables when alternatives are keys

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -37,7 +37,7 @@
 
 (define (make-alt-table pcontext initial-alt ctx)
   (define cost (alt-cost* initial-alt (context-repr ctx)))
-  (alt-table (make-immutable-hasheq (for/list ([(pt ex) (in-pcontext pcontext)]
+  (alt-table (make-immutable-hash (for/list ([(pt ex) (in-pcontext pcontext)]
                                              [err (errors (alt-expr initial-alt) pcontext ctx)])
                                     (cons pt (list (pareto-point cost err (list initial-alt))))))
              (hasheq initial-alt

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -37,14 +37,14 @@
 
 (define (make-alt-table pcontext initial-alt ctx)
   (define cost (alt-cost* initial-alt (context-repr ctx)))
-  (alt-table (make-immutable-hash (for/list ([(pt ex) (in-pcontext pcontext)]
+  (alt-table (make-immutable-hasheq (for/list ([(pt ex) (in-pcontext pcontext)]
                                              [err (errors (alt-expr initial-alt) pcontext ctx)])
                                     (cons pt (list (pareto-point cost err (list initial-alt))))))
-             (hash initial-alt
+             (hasheq initial-alt
                    (for/list ([(pt ex) (in-pcontext pcontext)])
                      pt))
-             (hash initial-alt #f)
-             (hash initial-alt cost)
+             (hasheq initial-alt #f)
+             (hasheq initial-alt cost)
              pcontext
              (list initial-alt)))
 
@@ -192,7 +192,7 @@
          [ppt (in-list curve)]
          [alt (in-list (pareto-point-data ppt))])
     (hash-set! alt->points* alt (cons pt (hash-ref alt->points* alt '()))))
-  (make-immutable-hash (hash->list alt->points*)))
+  (make-immutable-hasheq (hash->list alt->points*)))
 
 (define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point->alts alt->points alt->done? alt->cost pcontext all-alts) atab)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -41,8 +41,8 @@
                                              [err (errors (alt-expr initial-alt) pcontext ctx)])
                                     (cons pt (list (pareto-point cost err (list initial-alt))))))
              (hasheq initial-alt
-                   (for/list ([(pt ex) (in-pcontext pcontext)])
-                     pt))
+                     (for/list ([(pt ex) (in-pcontext pcontext)])
+                       pt))
              (hasheq initial-alt #f)
              (hasheq initial-alt cost)
              pcontext


### PR DESCRIPTION
In a recent PR, the `alt` struct was marked as `#:prefab`. This had the unfortunately side effect of changing `equal?` to be a recursive operation on `alt` instances. This change just makes sure we use `eq?` based tables when we want them.