### PR TITLE
Add CORS headers to checkstatus API

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -353,14 +353,16 @@
                                   (string->bytes/utf-8
                                    (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
+                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                     '())]
     [timeline
      (response 202
                #"Job in progress"
                (current-seconds)
                #"text/plain"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
+               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out)
                  (display (apply string-append
                                  (for/list ([entry timeline])


### PR DESCRIPTION
This PR adds CORS headers to the `checkstatus` API to allow Odyessy to start calling the new Async API's.