### PR TITLE
Batch-input to egg

### DIFF
--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -13,7 +13,8 @@
          deref ; Batchref -> Expr
          batch-replace ; Batch -> Lambda -> Batch
          egg-nodes->batch ; Nodes -> Spec-maps -> Batch -> (Listof Root)
-         batchref->expr) ; Batchref -> Expr
+         batchref->expr ; Batchref -> Expr
+         batch-extract-exprs) ; Batch -> (Listof Root) -> (Listof Expr)
 
 ;; This function defines the recursive structure of expressions
 
@@ -79,6 +80,14 @@
   (when timeline-push
     (timeline-push! 'compiler size (batch-length final)))
   final)
+
+(define (batch-extract-exprs b roots)
+  (define exprs (make-vector (batch-length b)))
+  (for ([node (in-vector (batch-nodes b))]
+        [idx (in-naturals)])
+    (vector-set! exprs idx (expr-recurse node (lambda (x) (vector-ref exprs x)))))
+  (for/list ([root roots])
+    (vector-ref exprs root)))
 
 (define (batch->progs b)
   (define exprs (make-vector (batch-length b)))

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -242,6 +242,15 @@
     (set-mutable-batch-index! out (batch-restore-index input-batch)))
   (values add-root clean-batch finalize-batch))
 
+(define input-batch (progs->batch (list (approx `(+ 3 (pow ,(literal 2 'something) x)) `(+ 2 x)))))
+(batch-nodes input-batch)
+(batch-nodes (batch-replace input-batch
+                            (lambda (node)
+                              (match node
+                                [(literal v _) v]
+                                [(approx spec impl) (approx spec impl)]
+                                [node node]))))
+
 ; Tests for progs->batch and batch->progs
 (module+ test
   (require rackunit)

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -242,15 +242,6 @@
     (set-mutable-batch-index! out (batch-restore-index input-batch)))
   (values add-root clean-batch finalize-batch))
 
-(define input-batch (progs->batch (list (approx `(+ 3 (pow ,(literal 2 'something) x)) `(+ 2 x)))))
-(batch-nodes input-batch)
-(batch-nodes (batch-replace input-batch
-                            (lambda (node)
-                              (match node
-                                [(literal v _) v]
-                                [(approx spec impl) (approx spec impl)]
-                                [node node]))))
-
 ; Tests for progs->batch and batch->progs
 (module+ test
   (require rackunit)

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -14,7 +14,8 @@
          batch-replace ; Batch -> Lambda -> Batch
          egg-nodes->batch ; Nodes -> Spec-maps -> Batch -> (Listof Root)
          batchref->expr ; Batchref -> Expr
-         batch-extract-exprs) ; Batch -> (Listof Root) -> (Listof Expr)
+         batch-extract-exprs ; Batch -> (Listof Root) -> (Listof Expr)
+         remove-zombie-nodes) ; Batch -> Batch
 
 ;; This function defines the recursive structure of expressions
 
@@ -117,7 +118,9 @@
   (define roots (vector-map (curry vector-ref mapping) (batch-roots b)))
   (mutable-batch->immutable out roots))
 
-; The function removes any zombie nodes from batch
+; The function removes any zombie nodes from batch with respect to the roots
+; Time complexity: O(|R| + |N|), where |R| - number of roots, |N| - length of nodes
+; Space complexity: O(|N| + |N*| + |R|), where |N*| is a length of nodes without zombie nodes
 (define (remove-zombie-nodes input-batch)
   (define nodes (batch-nodes input-batch))
   (define roots (batch-roots input-batch))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -165,54 +165,6 @@
 
     (vector-set! mappings n (insert-node! node* root?)))
 
-  ; ------------- Deboogs
-  #;(define expr->id (make-hash))
-  #;(define (insert! expr [root? #f])
-      ; transform the expression into a node pointing
-      ; to its child e-classes
-      (define node
-        (match expr
-          [(? number?) expr]
-          [(? symbol?) (normalize-var expr)]
-          [(literal v _) v]
-          [(approx spec impl)
-           (define spec* (insert! spec))
-           (define impl* (insert! impl))
-           (hash-ref! id->spec
-                      spec*
-                      (lambda ()
-                        (define spec* (normalize-spec spec)) ; preserved spec for extraction
-                        (define type (representation-type (repr-of impl ctx))) ; track type of spec
-                        (cons spec* type)))
-           (list '$approx spec* impl*)]
-          [(list op args ...) (cons op (map insert! args))]))
-      ; always insert the node if it is a root since
-      ; the e-graph tracks which nodes are roots
-      (cond
-        [root? (insert-node! node #t)]
-        [else
-         (define out (hash-ref! expr->id node (lambda () (insert-node! node #f))))
-         out]))
-
-  #;(define exprs (batch-extract-exprs batch roots))
-  #;(define out
-      (for/list ([expr (in-list exprs)])
-        (insert! expr #t)))
-  #;(define out
-      (for/list ([root (in-vector (batch-roots insert-batch))])
-        (remap root)))
-
-  #;
-  (when (or (equal?
-             out
-             '(26 25 24 23 38 34 29 27 46 45 65 64 53 47 70 75 74 73 8 11 10 33 41 43 52 66 67 69))
-            (equal?
-             out
-             '(26 25 24 23 38 37 32 30 46 45 65 64 63 57 70 75 74 73 17 19 18 36 41 43 62 66 67 69)))
-    (println (for/list ([root (in-vector (batch-roots insert-batch))])
-               (batch-ref insert-batch root))))
-  ;------------
-
   (for/list ([root (in-vector (batch-roots insert-batch))])
     (remap root)))
 

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -38,8 +38,10 @@
   (define lowering-rules (platform-lowering-rules))
 
   ; egg runner (2-phases for real rewrites and implementation selection)
+  (define batch (progs->batch progs))
   (define runner
-    (make-egg-runner progs
+    (make-egg-runner batch
+                     (batch-roots batch)
                      reprs
                      `((,lifting-rules . ((iteration . 1) (scheduler . simple)))
                        (,rules . ((node . ,(*node-limit*))))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -19,7 +19,8 @@
          "preprocess.rkt"
          "programs.rkt"
          "../utils/timeline.rkt"
-         "soundiness.rkt")
+         "soundiness.rkt"
+         "batch.rkt")
 (provide run-improve!)
 
 ;; The Herbie main loop goes through a simple iterative process:
@@ -374,7 +375,8 @@
      ; egg runner
      (define exprs (map alt-expr alts))
      (define reprs (map (lambda (expr) (repr-of expr (*context*))) exprs))
-     (define runner (make-egg-runner exprs reprs schedule))
+     (define batch (progs->batch exprs))
+     (define runner (make-egg-runner batch (batch-roots batch) reprs schedule))
 
      ; run egg
      (define simplified

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -40,7 +40,8 @@
         `((,lowering-rules . ((iteration . 1) (scheduler . simple))))))
 
   ; run egg
-  (define runner (make-egg-runner (map alt-expr approxs) reprs schedule))
+  (define batch (progs->batch (map alt-expr approxs)))
+  (define runner (make-egg-runner batch (batch-roots batch) reprs schedule))
   (define simplification-options
     (simplify-batch runner
                     (typed-egg-extractor
@@ -133,7 +134,9 @@
   (define exprs (map alt-expr altns))
   (define reprs (map (curryr repr-of (*context*)) exprs))
   (timeline-push! 'inputs (map ~a exprs))
-  (define runner (make-egg-runner exprs reprs schedule #:context (*context*)))
+
+  (define batch (progs->batch exprs))
+  (define runner (make-egg-runner batch (batch-roots batch) reprs schedule #:context (*context*)))
   ; variantss is a (listof roots))
   (define rootss (run-egg runner `(multi . ,extractor)))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -90,10 +90,13 @@
                 [altn (in-list altns)]
                 [fv (in-list free-vars)]
                 #:when (member var fv)) ; check whether var exists in expr at all
-            (for ([_ (in-range (*taylor-order-limit*))])
+            ;(printf "orig-expr = ~a\n" (alt-expr altn))
+            (for ([i (in-range (*taylor-order-limit*))])
               (define gen (genexpr))
+              ;(printf "~a) expression=~a\n" i gen)
               (unless (spec-has-nan? gen)
-                (sow (alt gen `(taylor ,name ,var) (list altn) '())))))
+                (sow (alt gen `(taylor ,name ,var) (list altn) '()))))
+            #;(sleep 20))
           (timeline-stop!))))
 
 (define (spec-has-nan? expr)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -90,13 +90,10 @@
                 [altn (in-list altns)]
                 [fv (in-list free-vars)]
                 #:when (member var fv)) ; check whether var exists in expr at all
-            ;(printf "orig-expr = ~a\n" (alt-expr altn))
             (for ([i (in-range (*taylor-order-limit*))])
               (define gen (genexpr))
-              ;(printf "~a) expression=~a\n" i gen)
               (unless (spec-has-nan? gen)
-                (sow (alt gen `(taylor ,name ,var) (list altn) '()))))
-            #;(sleep 20))
+                (sow (alt gen `(taylor ,name ,var) (list altn) '())))))
           (timeline-stop!))))
 
 (define (spec-has-nan? expr)

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -13,7 +13,8 @@
          "programs.rkt"
          "points.rkt"
          "../utils/timeline.rkt"
-         "../utils/float.rkt")
+         "../utils/float.rkt"
+         "batch.rkt")
 
 (provide find-preprocessing
          preprocess-pcontext
@@ -66,7 +67,8 @@
       (,lowering-rules . ((iteration . 1) (scheduler . simple)))))
 
   ; egg query
-  (define runner (make-egg-runner (list expr) (list (context-repr ctx)) schedule))
+  (define batch (progs->batch (list expr)))
+  (define runner (make-egg-runner batch (batch-roots batch) (list (context-repr ctx)) schedule))
 
   ; run egg
   (define simplified
@@ -100,8 +102,11 @@
 
   ;; make egg runner
   (define rules (real-rules (*simplify-rules*)))
+
+  (define batch (progs->batch specs))
   (define runner
-    (make-egg-runner specs
+    (make-egg-runner batch
+                     (batch-roots batch)
                      (map (lambda (_) (context-repr ctx)) specs)
                      `((,rules . ((node . ,(*node-limit*)))))))
 

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -28,6 +28,7 @@
   (match expr
     [(? literal?) (get-representation (literal-precision expr))]
     [(? variable?) (context-lookup ctx expr)]
+    [(list '$approx _ impl) (repr-of impl ctx)]
     [(approx _ impl) (repr-of impl ctx)]
     [(list 'if cond ift iff) (repr-of ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -2,7 +2,8 @@
 
 (require "../syntax/syntax.rkt"
          "../syntax/types.rkt"
-         "../utils/common.rkt")
+         "../utils/common.rkt"
+         (only-in "batch.rkt" batch-nodes))
 
 (provide expr?
          expr-contains?
@@ -12,6 +13,7 @@
          spec-prog?
          impl-prog?
          repr-of
+         repr-of-node
          location-do
          location-get
          free-variables
@@ -31,6 +33,17 @@
     [(list '$approx _ impl) (repr-of impl ctx)]
     [(approx _ impl) (repr-of impl ctx)]
     [(list 'if cond ift iff) (repr-of ift ctx)]
+    [(list op args ...) (impl-info op 'otype)]))
+
+; Index inside (batch-nodes batch) -> type
+(define (repr-of-node batch idx ctx)
+  (define node (vector-ref (batch-nodes batch) idx))
+  (match node
+    [(? literal?) (get-representation (literal-precision node))]
+    [(? variable?) (context-lookup ctx node)]
+    [(list '$approx _ impl)
+     (repr-of-node batch impl ctx)] ; here is a hack to match an after-parse structure
+    [(list 'if cond ift iff) (repr-of-node batch ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))
 
 (define (expr-contains? expr pred)

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -30,7 +30,6 @@
   (match expr
     [(? literal?) (get-representation (literal-precision expr))]
     [(? variable?) (context-lookup ctx expr)]
-    [(list '$approx _ impl) (repr-of impl ctx)]
     [(approx _ impl) (repr-of impl ctx)]
     [(list 'if cond ift iff) (repr-of ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -26,16 +26,14 @@
     (define (next [iter 0])
       (define coeff (simplify (replace-expression (coeffs i) var ((cdr tform) var))))
       (set! i (+ i 1))
-      (define out
-        (match coeff
-          [0
-           (if (< iter iters)
-               (next (+ iter 1))
-               (simplify (make-horner ((cdr tform) var) (reverse terms))))]
-          [_
-           (set! terms (cons (cons coeff (- i offset 1)) terms))
-           (simplify (make-horner ((cdr tform) var) (reverse terms)))]))
-      out)
+      (match coeff
+        [0
+         (if (< iter iters)
+             (next (+ iter 1))
+             (simplify (make-horner ((cdr tform) var) (reverse terms))))]
+        [_
+         (set! terms (cons (cons coeff (- i offset 1)) terms))
+         (simplify (make-horner ((cdr tform) var) (reverse terms)))]))
     next))
 
 ;; Our Taylor expander prefers sin, cos, exp, log, neg over trig, htrig, pow, and subtraction

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -20,13 +20,11 @@
   (define taylor-approxs (taylor var batch))
   (for/list ([root (in-vector (batch-roots batch))])
     (match-define (cons offset coeffs) (vector-ref taylor-approxs root))
-    ;(printf "coeffs=~a, offset=~a\n" coeffs offset)
     (define i 0)
     (define terms '())
 
     (define (next [iter 0])
       (define coeff (simplify (replace-expression (coeffs i) var ((cdr tform) var))))
-      ;(printf "iter=~a, coeff=~a\n" iter coeff)
       (set! i (+ i 1))
       (define out
         (match coeff
@@ -37,7 +35,6 @@
           [_
            (set! terms (cons (cons coeff (- i offset 1)) terms))
            (simplify (make-horner ((cdr tform) var) (reverse terms)))]))
-      ;(printf "out=~a\n" out)
       out)
     next))
 


### PR DESCRIPTION
This PR introduces new changes to `egg-herbie` pipeline.
Particularly speaking, `batch`-type input has been implemented for `egg`.
The reason behind this change is: 
Previously, `egg` received a `listof Expr` as an input for `egraph`. These expressions were converted to `batch` structure using internal `egraph` functions (`egraph_add_enode`).
We have noticed that this conversion from `listof Expr` to `batch-egraph` is redundant as we are planning to switch to `batch` structure for expressions inside Herbie.

Instead of doing what is described above, we convert this `listof Expr` to a `batch` on Herbie side and pass nodes to `egraph`.

The new strategy brings some speedup at `egraph-add-exprs` (370s -> 258s) and some slowdown on conversions from `progs->batch` (159s -> 210s). In addition, some extra conversions between `batch` and `listof Expr` are introduced at `simplify-batch` (~45s). Overall, the runtime is expected to be the same (and it is).

Tech details of PR:
The PR changes structure of `egraph-run-schedule`. Instead of storing `exprs`, it stores `batch` and corresponding `roots` that are to be inserted. 
The new structure of `egraph-run-schedule` matches the new `insert to egg` strategy.