### PR TITLE
Surface `exact errors` for Odyssey to consume.

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -143,7 +143,7 @@
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
   (*pcontext* test-pcontext)
-  (local-error-as-tree (test-input test) (*context*)))
+  (local-error-as-tree test (*context*)))
 
 (define (get-explanations test pcontext)
   (unless pcontext

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -347,7 +347,7 @@
       ['errors (make-error-result herbie-result job-id)]
       ['exacts (make-exacts-result herbie-result job-id)]
       ['improve (make-improve-result herbie-result test job-id)]
-      ['local-error (make-local-error-result herbie-result test job-id)]
+      ['local-error (make-local-error-result herbie-result job-id)]
       ['explanations (make-explanation-result herbie-result job-id)]
       ['sample (make-sample-result herbie-result test job-id)]
       [_ (error 'compute-result "unknown command ~a" kind)]))
@@ -365,25 +365,15 @@
           'path
           (make-path job-id)))
 
-(define (make-local-error-result herbie-result test job-id)
-  (define expr (prog->fpcore (test-input test) (test-context test)))
-  (define local-error (job-result-backend herbie-result))
-  ;; TODO: potentially unsafe if resugaring changes the AST
-  (define tree
-    (let loop ([expr expr]
-               [err local-error])
-      (match expr
-        [(list op args ...)
-         ;; err => (List (listof Integer) List ...)
-         (hasheq 'e
-                 (~a op)
-                 'avg-error
-                 (format-bits (errors-score (first err)))
-                 'children
-                 (map loop args (rest err)))]
-        ;; err => (List (listof Integer))
-        [_ (hasheq 'e (~a expr) 'avg-error (format-bits (errors-score (first err))) 'children '())])))
-  (hasheq 'command (get-command herbie-result) 'tree tree 'job job-id 'path (make-path job-id)))
+(define (make-local-error-result herbie-result job-id)
+  (hasheq 'command
+          (get-command herbie-result)
+          'tree
+          (job-result-backend herbie-result)
+          'job
+          job-id
+          'path
+          (make-path job-id)))
 
 (define (make-sample-result herbie-result test job-id)
   (define pctx (job-result-backend herbie-result))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -33,10 +33,16 @@
     [else #t]))
 
 (define (actual-errors expr pcontext)
-  (match-define (cons subexprs pt-errorss)
+
+  (define errs
     (parameterize ([*pcontext* pcontext])
-      (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
-                                                           (*context*)))))))
+      (first (compute-local-errors (list (all-subexpressions expr)) (*context*)))))
+
+  (define pruned (make-hash))
+  (for ([(k v) (in-hash errs)])
+    (hash-set! pruned k (hash-ref v 'errs)))
+  (define idk (flip-lists (hash->list pruned)))
+  (match-define (cons subexprs pt-errorss) idk)
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -213,7 +213,7 @@
                  'avg-error
                  (format-bits (errors-score (first err)))
                  'exact-value
-                 (first exact)
+                 (map ~s (first exact))
                  'children
                  (map loop args (rest err) (rest exact)))]
         ;; err => (List (listof Integer))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -7,6 +7,7 @@
          "../utils/common.rkt"
          "../utils/float.rkt"
          "../syntax/platform.rkt"
+         "../syntax/read.rkt"
          "points.rkt"
          "programs.rkt"
          "sampling.rkt"
@@ -181,12 +182,29 @@
 ;; Compute the local error of every subexpression of `prog`
 ;; and returns the error information as an S-expr in the
 ;; same shape as `prog`
-(define (local-error-as-tree expr ctx)
-  (define errs (first (compute-local-errors (list (all-subexpressions expr)) ctx)))
-  (let loop ([expr expr])
-    (define expr-info (hash-ref errs expr))
-    (define err-list (hash-ref expr-info 'errs))
-    (define exacts-list (hash-ref expr-info 'errs))
-    (match expr
-      [(list op args ...) (cons err-list (map loop args))]
-      [_ (list err-list)])))
+(define (local-error-as-tree test ctx)
+  (define errs (first (compute-local-errors (list (all-subexpressions (test-input test))) ctx)))
+  (define local-error
+    (let loop ([expr (test-input test)])
+      (define expr-info (hash-ref errs expr))
+      (define err-list (hash-ref expr-info 'errs))
+      (define exacts-list (hash-ref expr-info 'errs))
+      (match expr
+        [(list op args ...) (cons err-list (map loop args))]
+        [_ (list err-list)])))
+
+  (define tree
+    (let loop ([expr (prog->fpcore (test-input test) (test-context test))]
+               [err local-error])
+      (match expr
+        [(list op args ...)
+         ;; err => (List (listof Integer) List ...)
+         (hasheq 'e
+                 (~a op)
+                 'avg-error
+                 (format-bits (errors-score (first err)))
+                 'children
+                 (map loop args (rest err)))]
+        ;; err => (List (listof Integer))
+        [_ (hasheq 'e (~a expr) 'avg-error (format-bits (errors-score (first err))) 'children '())])))
+  tree)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -212,8 +212,8 @@
                  (~a op)
                  'avg-error
                  (format-bits (errors-score (first err)))
-                 'exact-errors
-                 (map format-bits (first exact))
+                 'exact-error
+                 (format-bits (errors-score (first exact)))
                  'children
                  (map loop args (rest err) (rest exact)))]
         ;; err => (List (listof Integer))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -175,7 +175,7 @@
       (begin0 (values subexpr
                       (hasheq 'errs
                               (vector->list (vector-ref errs n))
-                              'exacts
+                              'exact-values
                               (vector->list (vector-ref exacts-out n))))
         (set! n (add1 n))))))
 
@@ -193,10 +193,10 @@
         [(list op args ...) (cons err-list (map loop args))]
         [_ (list err-list)])))
 
-  (define exact-error
+  (define exact-values
     (let loop ([expr (test-input test)])
       (define expr-info (hash-ref errs expr))
-      (define exacts-list (hash-ref expr-info 'exacts))
+      (define exacts-list (hash-ref expr-info 'exact-values))
       (match expr
         [(list op args ...) (cons exacts-list (map loop args))]
         [_ (list exacts-list)])))
@@ -204,7 +204,7 @@
   (define tree
     (let loop ([expr (prog->fpcore (test-input test) (test-context test))]
                [err local-error]
-               [exact exact-error])
+               [exact exact-values])
       (match expr
         [(list op args ...)
          ;; err => (List (listof Integer) List ...)
@@ -212,8 +212,8 @@
                  (~a op)
                  'avg-error
                  (format-bits (errors-score (first err)))
-                 'exact-error
-                 (format-bits (errors-score (first exact)))
+                 'exact-value
+                 (first exact)
                  'children
                  (map loop args (rest err) (rest exact)))]
         ;; err => (List (listof Integer))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -8,11 +8,14 @@
          "../utils/float.rkt"
          "../syntax/platform.rkt"
          "../syntax/read.rkt"
+         "../syntax/read.rkt"
+         "rival.rkt"
          "points.rkt"
          "programs.rkt"
          "sampling.rkt"
          "simplify.rkt"
          "egg-herbie.rkt"
+         "compiler.rkt"
          "batch.rkt")
 
 (provide batch-localize-costs
@@ -132,7 +135,9 @@
   (define nodes (batch-nodes expr-batch))
   (define roots (batch-roots expr-batch))
 
+  ; TODO don't ignore the status code from make-real-compiler in eval-progs-real
   (define subexprs-fn (eval-progs-real (map prog->spec exprs-list) ctx-list))
+  (define actual-value-fn (compile-progs exprs-list ctx))
 
   (define errs
     (for/vector #:length (vector-length roots)
@@ -144,12 +149,21 @@
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
+  (define actuals-out
+    (for/vector #:length (vector-length roots)
+                ([node (in-vector roots)])
+      (make-vector (pcontext-length (*pcontext*)))))
+
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [pt-idx (in-naturals)])
+
     (define exacts (list->vector (apply subexprs-fn pt)))
+    (define actuals (apply actual-value-fn pt))
+
     (for ([expr (in-list exprs-list)]
           [root (in-vector roots)]
           [exact (in-vector exacts)]
+          [actual (in-vector actuals)]
           [expr-idx (in-naturals)])
       (define err
         (match (vector-ref nodes root)
@@ -167,7 +181,8 @@
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference exact approx repr)]))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
-      (vector-set! (vector-ref errs expr-idx) pt-idx err)))
+      (vector-set! (vector-ref errs expr-idx) pt-idx err)
+      (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)))
 
   (define n 0)
   (for/list ([subexprs (in-list subexprss)])
@@ -176,7 +191,9 @@
                       (hasheq 'errs
                               (vector->list (vector-ref errs n))
                               'exact-values
-                              (vector->list (vector-ref exacts-out n))))
+                              (vector->list (vector-ref exacts-out n))
+                              'actual-values
+                              (vector->list (vector-ref actuals-out n))))
         (set! n (add1 n))))))
 
 ;; Compute the local error of every subexpression of `prog`
@@ -201,10 +218,19 @@
         [(list op args ...) (cons exacts-list (map loop args))]
         [_ (list exacts-list)])))
 
+  (define actual-values
+    (let loop ([expr (test-input test)])
+      (define expr-info (hash-ref errs expr))
+      (define actual-list (hash-ref expr-info 'actual-values))
+      (match expr
+        [(list op args ...) (cons actual-list (map loop args))]
+        [_ (list actual-list)])))
+
   (define tree
     (let loop ([expr (prog->fpcore (test-input test) (test-context test))]
                [err local-error]
-               [exact exact-values])
+               [exact exact-values]
+               [actual actual-values])
       (match expr
         [(list op args ...)
          ;; err => (List (listof Integer) List ...)
@@ -214,8 +240,20 @@
                  (format-bits (errors-score (first err)))
                  'exact-value
                  (map ~s (first exact))
+                 'actual-value
+                 (map ~s (first actual))
                  'children
-                 (map loop args (rest err) (rest exact)))]
+                 (map loop args (rest err) (rest exact) (rest actual)))]
         ;; err => (List (listof Integer))
-        [_ (hasheq 'e (~a expr) 'avg-error (format-bits (errors-score (first err))) 'children '())])))
+        [_
+         (hasheq 'e
+                 (~a expr)
+                 'avg-error
+                 (format-bits (errors-score (first err)))
+                 'exact-value
+                 (map ~s (first exact))
+                 'actual-value
+                 (map ~s (first actual))
+                 'children
+                 '())])))
   tree)


### PR DESCRIPTION
This PR adds the exact error info to the `localerror` endpoint. Resulting in the JSON result looking similar to the following. Being an addition to the current JSON and not breaking the structure in which Odyessy knows how to consume. 

Testing locally Odyessy looks to function as normal with this additional information being added.

```json
{
  'avg-error': '0.0',
  children: [
    {
      'avg-error': '0',
      children: [Array],
      e: '+',
      'exact-error': '+nan.0'
    }
```

`+nan.0` is interpreted as undefined on the Odyessy side and is filtered out in this Odyessy [PR](https://github.com/herbie-fp/odyssey/pull/118) as there is no error here or maybe this should just be 0 like `avg-error` is?

Side effects: 
- I have consolidated where and how the local-error tree is constructed as it was currently being split between two places and `local-error-as-tree` is only called in one place.
- I have pruned these exact errors in two places as this new information isn't needed for the `batch-localize-errors` or `explain`.