### PR TITLE
Server no place mode

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -381,7 +381,6 @@
 (define (improve req)
   (improve-common req
                   (λ (command)
-                    (eprintf "HERE\n")
                     (define job-id (start-job command))
                     (wait-for-job job-id)
                     (redirect-to (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -381,6 +381,7 @@
 (define (improve req)
   (improve-common req
                   (λ (command)
+                    (eprintf "HERE\n")
                     (define job-id (start-job command))
                     (wait-for-job job-id)
                     (redirect-to (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -124,7 +124,10 @@
      (place-channel-put manager (list 'improve b))
      (log "Getting improve results.\n")
      (place-channel-get a)]
-    [else #f])) ; TODO Not supported yet
+    [else
+     (for/list ([(job-id result) (in-hash single-threaded-cache)]
+                #:when (equal? (hash-ref result 'command) "improve"))
+       (get-table-data-from-hash result (make-path job-id)))]))
 
 (define (job-count)
   (cond

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -57,7 +57,7 @@
   (define demo-port 8000)
   (define demo-public #f)
 
-  (define threads #f)
+  (define threads 1)
   (define report-note #f)
   (define timeout-set? #f)
 


### PR DESCRIPTION
This PR adds a "single thread" mode which the goal of is to have a mode that does not use places. Places can cause difficult debugging of lower-level core Herbie code so having a mode that does not add this indirection is a must before being able to use the server for other parts of Herbie like reports which generate the nightly.

In this mode, jobs are run when `start-job` is called and not when `wait-for-job` is called in order to support the demo. However, the demo doesn't stream the timeline and blocks until the job is completed.