### PR TITLE
Make eval faster through inlining

### DIFF
--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -53,6 +53,11 @@
 ;; Herbie's standard error measure is the average bits of error across
 ;; all points in a pcontext.
 
+(define (point-error out exact repr)
+  (if ((representation-special-value? repr) out)
+      (+ 1 (expt 2 (representation-total-bits repr)))
+      (ulp-difference out exact repr)))
+
 (define (average . s)
   (/ (apply + s) (length s)))
 
@@ -73,10 +78,10 @@
 (define (batch-errors exprs pcontext ctx)
   (define fn (compile-progs exprs ctx))
   (define repr (context-repr ctx))
-  (define special-value? (representation-special-value repr))
+  (define special-value? (representation-special-value? repr))
   (define special-error (+ 1 (expt 2 (representation-total-bits repr))))
   (define ->ordinal (representation-repr->ordinal repr))
-  (for/list ([exact (in-vector (pcontext-exacts pcontext))])
+  (for/list ([(point exact) (in-pcontext pcontext)])
     ; Shared across all outs for maximum performance
     (define exact-ordinal (->ordinal exact))
     (with-handlers ([exn:fail? (batch-errors-handler exprs point)])


### PR DESCRIPTION
This PR inlines `ulp-difference` into `point-error` into `batch-errors` to minimize the number of repeated calls to `bigfloat->flonum` and otherwise reduce eval time. Right now, eval takes 10min and only 25% of that is spent actually evaluating expressions; the hope is to bring that up somewhat. Let's see.