### PR TITLE
New `batch` abstractions

### DIFF
--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -6,203 +6,149 @@
 (provide progs->batch
          batch->progs
          (struct-out batch)
+         batch-length
          batch-ref
-         expand-taylor)
+         batch-replace
+         expand-taylor
+         batch-remove-approx)
 
-(struct batch ([nodes #:mutable] [roots #:mutable] vars [nodes-length #:mutable]))
+;; This function defines the recursive structure of expressions
+
+(define (expr-recurse expr f)
+  (match expr
+    [(approx spec impl) (approx spec (f impl))]
+    [(list op args ...) (cons op (map f args))]
+    [_ expr]))
+
+;; Batches store these recursive structures, flattened
+
+(struct batch ([nodes #:mutable] [roots #:mutable] vars))
+
+(define (batch-length b)
+  (cond
+    [(batch? b)
+     (vector-length (batch-nodes b))]
+    [(mutable-batch? b)
+     (hash-count (mutable-batch-index b))]
+    [else
+     (error 'batch-length "Invalid batch" b)]))
+
+(struct mutable-batch ([nodes #:mutable] [index #:mutable]))
+
+(define (make-mutable-batch)
+  (mutable-batch '() (make-hash)))
+
+(define (batch-push! b term)
+  (define hashcons (mutable-batch-index b))
+  (hash-ref! hashcons
+             term
+             (lambda ()
+               (let ([new-idx (hash-count hashcons)])
+                 (hash-set! hashcons term new-idx)
+                 (set-mutable-batch-nodes! b (cons term (mutable-batch-nodes b)))
+                 new-idx))))
+
+(define (mutable-batch->immutable b)
+  (batch (list->vector (reverse (mutable-batch-nodes b)))
+         '()
+         '()))
+
+(struct batchref (batch idx))
+
+(define (deref x)
+  (match-define (batchref b idx) x)
+  (expr-recurse (vector-ref (batch-nodes b) idx)
+                (lambda (ref) (batchref b ref))))
 
 (define (progs->batch exprs
                       #:timeline-push [timeline-push #f]
-                      #:vars [vars '()]
-                      #:ignore-approx [ignore-approx #t])
-  (define icache (reverse vars))
-  (define exprhash
-    (make-hash (for/list ([var vars]
-                          [i (in-naturals)])
-                 (cons var i))))
-  ; Counts
+                      #:vars [vars '()])
+
+  (define out (make-mutable-batch))
+  (for ([var (in-list vars)])
+    (batch-push! out var))
+
   (define size 0)
-  (define exprc 0)
-  (define varc (length vars))
-
-  ; Translates programs into an instruction sequence of operations
-  (define (munge-ignore-approx prog)
+  (define (munge prog)
     (set! size (+ 1 size))
-    (match prog ; approx nodes are ignored
-      [(approx _ impl) (munge-ignore-approx impl)]
-      [_
-       (define node ; This compiles to the register machine
-         (match prog
-           [(list op args ...) (cons op (map munge-ignore-approx args))]
-           [_ prog]))
-       (hash-ref! exprhash
-                  node
-                  (lambda ()
-                    (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                      (set! exprc (+ 1 exprc))
-                      (set! icache (cons node icache)))))]))
+    (batch-push! out (expr-recurse prog munge)))
 
-  ; Translates programs into an instruction sequence of operations
-  (define (munge-include-approx prog)
-    (set! size (+ 1 size))
-    (define node ; This compiles to the register machine
-      (match prog
-        [(approx spec impl) (approx spec (munge-include-approx impl))]
-        [(list op args ...) (cons op (map munge-include-approx args))]
-        [_ prog]))
-    (hash-ref! exprhash
-               node
-               (lambda ()
-                 (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                   (set! exprc (+ 1 exprc))
-                   (set! icache (cons node icache))))))
-
-  (define roots
-    (list->vector (map (if ignore-approx munge-ignore-approx munge-include-approx) exprs)))
-  (define nodes (list->vector (reverse icache)))
-  (define nodes-length (vector-length nodes))
-
+  (define roots (list->vector (map munge exprs)))
+  (define final (struct-copy batch (mutable-batch->immutable out) [roots roots]))
   (when timeline-push
-    (timeline-push! 'compiler (+ varc size) (+ exprc varc)))
-  (batch nodes roots vars nodes-length))
+    (timeline-push! 'compiler size (batch-length final)))
+  final)
 
-(define (batch->progs batch)
-  (define roots (batch-roots batch))
-  (define nodes (batch-nodes batch))
+(define (batch->progs b)
+  (define exprs (make-vector (batch-length b)))
+  (for ([node (in-vector (batch-nodes b))] [idx (in-naturals)])
+    (vector-set! exprs idx
+                 (expr-recurse node (lambda (x) (vector-ref exprs x)))))
+  (for/list ([root (batch-roots b)])
+    (vector-ref exprs root)))
 
-  (define (unmunge reg)
-    (define node (vector-ref nodes reg))
-    (match node
-      [(approx spec impl) (approx spec (unmunge impl))]
-      [(list op regs ...) (cons op (map unmunge regs))]
-      [_ node]))
+(define (batch-remove-approx batch)
+  (batch-replace batch
+                 (lambda (node)
+                   (match node
+                     [(approx spec impl) impl]
+                     [node node]))))
 
-  (define exprs
-    (for/list ([root (in-vector roots)])
-      (unmunge root)))
-  exprs)
+(define (batch-replace b f)
+  (define out (make-mutable-batch))
+  (define mapping (make-vector (batch-length b) -1))
+  (for ([node (in-vector (batch-nodes b))] [idx (in-naturals)])
+    (define replacement (f (expr-recurse node (lambda (x) (batchref b x)))))
+    (define final-idx
+      (let loop ([expr replacement])
+        (match expr
+          [(batchref b* idx)
+           (unless (eq? b* b)
+             (error 'batch-replace "Replacement ~a references the wrong batch ~a" replacement b*))
+           (when (= -1 (vector-ref mapping idx))
+             (error 'batch-replace "Replacement ~a references unknown index ~a" replacement idx))
+           (vector-ref mapping idx)]
+          [_
+           (batch-push! out (expr-recurse expr loop))])))
+    (vector-set! mapping idx final-idx))
+  (struct-copy batch (mutable-batch->immutable out)
+               [roots (vector-map (curry vector-ref mapping) (batch-roots b))]
+               [vars (batch-vars b)]))
 
 (define (expand-taylor input-batch)
-  (define vars (batch-vars input-batch))
-  (define nodes (batch-nodes input-batch))
-  (define roots (batch-roots input-batch))
-
-  ; Hash to avoid duplications
-  (define icache (reverse vars))
-  (define exprhash
-    (make-hash (for/list ([var vars]
-                          [i (in-naturals)])
-                 (cons var i))))
-  (define exprc 0)
-  (define varc (length vars))
-
-  ; Mapping from nodes to nodes*
-  (define mappings (build-vector (batch-nodes-length input-batch) values))
-
-  ; Adding a node to hash
-  (define (append-node node)
-    (hash-ref! exprhash
-               node
-               (lambda ()
-                 (begin0 (+ exprc varc) ; store in cache, update exprs, exprc
-                   (set! exprc (+ 1 exprc))
-                   (set! icache (cons node icache))))))
-
-  ; Sequential rewriting
-  (for ([node (in-vector nodes)]
-        [n (in-naturals)])
-    (match node
-      [(list '- arg1 arg2)
-       (define neg-index (append-node `(neg ,(vector-ref mappings arg2))))
-       (vector-set! mappings n (append-node `(+ ,(vector-ref mappings arg1) ,neg-index)))]
-      [(list 'pow base power)
-       #:when (equal? (vector-ref nodes power) 1/2) ; 1/2 is to be removed from exprhash
-       (vector-set! mappings n (append-node `(sqrt ,(vector-ref mappings base))))]
-      [(list 'pow base power)
-       #:when (equal? (vector-ref nodes power) 1/3) ; 1/3 is to be removed from exprhash
-       (vector-set! mappings n (append-node `(cbrt ,(vector-ref mappings base))))]
-      [(list 'pow base power)
-       #:when (equal? (vector-ref nodes power) 2/3) ; 2/3 is to be removed from exprhash
-       (define mult-index (append-node `(* ,(vector-ref mappings base) ,(vector-ref mappings base))))
-       (vector-set! mappings n (append-node `(cbrt ,mult-index)))]
-      [(list 'pow base power)
-       #:when (exact-integer? (vector-ref nodes power))
-       (vector-set! mappings
-                    n
-                    (append-node `(pow ,(vector-ref mappings base) ,(vector-ref mappings power))))]
-      [(list 'pow base power)
-       (define log-idx (append-node `(log ,(vector-ref mappings base))))
-       (define mult-idx (append-node `(* ,(vector-ref mappings power) ,log-idx)))
-       (vector-set! mappings n (append-node `(exp ,mult-idx)))]
-      [(list 'tan args)
-       (define sin-idx (append-node `(sin ,(vector-ref mappings args))))
-       (define cos-idx (append-node `(cos ,(vector-ref mappings args))))
-       (vector-set! mappings n (append-node `(/ ,sin-idx ,cos-idx)))]
-      [(list 'cosh args)
-       (define exp-idx (append-node `(exp ,(vector-ref mappings args))))
-       (define one-idx (append-node 1)) ; should it be 1 or literal 1 or smth?
-       (define inv-exp-idx (append-node `(/ ,one-idx ,exp-idx)))
-       (define add-idx (append-node `(+ ,exp-idx ,inv-exp-idx)))
-       (define half-idx (append-node 1/2))
-       (vector-set! mappings n (append-node `(* ,half-idx ,add-idx)))]
-      [(list 'sinh args)
-       (define exp-idx (append-node `(exp ,(vector-ref mappings args))))
-       (define one-idx (append-node 1))
-       (define inv-exp-idx (append-node `(/ ,one-idx ,exp-idx)))
-       (define neg-idx (append-node `(neg ,inv-exp-idx)))
-       (define add-idx (append-node `(+ ,exp-idx ,neg-idx)))
-       (define half-idx (append-node 1/2))
-       (vector-set! mappings n (append-node `(* ,half-idx ,add-idx)))]
-      [(list 'tanh args)
-       (define exp-idx (append-node `(exp ,(vector-ref mappings args))))
-       (define one-idx (append-node 1))
-       (define inv-exp-idx (append-node `(/ ,one-idx ,exp-idx)))
-       (define neg-idx (append-node `(neg ,inv-exp-idx)))
-       (define add-idx (append-node `(+ ,exp-idx ,inv-exp-idx)))
-       (define sub-idx (append-node `(+ ,exp-idx ,neg-idx)))
-       (vector-set! mappings n (append-node `(/ ,sub-idx ,add-idx)))]
-      [(list 'asinh args)
-       (define mult-idx (append-node `(* ,(vector-ref mappings args) ,(vector-ref mappings args))))
-       (define one-idx (append-node 1))
-       (define add-idx (append-node `(+ ,mult-idx ,one-idx)))
-       (define sqrt-idx (append-node `(sqrt ,add-idx)))
-       (define add2-idx (append-node `(+ ,(vector-ref mappings args) ,sqrt-idx)))
-       (vector-set! mappings n (append-node `(log ,add2-idx)))]
-      [(list 'acosh args)
-       (define mult-idx (append-node `(* ,(vector-ref mappings args) ,(vector-ref mappings args))))
-       (define -one-idx (append-node -1))
-       (define add-idx (append-node `(+ ,mult-idx ,-one-idx)))
-       (define sqrt-idx (append-node `(sqrt ,add-idx)))
-       (define add2-idx (append-node `(+ ,(vector-ref mappings args) ,sqrt-idx)))
-       (vector-set! mappings n (append-node `(log ,add2-idx)))]
-      [(list 'atanh args)
-       (define neg-idx (append-node `(neg ,(vector-ref mappings args))))
-       (define one-idx (append-node 1))
-       (define add-idx (append-node `(+ ,one-idx ,(vector-ref mappings args))))
-       (define sub-idx (append-node `(+ ,one-idx ,neg-idx)))
-       (define div-idx (append-node `(/ ,add-idx ,sub-idx)))
-       (define log-idx (append-node `(log ,div-idx)))
-       (define half-idx (append-node 1/2))
-       (vector-set! mappings n (append-node `(* ,half-idx ,log-idx)))]
-      [(list op args ...)
-       (vector-set! mappings n (append-node (cons op (map (curry vector-ref mappings) args))))]
-      [(approx spec impl)
-       (vector-set! mappings n (append-node (approx spec (vector-ref mappings impl))))]
-      [_ (vector-set! mappings n (append-node node))]))
-
-  (define roots* (vector-map (curry vector-ref mappings) roots))
-  (define nodes* (list->vector (reverse icache)))
-
-  ; This may be too expensive to handle simple 1/2, 1/3 and 2/3 zombie nodes..
-  #;(remove-zombie-nodes (batch nodes* roots* vars (vector-length nodes*)))
-
-  (batch nodes* roots* vars (vector-length nodes*)))
+  (batch-replace
+   input-batch
+   (lambda (node)
+     (match node
+       [(list '- ref1 ref2) `(+ ,ref1 (neg ,ref2))]
+       [(list 'pow base (app deref 1/2)) `(sqrt ,base)]
+       [(list 'pow base (app deref 1/3)) `(cbrt ,base)]
+       [(list 'pow base (app deref 2/3)) `(cbrt (* ,base ,base))]
+       [(list 'pow base (and power (app deref (? exact-integer?))))
+        (list 'pow base power)]
+       [(list 'pow base power)
+        `(exp (* ,power (log ,base)))]
+       [(list 'tan arg)
+        `(/ (sin ,arg) (cos ,arg))]
+       [(list 'cosh arg)
+        `(* 1/2 (+ (exp ,arg) (/ 1 (exp ,arg))))]
+       [(list 'sinh arg)
+        `(* 1/2 (+ (exp ,arg) (/ -1 (exp ,arg))))]
+       [(list 'tanh arg)
+        `(/ (+ (exp ,arg) (neg (/ 1 (exp ,arg)))) (+ (exp ,arg) (/ 1 (exp ,arg))))]
+       [(list 'asinh arg)
+        `(log (+ ,arg (sqrt (+ (* ,arg ,arg) 1))))]
+       [(list 'acosh arg)
+        `(log (+ ,arg (sqrt (+ (* ,arg ,arg) -1))))]
+       [(list 'atanh arg)
+        `(* 1/2 (log (/ (+ 1 ,arg) (+ 1 (neg ,arg)))))]
+       [_ node]))))
 
 ; The function removes any zombie nodes from batch
 (define (remove-zombie-nodes input-batch)
   (define nodes (batch-nodes input-batch))
   (define roots (batch-roots input-batch))
-  (define nodes-length (batch-nodes-length input-batch))
+  (define nodes-length (batch-length input-batch))
 
   (define zombie-mask (make-vector nodes-length #t))
   (for ([root (in-vector roots)])
@@ -232,7 +178,7 @@
                     nodes*))))
   (set! nodes* (list->vector (reverse nodes*)))
   (define roots* (vector-map (curry vector-ref mappings) roots))
-  (batch nodes* roots* (batch-vars input-batch) (vector-length nodes*)))
+  (batch nodes* roots* (batch-vars input-batch)))
 
 (define (batch-ref batch reg)
   (define (unmunge reg)
@@ -246,8 +192,9 @@
 ; Tests for expand-taylor
 (module+ test
   (require rackunit)
+
   (define (test-expand-taylor expr)
-    (define batch (progs->batch (list expr) #:ignore-approx #f))
+    (define batch (progs->batch (list expr)))
     (define batch* (expand-taylor batch))
     (car (batch->progs batch*)))
 
@@ -256,7 +203,7 @@
   (check-equal? '(log (+ x (sqrt (+ (* x x) 1)))) (test-expand-taylor '(asinh x)))
   (check-equal? '(/ (+ (exp x) (neg (/ 1 (exp x)))) (+ (exp x) (/ 1 (exp x))))
                 (test-expand-taylor '(tanh x)))
-  (check-equal? '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))) (test-expand-taylor '(sinh x)))
+  (check-equal? '(* 1/2 (+ (exp x) (/ -1 (exp x)))) (test-expand-taylor '(sinh x)))
   (check-equal? '(+ 1 (neg (+ 2 (neg 3)))) (test-expand-taylor '(- 1 (- 2 3))))
   (check-equal? '(* 1/2 (+ (exp x) (/ 1 (exp x)))) (test-expand-taylor '(cosh x)))
   (check-equal? '(/ (sin x) (cos x)) (test-expand-taylor '(tan x)))
@@ -275,8 +222,8 @@
 ; Tests for progs->batch and batch->progs
 (module+ test
   (require rackunit)
-  (define (test-munge-unmunge expr [ignore-approx #t])
-    (define batch (progs->batch (list expr) #:ignore-approx ignore-approx))
+  (define (test-munge-unmunge expr)
+    (define batch (progs->batch (list expr)))
     (check-equal? (list expr) (batch->progs batch)))
 
   (test-munge-unmunge '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))))
@@ -285,14 +232,13 @@
   (test-munge-unmunge '(cbrt x))
   (test-munge-unmunge '(x))
   (test-munge-unmunge
-   `(+ (sin ,(approx '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))) '(+ 3 (* 25 (sin 6))))) 4)
-   #f))
+   `(+ (sin ,(approx '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))) '(+ 3 (* 25 (sin 6))))) 4)))
 
 ; Tests for remove-zombie-nodes
 (module+ test
   (require rackunit)
   (define (zombie-test #:nodes nodes #:roots roots)
-    (define in-batch (batch nodes roots '() (vector-length nodes)))
+    (define in-batch (batch nodes roots '()))
     (define out-batch (remove-zombie-nodes in-batch))
     (batch-nodes out-batch))
 

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -145,7 +145,6 @@
       [_ node]))
   (unmunge reg))
 
-
 ; Tests for progs->batch and batch->progs
 (module+ test
   (require rackunit)

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -8,6 +8,7 @@
          (struct-out batch)
          batch-length
          batch-ref
+         deref
          batch-replace)
 
 ;; This function defines the recursive structure of expressions
@@ -144,35 +145,6 @@
       [_ node]))
   (unmunge reg))
 
-; Tests for expand-taylor
-(module+ test
-  (require rackunit)
-
-  (define (test-expand-taylor expr)
-    (define batch (progs->batch (list expr)))
-    (define batch* (expand-taylor batch))
-    (car (batch->progs batch*)))
-
-  (check-equal? '(* 1/2 (log (/ (+ 1 x) (+ 1 (neg x))))) (test-expand-taylor '(atanh x)))
-  (check-equal? '(log (+ x (sqrt (+ (* x x) -1)))) (test-expand-taylor '(acosh x)))
-  (check-equal? '(log (+ x (sqrt (+ (* x x) 1)))) (test-expand-taylor '(asinh x)))
-  (check-equal? '(/ (+ (exp x) (neg (/ 1 (exp x)))) (+ (exp x) (/ 1 (exp x))))
-                (test-expand-taylor '(tanh x)))
-  (check-equal? '(* 1/2 (+ (exp x) (/ -1 (exp x)))) (test-expand-taylor '(sinh x)))
-  (check-equal? '(+ 1 (neg (+ 2 (neg 3)))) (test-expand-taylor '(- 1 (- 2 3))))
-  (check-equal? '(* 1/2 (+ (exp x) (/ 1 (exp x)))) (test-expand-taylor '(cosh x)))
-  (check-equal? '(/ (sin x) (cos x)) (test-expand-taylor '(tan x)))
-  (check-equal? '(+ 1 (neg (* 1/2 (+ (exp (/ (sin 3) (cos 3))) (/ 1 (exp (/ (sin 3) (cos 3))))))))
-                (test-expand-taylor '(- 1 (cosh (tan 3)))))
-  (check-equal? '(exp (* a (log x))) (test-expand-taylor '(pow x a)))
-  (check-equal? '(+ x (sin a)) (test-expand-taylor '(+ x (sin a))))
-  (check-equal? '(cbrt x) (test-expand-taylor '(pow x 1/3)))
-  (check-equal? '(cbrt (* x x)) (test-expand-taylor '(pow x 2/3)))
-  (check-equal? '(+ 100 (cbrt x)) (test-expand-taylor '(+ 100 (pow x 1/3))))
-  (check-equal? `(+ 100 (cbrt (* x ,(approx 2 3))))
-                (test-expand-taylor `(+ 100 (pow (* x ,(approx 2 3)) 1/3))))
-  (check-equal? `(+ ,(approx 2 3) (cbrt x)) (test-expand-taylor `(+ ,(approx 2 3) (pow x 1/3))))
-  (check-equal? `(+ (cbrt x) ,(approx 2 1/3)) (test-expand-taylor `(+ (pow x 1/3) ,(approx 2 1/3)))))
 
 ; Tests for progs->batch and batch->progs
 (module+ test

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -50,6 +50,13 @@
 (define (if-proc c a b)
   (if c a b))
 
+(define (batch-remove-approx batch)
+  (batch-replace batch
+                 (lambda (node)
+                   (match node
+                     [(approx spec impl) impl]
+                     [node node]))))
+
 ;; Translates a Herbie IR into an interpretable IR.
 ;; Requires some hooks to complete the translation.
 (define (make-compiler exprs vars)

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -54,10 +54,10 @@
 ;; Requires some hooks to complete the translation.
 (define (make-compiler exprs vars)
   (define num-vars (length vars))
-  (define batch (progs->batch exprs #:timeline-push #t #:vars vars #:ignore-approx #t))
+  (define batch (batch-remove-approx (progs->batch exprs #:timeline-push #t #:vars vars)))
 
   (define instructions
-    (for/vector #:length (- (batch-nodes-length batch) num-vars)
+    (for/vector #:length (- (batch-length batch) num-vars)
                 ([node (in-vector (batch-nodes batch) num-vars)])
       (match node
         [(literal value (app get-representation repr)) (list (const (real->repr value repr)))]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -120,7 +120,7 @@
     (for/list ([subexpr (in-list exprs-list)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
 
-  (define expr-batch (progs->batch exprs-list #:ignore-approx #f))
+  (define expr-batch (progs->batch exprs-list))
   (define nodes (batch-nodes expr-batch))
   (define roots (batch-roots expr-batch))
 

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -77,7 +77,7 @@
 (define (taylor var expr-batch)
   "Return a pair (e, n), such that expr ~= e var^n"
   (define nodes (batch-nodes expr-batch))
-  (define taylor-approxs (make-vector (batch-nodes-length expr-batch))) ; vector of approximations
+  (define taylor-approxs (make-vector (batch-length expr-batch))) ; vector of approximations
 
   (for ([node (in-vector nodes)]
         [n (in-naturals)])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -44,7 +44,9 @@
        [(list 'pow base (app deref 1/2)) `(sqrt ,base)]
        [(list 'pow base (app deref 1/3)) `(cbrt ,base)]
        [(list 'pow base (app deref 2/3)) `(cbrt (* ,base ,base))]
-       [(list 'pow base (and power (app deref (? exact-integer?)))) `(pow base power)]
+       [(list 'pow base power)
+        #:when (exact-integer? (deref power))
+        `(pow ,base ,power)]
        [(list 'pow base power) `(exp (* ,power (log ,base)))]
        [(list 'tan arg) `(/ (sin ,arg) (cos ,arg))]
        [(list 'cosh arg) `(* 1/2 (+ (exp ,arg) (/ 1 (exp ,arg))))]


### PR DESCRIPTION
This PR introduces a couple of simplifications / changes / abstractions for batches.

First, there are now `mutable-batch` objects. These are basically the core of `progs→batch`, but turned into a separate mutable object. Concretely, a `mutable-batch` is a hash table (from node to index) plus a list of nodes in reverse order. (It also stores the vars, in reverse order, for the same reason (if any) as regular batches.) You can convert a mutable batch into an immutable one, though you need to supply a rootvec.

Second, there are now `batchref` objects. This just stores a batch and an index, and you can unfold it one step with `deref`. These aren't yet super important, but they're used in...

Third, there's now a `batch-replace` function. This function takes a callback that outputs expressions, with leaves filled in with `batchref`s. This is a little confusing, so consider an example:

```
(define (simplify-sqrt input-batch)
  (batch-replace
   input-batch
   (lambda (node)
     (match node
       [(list 'pow base (app deref 1/2)) `(sqrt ,base)]
       [node node]))))
```

Suppose the input batch is just the expression `(pow x 1/2)`. Then as a batch `#a` it contains:

```
0 → x
1 → 1/2
2 → (pow 0 1)
```

The callback inside `simplify-sqrt` will be called with `(pow (batchref #a 0) (batchref #a 1))`. This matches the first pattern, though note that the subpattern for the section argument—`(app deref 1/2)`—looks up the second argument in the batch to make sure it is exactly `1/2`. Then our callback returns `(sqrt (batchref #a 0))`; `batch-replace` recognizes the `batchref` objects and rewrites them to point into the new batch, properly deduplicating things when necessary.

There are also various minor optimizations, like I tweaked what `sinh` expands to for Taylor and I made `batch→progs` faster.