### PR TITLE
Concrete Values

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -166,7 +166,7 @@ const localError2 = await (await fetch(makeEndpoint("/api/localerror"), {
 assert.notEqual(localError1.job, localError2.job)
 // Assert local error works for default example.
 const ignoredValue = 1e+308
-// '(FPCore (1e-100) (- (sqrt (+ x 1)) (sqrt x)))'
+'(FPCore (1e-100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
   method: 'POST', body: JSON.stringify({
     formula: FPCoreFormula, sample: [[[1e-100], ignoredValue]], seed: 5
@@ -180,12 +180,12 @@ const xNode = localError5.tree['children'][0]['children'][0]['children'][0]
 const oneNode = localError5.tree['children'][0]['children'][0]['children'][1]
 
 //        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
-assertCheckNode(rootMinusNode, '-', '1.0', '0', '1.0', '-1e-50', 1)
-assertCheckNode(leftSQRT, 'sqrt', '1.0', '0', '1.0', '5e-101', 1)
-assertCheckNode(rightSQRT, 'sqrt', '1e-50', '0', '1e-50', '2.379726195519099e-68', 1)
-assertCheckNode(plusNode, '+', '1.0', '0', '1.0', '1e-100', 1)
-assertCheckNode(xNode, 'x', '1e-100', '0', '1e-100', '0', 1)
-assertCheckNode(oneNode, '1.0', '1.0', '0', '1.0', '0', 1)
+assertCheckNode(rootMinusNode, '-', '1.0', '0.0', '1.0', '-1e-50', 1)
+assertCheckNode(leftSQRT, 'sqrt', '1.0', '0.0', '1.0', '5e-101', 1)
+assertCheckNode(rightSQRT, 'sqrt', '1e-50', '0.0', '1e-50', '2.379726195519099e-68', 1)
+assertCheckNode(plusNode, '+', '1.0', '0.0', '1.0', '1e-100', 1)
+assertCheckNode(xNode, 'x', '1e-100', '0.0', '1e-100', '0', 1)
+assertCheckNode(oneNode, '1.0', '1.0', '0.0', '1.0', '-0.0', 1)
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -199,17 +199,13 @@ const rightSQRT6 = localError6.tree['children'][1]
 const plusNode6 = localError6.tree['children'][0]['children'][0]
 const xNode6 = localError6.tree['children'][0]['children'][0]['children'][0]
 const oneNode6 = localError6.tree['children'][0]['children'][0]['children'][1]
-// (eval (- (- (sqrt (+ 1e100 1)) (sqrt 1e100)) 5e-51))
-// TODO finish TEST
 //        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
-// console.log(rootMinusNode6)
-// assertCheckNode(rootMinusNode6, '-', '0.0', '61.7', '5e-51', '-1e-50', 1)
-// console.log(leftSQRT6)
-// assertCheckNode(leftSQRT6, 'sqrt', '1.0', '0', '1.0000000000000001e50', '-9.9999999999999995e33', 1)
-assertCheckNode(rightSQRT6, 'sqrt', '1e+50', '0', '1e+50', '-6.834625285603891e+33', 1)
-assertCheckNode(plusNode6, '+', '1e+100', '0', '1e+100', '1.0', 1)
-assertCheckNode(xNode6, 'x', '1e+100', '0', '1e+100', '0', 1)
-assertCheckNode(oneNode6, '1.0', '1.0', '0', '1.0', '0', 1)
+assertCheckNode(rootMinusNode6, '-', '0.0', '61.7', '5e-51', '-7.78383463033115e-68', 3854499065107888000)
+assertCheckNode(leftSQRT6, 'sqrt', '1e+50', '0.0', '1e+50', '-6.834625285603891e+33', 1)
+assertCheckNode(rightSQRT6, 'sqrt', '1e+50', '0.0', '1e+50', '-6.834625285603891e+33', 1)
+assertCheckNode(plusNode6, '+', '1e+100', '0.0', '1e+100', '1.0', 1)
+assertCheckNode(xNode6, 'x', '1e+100', '0.0', '1e+100', '0', 1)
+assertCheckNode(oneNode6, '1.0', '1.0', '0.0', '1.0', '-0.0', 1)
 
 function assertCheckNode(node, name, approx, avg_error, exact_value, true_error_value, ulps_error) {
   assert.equal(node['e'], name)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -91,11 +91,9 @@ const explainBody = {
     formula: FPCoreFormula, sample: sample.points
   })
 }
-
 const explain = await (await fetch(makeEndpoint("/api/explanations"), explainBody)).json()
 assertIdAndPath(explain)
 assert.equal(explain.explanation.length > 0, true, 'explanation should not be empty');
-
 const explainAsyncResult = await callAsyncAndWaitJSONResult("/api/start/explanations", explainBody)
 assertIdAndPath(explainAsyncResult)
 assert.equal(explainAsyncResult.explanation.length > 0, true, 'explanation should not be empty');
@@ -144,10 +142,9 @@ assert.deepEqual(calculateAsyncResult.points, [[[1], -1.4142135623730951]])
 // Local error endpoint
 const localErrorBody = {
   method: 'POST', body: JSON.stringify({
-    formula: FPCoreFormula, sample: sample2.points
+    formula: FPCoreFormula, sample: sample.points
   })
 }
-
 const localError = await (await fetch(makeEndpoint("/api/localerror"), localErrorBody)).json()
 assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -190,6 +190,30 @@ assertCheckNode(plusNode, '+', '1.0', '0', '1.0', '1e-100', 1)
 assertCheckNode(xNode, 'x', '1e-100', '0', '1e-100', '0', 1)
 assertCheckNode(oneNode, '1.0', '1.0', '0', '1.0', '0', 1)
 
+// '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
+const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: [[[1e100], ignoredValue]], seed: 5
+  })
+})).json()
+const rootMinusNode6 = localError6.tree
+const leftSQRT6 = localError6.tree['children'][0]
+const rightSQRT6 = localError6.tree['children'][1]
+const plusNode6 = localError6.tree['children'][0]['children'][0]
+const xNode6 = localError6.tree['children'][0]['children'][0]['children'][0]
+const oneNode6 = localError6.tree['children'][0]['children'][0]['children'][1]
+// (eval (- (- (sqrt (+ 1e100 1)) (sqrt 1e100)) 5e-51))
+// TODO finish TEST
+//        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
+// console.log(rootMinusNode6)
+// assertCheckNode(rootMinusNode6, '-', '0.0', '61.7', '5e-51', '-1e-50', 1)
+// console.log(leftSQRT6)
+// assertCheckNode(leftSQRT6, 'sqrt', '1.0', '0', '1.0000000000000001e50', '-9.9999999999999995e33', 1)
+assertCheckNode(rightSQRT6, 'sqrt', '1e+50', '0', '1e+50', '-6.834625285603891e+33', 1)
+assertCheckNode(plusNode6, '+', '1e+100', '0', '1e+100', '1.0', 1)
+assertCheckNode(xNode6, 'x', '1e+100', '0', '1e+100', '0', 1)
+assertCheckNode(oneNode6, '1.0', '1.0', '0', '1.0', '0', 1)
+
 function assertCheckNode(node, name, approx, avg_error, exact_value, true_error_value, ulps_error) {
   assert.equal(node['e'], name)
   assert.equal(node['approx-value'][0], approx)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -6,6 +6,7 @@ import { strict as assert } from 'node:assert';  // use strict equality everywhe
 const SAMPLE_SIZE = 8000
 const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
+const FPCoreFormula3 = '(FPCore (x) (if (<= (- (sqrt (+ x 1.0)) (sqrt x)) 0.05) (* 0.5 (sqrt (/ 1.0 x))) (fma (fma (- 0.125) x 0.5) x (- 1.0 (sqrt x)))))'
 const eval_sample = [[[1], -1.4142135623730951]]
 
 // improve endpoint
@@ -215,6 +216,14 @@ function assertCheckNode(node, name, approx, avg_error, exact_value, true_error_
   assert.equal(node['true-error-value'][0], true_error_value)
   assert.equal(node['ulps-error'][0], ulps_error)
 }
+
+// TODO if statements
+// const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
+//   method: 'POST', body: JSON.stringify({
+//     formula: FPCoreFormula3, sample: [[[1e100], ignoredValue]], seed: 5
+//   })
+// })).json()
+
 // Alternatives endpoint
 const altBody = {
   method: 'POST', body: JSON.stringify({

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -8,56 +8,56 @@ const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
 const eval_sample = [[[1], -1.4142135623730951]]
 
-// improve endpoint
-const improveResponse = await fetch(makeEndpoint(`/improve?formula=${encodeURIComponent(FPCoreFormula2)}`), { method: 'GET' })
-assert.equal(improveResponse.status, 200)
-let redirect = improveResponse.url.split("/")
-const jobID = redirect[3].split(".")[0]
-// This test is a little flaky as the character count of the response is not consistent.
-// const improveHTML = await improveResponse.text()
-// const improveHTMLexpectedCount = 25871
-// assert.equal(improveHTML.length, improveHTMLexpectedCount, `HTML response character count should be ${improveHTMLexpectedCount} unless HTML changes.`)
+// // improve endpoint
+// const improveResponse = await fetch(makeEndpoint(`/improve?formula=${encodeURIComponent(FPCoreFormula2)}`), { method: 'GET' })
+// assert.equal(improveResponse.status, 200)
+// let redirect = improveResponse.url.split("/")
+// const jobID = redirect[3].split(".")[0]
+// // This test is a little flaky as the character count of the response is not consistent.
+// // const improveHTML = await improveResponse.text()
+// // const improveHTMLexpectedCount = 25871
+// // assert.equal(improveHTML.length, improveHTMLexpectedCount, `HTML response character count should be ${improveHTMLexpectedCount} unless HTML changes.`)
 
-// timeline
-const timelineRSP = await fetch(makeEndpoint(`/timeline/${jobID}`), { method: 'GET' })
-assert.equal(timelineRSP.status, 201)
-const timeline = await timelineRSP.json()
-assert.equal(timeline.length > 0, true)
+// // timeline
+// const timelineRSP = await fetch(makeEndpoint(`/timeline/${jobID}`), { method: 'GET' })
+// assert.equal(timelineRSP.status, 201)
+// const timeline = await timelineRSP.json()
+// assert.equal(timeline.length > 0, true)
 
-// Test with a likely missing job-id
-const badTimelineRSP = await fetch(makeEndpoint("/timeline/42069"), { method: 'GET' })
-assert.equal(badTimelineRSP.status, 404)
+// // Test with a likely missing job-id
+// const badTimelineRSP = await fetch(makeEndpoint("/timeline/42069"), { method: 'GET' })
+// assert.equal(badTimelineRSP.status, 404)
 
-// improve-start endpoint
-const URIencodedBody = "formula=" + encodeURIComponent(FPCoreFormula)
-const startResponse = await fetch(makeEndpoint("/api/start/improve"), {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/x-www-form-urlencoded',
-  },
-  body: URIencodedBody
-})
-const testResult = (startResponse.status == 201 || startResponse.status == 202)
-assert.equal(testResult, true)
-const improveResultPath = startResponse.headers.get("location")
-let counter = 0
-let cap = 100
-// Check status endpoint
-let checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
-/*
-This is testing if the /api/start/improve test at the beginning has been completed. The cap and counter is a sort of timeout for the test. Ends up being 10 seconds max.
-*/
-while (checkStatus.status != 201 && counter < cap) {
-  counter += 1
-  checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
-  await new Promise(r => setTimeout(r, 100)); // ms
-}
-assert.equal(checkStatus.statusText, 'Job complete')
+// // improve-start endpoint
+// const URIencodedBody = "formula=" + encodeURIComponent(FPCoreFormula)
+// const startResponse = await fetch(makeEndpoint("/api/start/improve"), {
+//   method: 'POST',
+//   headers: {
+//     'Content-Type': 'application/x-www-form-urlencoded',
+//   },
+//   body: URIencodedBody
+// })
+// const testResult = (startResponse.status == 201 || startResponse.status == 202)
+// assert.equal(testResult, true)
+// const improveResultPath = startResponse.headers.get("location")
+// let counter = 0
+// let cap = 100
+// // Check status endpoint
+// let checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
+// /*
+// This is testing if the /api/start/improve test at the beginning has been completed. The cap and counter is a sort of timeout for the test. Ends up being 10 seconds max.
+// */
+// while (checkStatus.status != 201 && counter < cap) {
+//   counter += 1
+//   checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
+//   await new Promise(r => setTimeout(r, 100)); // ms
+// }
+// assert.equal(checkStatus.statusText, 'Job complete')
 
-// up endpoint
-const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
-assert.equal('Up', up.statusText)
-// TODO how do I test down state?
+// // up endpoint
+// const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
+// assert.equal('Up', up.statusText)
+// // TODO how do I test down state?
 
 // Sample endpoint
 const sampleBody = {
@@ -69,31 +69,35 @@ const sampleAsyncResult = await callAsyncAndWaitJSONResult("/api/start/sample", 
 const jid = sampleRSP.headers.get("x-herbie-job-id")
 assert.notEqual(jid, null)
 const sample = await sampleRSP.json()
-assertIdAndPath(sampleAsyncResult)
-assert.ok(sampleAsyncResult.points)
-assert.equal(sampleAsyncResult.points.length, SAMPLE_SIZE)
-assertIdAndPath(sample)
-assert.ok(sample.points)
-assert.equal(sample.points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
+// assertIdAndPath(sampleAsyncResult)
+// assert.ok(sampleAsyncResult.points)
+// assert.equal(sampleAsyncResult.points.length, SAMPLE_SIZE)
+// assertIdAndPath(sample)
+// assert.ok(sample.points)
+// assert.equal(sample.points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
 
-// Make second call to test that results are the same
-const sample2RPS = await fetch(makeEndpoint("/api/sample"), sampleBody)
-const jid2 = sample2RPS.headers.get("x-herbie-job-id")
-assert.notEqual(jid2, null)
-const sample2 = await sample2RPS.json()
-assertIdAndPath(sample2)
-assert.deepEqual(sample.points[1], sample2.points[1])
+// // Make second call to test that results are the same
+// const sample2RPS = await fetch(makeEndpoint("/api/sample"), sampleBody)
+// const jid2 = sample2RPS.headers.get("x-herbie-job-id")
+// assert.notEqual(jid2, null)
+// const sample2 = await sample2RPS.json()
+// assertIdAndPath(sample2)
+// assert.deepEqual(sample.points[1], sample2.points[1])
 
 //Explanations endpoint
 const explainBody = {
   method: 'POST',
   body: JSON.stringify({
-    formula: FPCoreFormula, sample: sample2.points
+    formula: FPCoreFormula, sample: sample.points
   })
 }
+
+console.log("HERE")
 const explain = await (await fetch(makeEndpoint("/api/explanations"), explainBody)).json()
 assertIdAndPath(explain)
 assert.equal(explain.explanation.length > 0, true, 'explanation should not be empty');
+
+console.log("HERE")
 const explainAsyncResult = await callAsyncAndWaitJSONResult("/api/start/explanations", explainBody)
 assertIdAndPath(explainAsyncResult)
 assert.equal(explainAsyncResult.explanation.length > 0, true, 'explanation should not be empty');
@@ -145,6 +149,7 @@ const localErrorBody = {
     formula: FPCoreFormula, sample: sample2.points
   })
 }
+
 const localError = await (await fetch(makeEndpoint("/api/localerror"), localErrorBody)).json()
 assertIdAndPath(localError)
 assert.equal(localError.tree['avg-error'] > 0, true)
@@ -164,7 +169,38 @@ const localError2 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test that different sample points produce different job ids ensuring that different results are served for these inputs.
 assert.notEqual(localError1.job, localError2.job)
+console.log("HERE")
+// Assert local error works for default example.
+const ignoredValue = 1e+308
+// '(FPCore (1e-100) (- (sqrt (+ x 1)) (sqrt x)))'
+const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula, sample: [[[1e-100], ignoredValue]], seed: 5
+  })
+})).json()
+const rootMinusNode = localError5.tree
+const leftSQRT = localError5.tree['children'][0]
+const rightSQRT = localError5.tree['children'][1]
+const plusNode = localError5.tree['children'][0]['children'][0]
+const xNode = localError5.tree['children'][0]['children'][0]['children'][0]
+const oneNode = localError5.tree['children'][0]['children'][0]['children'][1]
 
+//        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
+assertCheckNode(rootMinusNode, '-', '1.0', '0', '1.0', '-1e-50', 1)
+assertCheckNode(leftSQRT, 'sqrt', '1.0', '0', '1.0', '5e-101', 1)
+assertCheckNode(rightSQRT, 'sqrt', '1e-50', '0', '1e-50', '2.379726195519099e-68', 1)
+assertCheckNode(plusNode, '+', '1.0', '0', '1.0', '1e-100', 1)
+assertCheckNode(xNode, 'x', '1e-100', '0', '1e-100', '0', 1)
+assertCheckNode(oneNode, '1.0', '1.0', '0', '1.0', '0', 1)
+
+function assertCheckNode(node, name, approx, avg_error, exact_value, true_error_value, ulps_error) {
+  assert.equal(node['e'], name)
+  assert.equal(node['approx-value'][0], approx)
+  assert.equal(node['avg-error'], avg_error)
+  assert.equal(node['exact-value'][0], exact_value)
+  assert.equal(node['true-error-value'][0], true_error_value)
+  assert.equal(node['ulps-error'][0], ulps_error)
+}
 // Alternatives endpoint
 const altBody = {
   method: 'POST', body: JSON.stringify({

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -8,56 +8,56 @@ const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'
 const eval_sample = [[[1], -1.4142135623730951]]
 
-// // improve endpoint
-// const improveResponse = await fetch(makeEndpoint(`/improve?formula=${encodeURIComponent(FPCoreFormula2)}`), { method: 'GET' })
-// assert.equal(improveResponse.status, 200)
-// let redirect = improveResponse.url.split("/")
-// const jobID = redirect[3].split(".")[0]
-// // This test is a little flaky as the character count of the response is not consistent.
-// // const improveHTML = await improveResponse.text()
-// // const improveHTMLexpectedCount = 25871
-// // assert.equal(improveHTML.length, improveHTMLexpectedCount, `HTML response character count should be ${improveHTMLexpectedCount} unless HTML changes.`)
+// improve endpoint
+const improveResponse = await fetch(makeEndpoint(`/improve?formula=${encodeURIComponent(FPCoreFormula2)}`), { method: 'GET' })
+assert.equal(improveResponse.status, 200)
+let redirect = improveResponse.url.split("/")
+const jobID = redirect[3].split(".")[0]
+// This test is a little flaky as the character count of the response is not consistent.
+// const improveHTML = await improveResponse.text()
+// const improveHTMLexpectedCount = 25871
+// assert.equal(improveHTML.length, improveHTMLexpectedCount, `HTML response character count should be ${improveHTMLexpectedCount} unless HTML changes.`)
 
-// // timeline
-// const timelineRSP = await fetch(makeEndpoint(`/timeline/${jobID}`), { method: 'GET' })
-// assert.equal(timelineRSP.status, 201)
-// const timeline = await timelineRSP.json()
-// assert.equal(timeline.length > 0, true)
+// timeline
+const timelineRSP = await fetch(makeEndpoint(`/timeline/${jobID}`), { method: 'GET' })
+assert.equal(timelineRSP.status, 201)
+const timeline = await timelineRSP.json()
+assert.equal(timeline.length > 0, true)
 
-// // Test with a likely missing job-id
-// const badTimelineRSP = await fetch(makeEndpoint("/timeline/42069"), { method: 'GET' })
-// assert.equal(badTimelineRSP.status, 404)
+// Test with a likely missing job-id
+const badTimelineRSP = await fetch(makeEndpoint("/timeline/42069"), { method: 'GET' })
+assert.equal(badTimelineRSP.status, 404)
 
-// // improve-start endpoint
-// const URIencodedBody = "formula=" + encodeURIComponent(FPCoreFormula)
-// const startResponse = await fetch(makeEndpoint("/api/start/improve"), {
-//   method: 'POST',
-//   headers: {
-//     'Content-Type': 'application/x-www-form-urlencoded',
-//   },
-//   body: URIencodedBody
-// })
-// const testResult = (startResponse.status == 201 || startResponse.status == 202)
-// assert.equal(testResult, true)
-// const improveResultPath = startResponse.headers.get("location")
-// let counter = 0
-// let cap = 100
-// // Check status endpoint
-// let checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
-// /*
-// This is testing if the /api/start/improve test at the beginning has been completed. The cap and counter is a sort of timeout for the test. Ends up being 10 seconds max.
-// */
-// while (checkStatus.status != 201 && counter < cap) {
-//   counter += 1
-//   checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
-//   await new Promise(r => setTimeout(r, 100)); // ms
-// }
-// assert.equal(checkStatus.statusText, 'Job complete')
+// improve-start endpoint
+const URIencodedBody = "formula=" + encodeURIComponent(FPCoreFormula)
+const startResponse = await fetch(makeEndpoint("/api/start/improve"), {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  },
+  body: URIencodedBody
+})
+const testResult = (startResponse.status == 201 || startResponse.status == 202)
+assert.equal(testResult, true)
+const improveResultPath = startResponse.headers.get("location")
+let counter = 0
+let cap = 100
+// Check status endpoint
+let checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
+/*
+This is testing if the /api/start/improve test at the beginning has been completed. The cap and counter is a sort of timeout for the test. Ends up being 10 seconds max.
+*/
+while (checkStatus.status != 201 && counter < cap) {
+  counter += 1
+  checkStatus = await fetch(makeEndpoint(improveResultPath), { method: 'GET' })
+  await new Promise(r => setTimeout(r, 100)); // ms
+}
+assert.equal(checkStatus.statusText, 'Job complete')
 
-// // up endpoint
-// const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
-// assert.equal('Up', up.statusText)
-// // TODO how do I test down state?
+// up endpoint
+const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
+assert.equal('Up', up.statusText)
+// TODO how do I test down state?
 
 // Sample endpoint
 const sampleBody = {
@@ -69,20 +69,20 @@ const sampleAsyncResult = await callAsyncAndWaitJSONResult("/api/start/sample", 
 const jid = sampleRSP.headers.get("x-herbie-job-id")
 assert.notEqual(jid, null)
 const sample = await sampleRSP.json()
-// assertIdAndPath(sampleAsyncResult)
-// assert.ok(sampleAsyncResult.points)
-// assert.equal(sampleAsyncResult.points.length, SAMPLE_SIZE)
-// assertIdAndPath(sample)
-// assert.ok(sample.points)
-// assert.equal(sample.points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
+assertIdAndPath(sampleAsyncResult)
+assert.ok(sampleAsyncResult.points)
+assert.equal(sampleAsyncResult.points.length, SAMPLE_SIZE)
+assertIdAndPath(sample)
+assert.ok(sample.points)
+assert.equal(sample.points.length, SAMPLE_SIZE, `sample size should be ${SAMPLE_SIZE}`)
 
-// // Make second call to test that results are the same
-// const sample2RPS = await fetch(makeEndpoint("/api/sample"), sampleBody)
-// const jid2 = sample2RPS.headers.get("x-herbie-job-id")
-// assert.notEqual(jid2, null)
-// const sample2 = await sample2RPS.json()
-// assertIdAndPath(sample2)
-// assert.deepEqual(sample.points[1], sample2.points[1])
+// Make second call to test that results are the same
+const sample2RPS = await fetch(makeEndpoint("/api/sample"), sampleBody)
+const jid2 = sample2RPS.headers.get("x-herbie-job-id")
+assert.notEqual(jid2, null)
+const sample2 = await sample2RPS.json()
+assertIdAndPath(sample2)
+assert.deepEqual(sample.points[1], sample2.points[1])
 
 //Explanations endpoint
 const explainBody = {
@@ -92,12 +92,10 @@ const explainBody = {
   })
 }
 
-console.log("HERE")
 const explain = await (await fetch(makeEndpoint("/api/explanations"), explainBody)).json()
 assertIdAndPath(explain)
 assert.equal(explain.explanation.length > 0, true, 'explanation should not be empty');
 
-console.log("HERE")
 const explainAsyncResult = await callAsyncAndWaitJSONResult("/api/start/explanations", explainBody)
 assertIdAndPath(explainAsyncResult)
 assert.equal(explainAsyncResult.explanation.length > 0, true, 'explanation should not be empty');
@@ -169,7 +167,6 @@ const localError2 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test that different sample points produce different job ids ensuring that different results are served for these inputs.
 assert.notEqual(localError1.job, localError2.job)
-console.log("HERE")
 // Assert local error works for default example.
 const ignoredValue = 1e+308
 // '(FPCore (1e-100) (- (sqrt (+ x 1)) (sqrt x)))'

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -46,8 +46,7 @@
   (define pruned (make-hash))
   (for ([(k v) (in-hash errs)])
     (hash-set! pruned k (hash-ref v 'errs)))
-  (define idk (flip-lists (hash->list pruned)))
-  (match-define (cons subexprs pt-errorss) idk)
+  (match-define (cons subexprs pt-errorss) (flip-lists (hash->list pruned)))
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -41,7 +41,7 @@
 
   (define errs
     (parameterize ([*pcontext* pcontext])
-      (first (compute-local-errors (list (all-subexpressions expr)) (*context*)))))
+      (first (compute-local-errors (list (all-subexpressions expr)) (*context*) #f))))
 
   (define pruned (make-hash))
   (for ([(k v) (in-hash errs)])

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -45,7 +45,7 @@
 
   (define pruned (make-hash))
   (for ([(k v) (in-hash errs)])
-    (hash-set! pruned k (hash-ref v 'errs)))
+    (hash-set! pruned k (hash-ref v 'ulp-errs)))
   (match-define (cons subexprs pt-errorss) (flip-lists (hash->list pruned)))
 
   (define pt-worst-subexpr

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -38,15 +38,10 @@
     [else #t]))
 
 (define (actual-errors expr pcontext)
-
-  (define errs
+  (match-define (cons subexprs pt-errorss)
     (parameterize ([*pcontext* pcontext])
-      (first (compute-local-errors (list (all-subexpressions expr)) (*context*) #f))))
-
-  (define pruned (make-hash))
-  (for ([(k v) (in-hash errs)])
-    (hash-set! pruned k (hash-ref v 'ulp-errs)))
-  (match-define (cons subexprs pt-errorss) (flip-lists (hash->list pruned)))
+      (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
+                                                           (*context*)))))))
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -194,6 +194,8 @@
            (match exact
              [`+nan.0 `+nan.0]
              [`-nan.0 `-nan.0]
+             [`+inf.0 `+inf.0]
+             [`-inf.0 `-inf.0]
              [value
               ; __exact double underscore to avoid conflicts with user provided
               ; variables. Could use name mangling long term.

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -132,6 +132,7 @@
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors subexprss ctx)
+  (define our_repr (context-repr ctx))
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
@@ -200,12 +201,12 @@
               (define true-error-expr (list `(- ,spec __exact)))
               (define diffMachine
                 (rival-compile true-error-expr modifed-vars (list flonum-discretization)))
-              (define inputs (map bf (append pt (list exact)))) ; TODO remove bf hack
+              (define inputs (map (representation-repr->bf our_repr) (append pt (list exact))))
               ;; ??? Is this always length 1, as we are asking about exact?
               (define true-error (vector-ref (rival-apply diffMachine (list->vector inputs)) 0))
               true-error])]))
 
-      (define ulp-err ; ??? Is this upls of error?
+      (define ulp-err
         (match (vector-ref nodes root)
           [(? literal?) 1]
           [(? variable?) 1]
@@ -219,7 +220,6 @@
              (for/list ([idx (in-list args-roots)])
                (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
            (define approx (apply (impl-info f 'fl) argapprox))
-           ;; ??? Should we compute `exact` against `actual` now?
            (ulp-difference exact approx repr)]))
 
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -130,6 +130,79 @@
           >
           #:key (compose errors-score car))))
 
+(define (compute-true-error exprs-list spec-vec roots nodes actuals exacts ctx pt-idx pt)
+
+  ; Keep track of where the variales are for later.
+  (define variables (make-hash))
+  ; not sure if we need to save expr or spec
+  (for ([subexpr (in-list exprs-list)]
+        [spec (in-vector spec-vec)]
+        [root (in-vector roots)])
+    (match (vector-ref nodes root)
+      [(? variable?) (hash-set! variables root spec)]
+      [_ empty]))
+  (eprintf "Variables: ~a\n" variables)
+
+  ; (for ([(pt ex) (in-pcontext (*pcontext*))]
+  ;       [pt-idx (in-naturals)])
+
+  ;; Don't love that we do this per point iteration but oh well.
+  (define actuals-map
+    (for/hash ([subexpr (in-list exprs-list)]
+               [actual (in-vector actuals)])
+      (values subexpr actual)))
+  (define exacts-map
+    (for/hash ([subexpr (in-list exprs-list)]
+               [exact (in-vector exacts)])
+      (values subexpr exact)))
+
+  (define diff-map (make-hash))
+
+  ;; Roots maps specs to node index, as node and spec/exacts are in different orderings.
+  (for ([spec (in-vector spec-vec)]
+        [expr (in-list exprs-list)]
+        [root (in-vector roots)]
+        [exact (in-vector exacts)])
+    ; (define true-error
+    (match (vector-ref nodes root)
+      [(? literal?)
+       (eprintf "LITERAL[exact: ~a, root: ~a]\n" exact root)
+       0]
+      [(? variable?)
+       (eprintf "VARIABLE[node ~a, exact: ~a, root: ~a]\n" (vector-ref nodes root) exact root)
+       0]
+      [(approx _ impl)
+       (define repr (repr-of expr ctx))
+       (eprintf "APPROX[exact: ~a, root: ~a]\n" exact root)
+       1] ;; TODO
+      ;; ??? Do I ignore this as well?
+      [`(if ,c ,ift ,iff) 0]
+      [(list f args-roots ...)
+       ;; Find the index of the variables we need to substitute.
+       (eprintf "EXPR[node: ~a, exact: ~a, root: ~a, sepc: ~a]\n"
+                (vector-ref nodes root)
+                exact
+                root
+                spec)
+       (define repr (impl-info f 'otype))
+       (eprintf "args-roots: ~a\n" args-roots)
+       (define var-list
+         (for/list ([idx (in-list args-roots)]
+                    #:when (hash-has-key? variables idx))
+           (hash-ref variables idx)))
+       (eprintf "var-list: ~a\n" var-list)
+       (define temp-exacts
+         (for/list ([idx (in-list args-roots)])
+           (vector-ref exacts (vector-member idx roots))))
+       (eprintf "child-exacts: ~a\n" temp-exacts)
+       (define temp-specs
+         (for/list ([idx (in-list args-roots)])
+           (vector-ref spec-vec (vector-member idx roots))))
+       (eprintf "child-specs: ~a\n" temp-specs)
+       ; arg's index mapping to exact
+       1])) ;; TODO
+  1)
+
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors subexprss ctx)
   (define exprs-list (append* subexprss)) ; unroll subexprss
@@ -137,6 +210,8 @@
     (for/list ([subexpr (in-list exprs-list)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
 
+  (define spec-list (map prog->spec exprs-list))
+  (define spec-vec (list->vector spec-list))
   (define expr-batch (progs->batch exprs-list))
   (define nodes (batch-nodes expr-batch))
   (define roots (batch-roots expr-batch))
@@ -163,9 +238,14 @@
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [pt-idx (in-naturals)])
+    ; (define pt-idx (list 0 1))
+    ; (define pt (list 1.0 6.9))
 
     (define exacts (list->vector (apply subexprs-fn pt)))
     (define actuals (apply actual-value-fn pt))
+
+    (compute-true-error exprs-list spec-vec roots nodes actuals exacts ctx pt-idx pt)
+    (eprintf "true error here!\n")
 
     (for ([expr (in-list exprs-list)]
           [root (in-vector roots)]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -132,6 +132,8 @@
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors subexprss ctx true-err?)
+  ; true-err? is a flag used weather we should run true error or not.
+  ; TODO split out local error for `core` use vs Odyessy?
   (define our_repr (context-repr ctx))
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define ctx-list
@@ -169,7 +171,6 @@
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
-  ; Points are ordered in the ordering that they appear in the spec.
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [pt-idx (in-naturals)])
 
@@ -187,7 +188,7 @@
             (match (vector-ref nodes root)
               [(? literal?) 0]
               [(? variable?) 0]
-              [(approx aprx-spec impl) exact] ;; TODO understand approx nodes.
+              [(approx aprx-spec impl) exact] ;; TODO not sure what to do here.
               [`(if ,c ,ift ,iff) 0]
               [(list f args-roots ...)
                ;; Find the index of the variables we need to substitute.

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -192,7 +192,6 @@
 
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
   (define actual-value-fn (compile-progs exprs-list ctx))
-  (define compare-fn (eval-progs-real compare-specs extended))
 
   (define ulp-errs
     (for/vector #:length (vector-length roots)
@@ -231,11 +230,20 @@
       (define true-err
         (match (vector-ref nodes root)
           [(? literal?)
+           (eprintf "literal?\n")
            (define inputs (append (list exact) (vector->list (make-vector (length pt) 0))))
+           (define compare-fn (eval-progs-real compare-specs extended))
            (define true-errors (list->vector (apply compare-fn inputs)))
            (vector-ref true-errors 0)]
           [(? variable?) 0]
-          [_
+          [(approx approx-spec impl)
+           (eprintf "approx: ~a, ~a\n" approx-spec impl)
+           0]
+          [`(if ,c ,ift ,iff)
+           (eprintf "if, ~a, ~a, ~a\n" c ift iff)
+           0]
+          [(list f args-roots ...)
+           (eprintf "func\n")
            (define extended (context-append cur-ctx exact-var-name (context-repr cur-ctx)))
            (define compare-specs `(- ,cur-sepc ,exact-var-name))
            (define new-compare (eval-progs-real (list compare-specs) (list extended)))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -117,7 +117,7 @@
     (for/list ([h (in-list errss)])
       (define pruned (make-hash))
       (for ([(k v) (in-hash h)])
-        (hash-set! pruned k (hash-ref v 'errs)))
+        (hash-set! pruned k (hash-ref v 'ulp-errs)))
       pruned))
 
   (for/list ([_ (in-list exprs)]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require math/bigfloat 
+(require math/bigfloat
          rival)
 (require "../syntax/sugar.rkt"
          "../syntax/syntax.rkt"
@@ -172,7 +172,8 @@
           [exact (in-vector exacts)]
           [actual (in-vector actuals)]
           [expr-idx (in-naturals)])
-      (define diff (vector-ref (rival-apply diffMachine (list->vector `(,(bf exact) ,(bf actual)))) 0))
+      (define diff
+        (vector-ref (rival-apply diffMachine (list->vector `(,(bf exact) ,(bf actual)))) 0))
       (define err
         (match (vector-ref nodes root)
           [(? literal?) 1]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -181,7 +181,8 @@
           [actual (in-vector actuals)]
           [expr-idx (in-naturals)])
       (define apx #f)
-      (define diff #f)
+      (define machineD (rival-compile (list `(- ,exact ,actual)) (list) (list flonum-discretization)))
+      (define diff (vector-ref (rival-apply machineD (vector)) 0))
       (define err
         (match (vector-ref nodes root)
           [(? literal?) 1]
@@ -197,9 +198,6 @@
                (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
            (define approx (apply (impl-info f 'fl) argapprox))
            (set! apx approx)
-           ;  (define machineD
-           ;    (rival-compile (list `(- ,exact ,actual)) (list) (list flonum-discretization)))
-           ;  (set! diff (vector-ref (rival-apply machineD (vector)) 0))
            (ulp-difference exact approx repr)]))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref errs expr-idx) pt-idx err)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -43,8 +43,10 @@
   (define lowering-rules (platform-lowering-rules))
 
   ; egg runner (2-phases for real rewrites and implementation selection)
+  (define batch (progs->batch progs))
   (define runner
-    (make-egg-runner progs
+    (make-egg-runner batch
+                     (batch-roots batch)
                      reprs
                      `((,lifting-rules . ((iteration . 1) (scheduler . simple)))
                        (,rules . ((node . ,(*node-limit*))))
@@ -195,9 +197,9 @@
                (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
            (define approx (apply (impl-info f 'fl) argapprox))
            (set! apx approx)
-           (define machineD
-             (rival-compile (list `(- ,exact ,actual)) (list) (list flonum-discretization)))
-           (set! diff (vector-ref (rival-apply machineD (vector)) 0))
+           ;  (define machineD
+           ;    (rival-compile (list `(- ,exact ,actual)) (list) (list flonum-discretization)))
+           ;  (set! diff (vector-ref (rival-apply machineD (vector)) 0))
            (ulp-difference exact approx repr)]))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref errs expr-idx) pt-idx err)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -220,7 +220,7 @@
                               'diff-values
                               (vector->list (vector-ref diffs-out n))
                               'apx-values
-                              (vector->list (vector-ref diffs-out n))))
+                              (vector->list (vector-ref apx-out n))))
         (set! n (add1 n))))))
 
 ;; Compute the local error of every subexpression of `prog`

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -186,8 +186,7 @@
         (match (vector-ref nodes root)
           [(? literal?) 0]
           [(? variable?) 0]
-          [(approx aprx-spec impl)
-           exact] ;; TODO understand approx nodes.
+          [(approx aprx-spec impl) exact] ;; TODO understand approx nodes.
           [`(if ,c ,ift ,iff) 0]
           [(list f args-roots ...)
            ;; Find the index of the variables we need to substitute.

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -12,6 +12,7 @@
          (struct-out context)
          *context*
          context-extend
+         context-append
          context-lookup)
 
 (module+ internals
@@ -133,6 +134,12 @@
                ctx
                [vars (cons var (context-vars ctx))]
                [var-reprs (cons repr (context-var-reprs ctx))]))
+
+(define (context-append ctx var repr)
+  (struct-copy context
+               ctx
+               [vars (append (context-vars ctx) (list var))]
+               [var-reprs (append (context-var-reprs ctx) (list repr))]))
 
 (define (context-lookup ctx var)
   (dict-ref (map cons (context-vars ctx) (context-var-reprs ctx)) var))


### PR DESCRIPTION
This PR surfaces the "true error" of an expression for the local error tree in Odyessy. 

Before merging:
- [x] Finish the Unit test with correct values.
- [ ] Approx Nodes
- [ ] Display values with `value->json`?
- [ ] Is ulp-error correct?
- [x] Split out true error from core and remove flag?