### PR TITLE
Rewrite the eclass-reading code

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -241,11 +241,10 @@
                       ->
                       [f : _rust/string]
                       ->
-                      (values
-                       (if (zero? (u32vector-length v))
-                          (or (string->number f) (string->symbol f))
-                          (string->symbol f))
-                       v)))
+                      (values (if (zero? (u32vector-length v))
+                                  (or (string->number f) (string->symbol f))
+                                  (string->symbol f))
+                              v)))
 
 ;; This fairly long and ugly method is the core of our egg FFI.
 ;; It iterates over all enodes in the egraph, returning for each:
@@ -278,8 +277,7 @@
   (define num-eclasses (u32vector-length eclass-ids))
 
   (cond
-    [(= num-eclasses 0)
-     (in-range 0)]
+    [(= num-eclasses 0) (in-range 0)]
     [else
      (define first-eclass (u32vector-ref eclass-ids 0))
      (define first-eclass-size (egraph_eclass_size egg-ptr first-eclass))
@@ -291,39 +289,42 @@
 
      (make-do-sequence
       (lambda ()
-        (values
-         (lambda (i)
-           (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
-           (define node-size (egraph_enode_size egg-ptr eclass-id enode-idx))
-           (define vec
-             (match node-size [0 0-vec] [1 1-vec] [2 2-vec] [3 3-vec] [n (make-u32vector n)]))
-           (define-values (op args) (egraph_get_node egg-ptr eclass-id enode-idx vec))
-           (for ([i (in-range (u32vector-length args))])
-             (define sub-eclass-id (u32vector-ref args i))
-             (u32vector-set! args i (u32vector-ref egg-id->idx sub-eclass-id)))
-           (values eclass-idx op args))
-         (lambda (i)
-           (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
-           (define enode-idx* (add1 enode-idx))
-           (cond
-             [(< enode-idx* eclass-size)
-              (vector-set! i 3 enode-idx*)]
-             [else
-              (define eclass-idx* (add1 eclass-idx))
-              (vector-set! i 0 eclass-idx*)
-              (when (< eclass-idx* num-eclasses)
-                (define eclass-id* (u32vector-ref eclass-ids eclass-idx*))
-                (vector-set! i 1 eclass-id*)
-                (define eclass-size* (egraph_eclass_size egg-ptr eclass-id*))
-                (vector-set! i 2 eclass-size*)
-                (vector-set! i 3 0))])
-           i)
-         (vector 0 first-eclass first-eclass-size 0)
-         (lambda (i)
-           (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
-           (< eclass-idx num-eclasses))
-         #f
-         #f)))]))
+        (values (lambda (i)
+                  (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+                  (define node-size (egraph_enode_size egg-ptr eclass-id enode-idx))
+                  (define vec
+                    (match node-size
+                      [0 0-vec]
+                      [1 1-vec]
+                      [2 2-vec]
+                      [3 3-vec]
+                      [n (make-u32vector n)]))
+                  (define-values (op args) (egraph_get_node egg-ptr eclass-id enode-idx vec))
+                  (for ([i (in-range (u32vector-length args))])
+                    (define sub-eclass-id (u32vector-ref args i))
+                    (u32vector-set! args i (u32vector-ref egg-id->idx sub-eclass-id)))
+                  (values eclass-idx op args))
+                (lambda (i)
+                  (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+                  (define enode-idx* (add1 enode-idx))
+                  (cond
+                    [(< enode-idx* eclass-size) (vector-set! i 3 enode-idx*)]
+                    [else
+                     (define eclass-idx* (add1 eclass-idx))
+                     (vector-set! i 0 eclass-idx*)
+                     (when (< eclass-idx* num-eclasses)
+                       (define eclass-id* (u32vector-ref eclass-ids eclass-idx*))
+                       (vector-set! i 1 eclass-id*)
+                       (define eclass-size* (egraph_eclass_size egg-ptr eclass-id*))
+                       (vector-set! i 2 eclass-size*)
+                       (vector-set! i 3 0))])
+                  i)
+                (vector 0 first-eclass first-eclass-size 0)
+                (lambda (i)
+                  (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+                  (< eclass-idx num-eclasses))
+                #f
+                #f)))]))
 
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -15,7 +15,7 @@
          egraph_find
          egraph_serialize
          egraph_get_eclasses
-         egraph_get_eclass
+         in-egraph-enodes
          egraph_get_simplest
          egraph_get_variants
          egraph_get_cost
@@ -241,21 +241,85 @@
                       ->
                       [f : _rust/string]
                       ->
-                      (if (zero? (u32vector-length v))
+                      (values
+                       (if (zero? (u32vector-length v))
                           (or (string->number f) (string->symbol f))
-                          (cons (string->symbol f) v))))
-; u32vector
-(define empty-u32vec (make-u32vector 0))
+                          (string->symbol f))
+                       v)))
 
-; egraph -> id -> (vectorof (or symbol? number? (cons symbol u32vector)))
-(define (egraph_get_eclass egg-ptr id)
-  (define n (egraph_eclass_size egg-ptr id))
-  (for/vector #:length n
-              ([i (in-range n)])
-    (define node-size (egraph_enode_size egg-ptr id i))
-    (if (zero? node-size)
-        (egraph_get_node egg-ptr id i empty-u32vec)
-        (egraph_get_node egg-ptr id i (make-u32vector node-size)))))
+;; This fairly long and ugly method is the core of our egg FFI.
+;; It iterates over all enodes in the egraph, returning for each:
+;;
+;; - The eclass id. This is normalize to range over 1..n
+;; - The operator name, which is a symbol or a number
+;; - A u32vector of child eclass ids, which are also normalized.
+;;
+;; If an enode is an atom, like a symbol or a number, there aren't any
+;; children. The same holds if it's a zero-argument operator; these
+;; cases need to be disambiguated by the caller.
+;;
+;; This method is also extremely performance sensitive, so it is written
+;; to maximize performance. This leads to a key constraint:
+;;
+;; - The u32vector of child eclass ids cannot escape the caller; it is
+;;   invalidated with each iteration.
+;;
+;; The caller must be careful!
+
+(define (in-egraph-enodes egg-ptr)
+  (define eclass-ids (egraph_get_eclasses egg-ptr))
+  (define max-id
+    (for/fold ([current-max 0]) ([idx (in-range (u32vector-length eclass-ids))])
+      (define egg-id (u32vector-ref eclass-ids idx))
+      (max current-max egg-id)))
+  (define egg-id->idx (make-u32vector (+ max-id 1)))
+  (for ([idx (in-range (u32vector-length eclass-ids))])
+    (u32vector-set! egg-id->idx (u32vector-ref eclass-ids idx) idx))
+  (define num-eclasses (u32vector-length eclass-ids))
+
+  (define 0-vec (make-u32vector 0))
+  (define 1-vec (make-u32vector 1))
+  (define 2-vec (make-u32vector 2))
+  (define 3-vec (make-u32vector 3))
+
+  (define first-eclass (u32vector-ref eclass-ids 0))
+  (define first-eclass-size (egraph_eclass_size egg-ptr first-eclass))
+
+  (make-do-sequence
+   (lambda ()
+     (values
+      (lambda (i)
+        (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+        (define node-size (egraph_enode_size egg-ptr eclass-id enode-idx))
+        (define vec
+          (match node-size [0 0-vec] [1 1-vec] [2 2-vec] [3 3-vec] [n (make-u32vector n)]))
+        (define-values (op args) (egraph_get_node egg-ptr eclass-id enode-idx vec))
+        (for ([i (in-range (u32vector-length args))])
+          (define sub-eclass-id (u32vector-ref args i))
+          (u32vector-set! args i (u32vector-ref egg-id->idx sub-eclass-id)))
+        (values eclass-idx op args))
+      (lambda (i)
+        (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+        (define enode-idx* (add1 enode-idx))
+        (cond
+          [(< enode-idx* eclass-size)
+           (vector-set! i 3 enode-idx*)]
+          [else
+           (define eclass-idx* (add1 eclass-idx))
+           (vector-set! i 0 eclass-idx*)
+           (when (< eclass-idx* num-eclasses)
+             (define eclass-id* (u32vector-ref eclass-ids eclass-idx*))
+             (vector-set! i 1 eclass-id*)
+             (define eclass-size* (egraph_eclass_size egg-ptr eclass-id*))
+             (vector-set! i 2 eclass-size*)
+             (vector-set! i 3 0))])
+        i)
+      (vector 0 first-eclass first-eclass-size 0)
+      (lambda (i)
+        (match-define (vector eclass-idx eclass-id eclass-size enode-idx) i)
+        (< eclass-idx num-eclasses))
+      #f
+      #f))))
 
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -559,10 +559,10 @@
      (define itypes (if (impl-exists? f) (impl-info f 'itype) (operator-info f 'itype)))
      ; unsafe since we don't check that |itypes| = |ids|
      ; optimize for common cases to avoid extra allocations
-     (cons
-      f
-      (for/list ([id (in-u32vector ids)] [itype (in-list itypes)])
-        (lookup id itype)))]))
+     (cons f
+           (for/list ([id (in-u32vector ids)]
+                      [itype (in-list itypes)])
+             (lookup id itype)))]))
 
 ;; Rebuilds an e-node using typed e-classes
 (define (rebuild-enode enode type lookup)
@@ -610,7 +610,8 @@
 
   (define types (all-reprs/types))
   (define type->idx
-    (for/hasheq ([type (in-list types)] [idx (in-naturals)])
+    (for/hasheq ([type (in-list types)]
+                 [idx (in-naturals)])
       (values type idx)))
   (define num-types (hash-count type->idx))
 
@@ -632,24 +633,15 @@
   ; NOTE: nodes in typed eclasses are reversed relative
   ; to their position in untyped eclasses
   (for ([(eclass op args) (in-egraph-enodes egg-ptr)])
-    #;(define enode
-      (if (or (number? op)
-              (and (hash-has-key? egg->herbie op) (zero? (u32vector-length args))))
-          op
-          (cons op args)))
     ; get all possible types for the enode
     ; lookup its correct eclass and add the rebuilt node
     (define types (enode-type op egg->herbie))
     (for ([type (in-list types)])
       (define id (idx+type->id eclass type))
-      #;(define enode** (rebuild-enode enode type idx+type->id))
       (define enode* (rebuild-enode* op args type egg->herbie idx+type->id))
-      #;(unless (equal? enode* enode**)
-        (error 'rebuild-enode "Don't match" enode* enode**))
       (vector-set! id->eclass id (cons enode* (vector-ref id->eclass id)))
       (match enode*
-        [(list _)
-         (vector-set! id->leaf? id #t)]
+        [(list _) (vector-set! id->leaf? id #t)]
         [(list _ ids ...)
          (for ([child-id (in-list ids)])
            (vector-set! id->parents child-id (cons id (vector-ref id->parents child-id))))]


### PR DESCRIPTION
This PR basically attempts to optimize `split-untyped-eclasses`, which on its own is about 7.5 minutes of runtime in a nightly. To do so it:

- Uses sequences of "stream in" enodes instead of ever allocating a vector of all the ones in an eclass. This also reduces allocations.
- Micro-optimizes the transformations from types and egg eclass ids to Herbie-side ids
- Unpacks enodes in a couple of cases to save a minute number of allocations

The results code is fairly ugly (it is almost C code) and it's not clear if the result is actually much faster. Life is hard!