### PR TITLE
Add Resyntax Autofixer workflow

### DIFF
--- a/.github/workflows/resyntax-autofixer.rkt
+++ b/.github/workflows/resyntax-autofixer.rkt
@@ -1,0 +1,37 @@
+name: Resyntax Autofixer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 7"
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: "Install Packages"
+        run: sudo apt-get install -y libmpfr6 libmpfr-dev
+      - name: "Install Racket"
+        uses: Bogdanp/setup-racket@v1.11
+        with:
+          version: current
+      - name: Install Rust compiler
+        uses: dtolnay/rust-toolchain@stable
+        with:
+            toolchain: stable
+            components: rustfmt, clippy
+      - uses: actions/checkout@master
+      - name: "Install dependencies"
+        run: make install
+      - name: Create a Resyntax pull request
+        uses: jackfirth/create-resyntax-pull-request@v0.4.1
+        with:
+          private-key: ${{ secrets.RESYNTAX_APP_PRIVATE_KEY }}
+          max-fixes: '5'
+          max-modified-files: '3'
+          max-modified-lines: '100'

--- a/.github/workflows/resyntax-autofixer.rkt
+++ b/.github/workflows/resyntax-autofixer.rkt
@@ -3,7 +3,7 @@ name: Resyntax Autofixer
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 7"
+    - cron: "0 0 * * 0"
 
 jobs:
   autofix:


### PR DESCRIPTION
As discussed at RacketCon, this pull request adds the Resyntax Autofixer workflow to this repository. Once a week, this workflow will run Resyntax on the repository. Resyntax selects a small handful of suggested fixes and puts them into a new pull request. Configurable limits are placed on the number of fixes applied, how many files are touched, and the size of the pull request. I've set those limits quite low to start but feel free to change them to whatever suits your process.

You'll also need to add a secret named `RESYNTAX_APP_PRIVATE_KEY` to the repository. I can send you a key out-of-band.