### PR TITLE
Add new benchmark for log transform.

### DIFF
--- a/bench/graphics/log-transform.fpcore
+++ b/bench/graphics/log-transform.fpcore
@@ -1,12 +1,10 @@
 ; This example is taken from the Image Processing domain and referred to 
-; as "Logarithmic Transform". This in it's basic form is used to bring out
+; as "Logarithmic Transform". This in its basic form is used to bring out
 ; details in dark parts of an image. This instantiation of the idea is for 1D
 ; as opposed to 2D images.
 
 (FPCore (c x y)
   :name "Logarithmic Transform"
-  :precision binary64
-  :pre (and (and (and (<= -1.79e+308 c) (<= c 1.79e+308)) (and (<= -1.79e+308 x) (<= x 1.79e+308))) (and (<= -1.79e+308 y) (<= y 1.79e+308)))
   :alt
     (* c (log1p (* (expm1 x) y)))
 

--- a/bench/graphics/log-transform.fpcore
+++ b/bench/graphics/log-transform.fpcore
@@ -1,0 +1,13 @@
+; This example is taken from the Image Processing domain and referred to 
+; as "Logarithmic Transform". This in it's basic form is used to bring out
+; details in dark parts of an image. This instantiation of the idea is for 1D
+; as opposed to 2D images.
+
+(FPCore (c x y)
+  :name "Logarithmic Transform"
+  :precision binary64
+  :pre (and (and (and (<= -1.79e+308 c) (<= c 1.79e+308)) (and (<= -1.79e+308 x) (<= x 1.79e+308))) (and (<= -1.79e+308 y) (<= y 1.79e+308)))
+  :alt
+    (* c (log1p (* (expm1 x) y)))
+
+  (* c (log (+ 1.0 (* (- (pow E x) 1.0) y)))))


### PR DESCRIPTION
This PR adds a new benchmark to get a graphics suit of Herbie. This benchmark is motivated by the Image Processing domain of computer science. This Log Transform is used to bring out detail in dark parts of images.

Credit to Professor Elhabian for the example.
 
<img width="1180" alt="Screenshot 2024-09-12 at 11 23 11 AM" src="https://github.com/user-attachments/assets/1cccbd8a-46b8-431c-9d89-50c4f834d452">