### PR TITLE
Tiny e-graph speedups

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1158,10 +1158,8 @@
   (define root-ids (egraph-add-exprs egg-graph exprs ctx))
 
   ; run the schedule
-  (define rule-apps (make-hash))
   (define egg-graph*
-    (for/fold ([egg-graph egg-graph]) ([instr (in-list schedule)])
-      (match-define (cons rules params) instr)
+    (for/fold ([egg-graph egg-graph]) ([(rules params) (in-dict schedule)])
       ; run rules in the egraph
       (define egg-rules (expand-rules rules))
       (define-values (egg-graph* iteration-data) (egraph-run-rules egg-graph egg-rules params))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1165,7 +1165,8 @@
       (define-values (egg-graph* iteration-data) (egraph-run-rules egg-graph egg-rules params))
 
       ; get cost statistics
-      (for ([iter (in-list iteration-data)] [i (in-naturals)])
+      (for ([iter (in-list iteration-data)]
+            [i (in-naturals)])
         (define cnt (iteration-data-num-nodes iter))
         (define cost (apply + (map (λ (id) (egraph-get-cost egg-graph* id i)) root-ids)))
         (timeline-push! 'egraph i cnt cost (iteration-data-time iter)))


### PR DESCRIPTION
This PR just removes the code that records how many times each rule was applied. This data was basically always useless and it turns out to take a surprisingly long time to actually, you know, run.