### PR TITLE
More prune optimizations

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -21,7 +21,7 @@
 
 ;; Public API
 
-(struct alt-table (point->alts alt->points alt->done? alt->cost context all) #:prefab)
+(struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
 
 (define (backup-alt-cost altn)
   (let loop ([expr (alt-expr altn)])
@@ -37,12 +37,12 @@
 
 (define (make-alt-table pcontext initial-alt ctx)
   (define cost (alt-cost* initial-alt (context-repr ctx)))
-  (alt-table (make-immutable-hash (for/list ([(pt ex) (in-pcontext pcontext)]
+  (alt-table (make-immutable-hash (for/list ([idx (in-range (pcontext-length pcontext))]
                                              [err (errors (alt-expr initial-alt) pcontext ctx)])
-                                    (cons pt (list (pareto-point cost err (list initial-alt))))))
+                                    (cons idx (list (pareto-point cost err (list initial-alt))))))
              (hasheq initial-alt
-                     (for/list ([(pt ex) (in-pcontext pcontext)])
-                       pt))
+                     (for/list ([idx (in-range (pcontext-length pcontext))])
+                       idx))
              (hasheq initial-alt #f)
              (hasheq initial-alt cost)
              pcontext
@@ -55,7 +55,7 @@
   (struct-copy alt-table atab [alt->done? new-done-table]))
 
 (define (atab-completed? atab)
-  (andmap (curry hash-ref (alt-table-alt->done? atab)) (hash-keys (alt-table-alt->points atab))))
+  (andmap (curry hash-ref (alt-table-alt->done? atab)) (hash-keys (alt-table-alt->point-idxs atab))))
 
 ;;
 ;; Extracting lists from sets or hash tables
@@ -72,13 +72,13 @@
   (sort altns expr<? #:key alt-expr))
 
 (define (atab-active-alts atab)
-  (order-altns (hash-keys (alt-table-alt->points atab))))
+  (order-altns (hash-keys (alt-table-alt->point-idxs atab))))
 
 (define (atab-all-alts atab)
   (order-altns (alt-table-all atab)))
 
 (define (atab-not-done-alts atab)
-  (define altns (hash-keys (alt-table-alt->points atab)))
+  (define altns (hash-keys (alt-table-alt->point-idxs atab)))
   (define not-done? (negate (curry hash-ref (alt-table-alt->done? atab))))
   (order-altns (filter not-done? altns)))
 
@@ -121,7 +121,7 @@
 (define (worst atab removable)
   ;; Metrics for "worst" alt
   (define (alt-num-points a)
-    (length (hash-ref (alt-table-alt->points atab) a)))
+    (length (hash-ref (alt-table-alt->point-idxs atab) a)))
   (define (alt-done? a)
     (if (hash-ref (alt-table-alt->done? atab) a) 1 0))
   (define (alt-cost a)
@@ -148,19 +148,19 @@
     (hash-remove hash key)))
 
 (define (atab-remove* atab . altns)
-  (match-define (alt-table point->alts alt->points alt->done? alt->cost pctx _) atab)
-  (define pnts->alts*
-    (for/hash ([(pt curve) (in-hash point->alts)])
-      (values pt (pareto-map (curry remq* altns) curve))))
+  (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pctx _) atab)
+  (define pnt-idx->alts*
+    (for/hash ([(idx curve) (in-hash point-idx->alts)])
+      (values idx (pareto-map (curry remq* altns) curve))))
   (struct-copy alt-table
                atab
-               [point->alts pnts->alts*]
-               [alt->points (hash-remove* alt->points altns)]
+               [point-idx->alts pnt-idx->alts*]
+               [alt->point-idxs (hash-remove* alt->point-idxs altns)]
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (atab-eval-altns atab altns ctx)
-  (define errss (flip-lists (batch-errors (map alt-expr altns) (alt-table-context atab) ctx)))
+  (define errss (flip-lists (batch-errors (map alt-expr altns) (alt-table-pcontext atab) ctx)))
   (define costs (map (curryr alt-cost* (context-repr ctx)) altns))
   (values errss costs))
 
@@ -179,40 +179,41 @@
             (values atab progs)
             (values (atab-add-altn atab altn errs cost) (set-add progs prog))))))
   (define atab**
-    (struct-copy alt-table atab* [alt->points (invert-index (alt-table-point->alts atab*))]))
+    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
   (define atab*** (atab-prune atab**))
   (struct-copy alt-table
                atab***
-               [alt->points (invert-index (alt-table-point->alts atab***))]
-               [all (set-union (alt-table-all atab) (hash-keys (alt-table-alt->points atab***)))]))
+               [alt->point-idxs (invert-index (alt-table-point-idx->alts atab***))]
+               [all
+                (set-union (alt-table-all atab) (hash-keys (alt-table-alt->point-idxs atab***)))]))
 
-(define (invert-index idx)
+(define (invert-index point-idx->alts)
   (define alt->points* (make-hasheq))
-  (for* ([(pt curve) (in-hash idx)]
+  (for* ([(idx curve) (in-hash point-idx->alts)]
          [ppt (in-list curve)]
          [alt (in-list (pareto-point-data ppt))])
-    (hash-set! alt->points* alt (cons pt (hash-ref alt->points* alt '()))))
+    (hash-set! alt->points* alt (cons idx (hash-ref alt->points* alt '()))))
   (make-immutable-hasheq (hash->list alt->points*)))
 
 (define (atab-add-altn atab altn errs cost)
-  (match-define (alt-table point->alts alt->points alt->done? alt->cost pcontext all-alts) atab)
+  (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
 
   (define point->alts*
-    (for/hash ([(pt ex) (in-pcontext pcontext)]
+    (for/hash ([idx (in-range (pcontext-length pcontext))]
                [err (in-list errs)])
       (define ppt (pareto-point cost err (list altn)))
-      (values pt (pareto-union (list ppt) (hash-ref point->alts pt)))))
+      (values idx (pareto-union (list ppt) (hash-ref point-idx->alts idx)))))
 
   (alt-table point->alts*
-             (hash-set alt->points altn #f)
+             (hash-set alt->point-idxs altn #f)
              (hash-set alt->done? altn #f)
              (hash-set alt->cost altn cost)
              pcontext
              #f))
 
 (define (atab-min-errors atab)
-  (define pnt->alts (alt-table-point->alts atab))
-  (for/list ([(pt ex) (in-pcontext (alt-table-context atab))])
-    (define curve (hash-ref pnt->alts pt))
+  (define pnt-idx->alts (alt-table-point-idx->alts atab))
+  (for/list ([idx (in-range (pcontext-length (alt-table-pcontext atab)))])
+    (define curve (hash-ref pnt-idx->alts idx))
     ;; Curve is sorted so lowest error is first
     (pareto-point-error (first curve))))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -209,9 +209,7 @@
                       ; optimization: combining means that `alts1` corresponds to
                       ; the new pareto point
                       (match-define (list altn) alts1)
-                      (if (ormap (lambda (a) (alt-equal? a altn)) alts2)
-                          alts2
-                          (cons altn alts2))))))
+                      (if (ormap (lambda (a) (alt-equal? a altn)) alts2) alts2 (cons altn alts2))))))
 
   (alt-table point-idx->alts*
              (hash-set alt->point-idxs altn #f)

--- a/src/utils/pareto.rkt
+++ b/src/utils/pareto.rkt
@@ -37,7 +37,7 @@
 ;; Takes two lists of `pareto-point` structs that are Pareto-optimal
 ;; and returns the Pareto-optimal subset of their union.
 ;; The curves most be sorted using the same method.
-(define (pareto-union curve1 curve2)
+(define (pareto-union curve1 curve2 #:combine [combine (lambda (a b) (append a b))])
   (let loop ([curve1 curve1]
              [curve2 curve2])
     ; The curve is sorted so that highest accuracy is first
@@ -49,7 +49,7 @@
          ['< (loop curve1 rest2)]
          ['> (loop rest1 curve2)]
          ['=
-          (define joint-data (append (pareto-point-data ppt1) (pareto-point-data ppt2)))
+          (define joint-data (combine (pareto-point-data ppt1) (pareto-point-data ppt2)))
           (define joint (struct-copy pareto-point ppt1 [data joint-data]))
           (cons joint (loop rest1 rest2))]
          ['<>


### PR DESCRIPTION
Adds two optimizations to the alt table:
- `point->alt` map is a vector from index (in the pcontext) to alt since the number of points is fixed
- deduplication when updating Pareto frontiers