### PR TITLE
Do less profiling because the profiler is slow

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -301,7 +301,7 @@
     (if profile?
         (profile-thunk (λ () (compute-result test))
                        #:order 'total
-                       #:delay 0.001
+                       #:delay 0.01
                        #:render (λ (p order) (write-json (profile->json p) profile?)))
         (compute-result test)))
 


### PR DESCRIPTION
The Racket `profile` library has an accidentally-quadratic topological sort algorithm, which causes all of our timeouts. Obviously the idea fix would be to make it faster, which might be possible, but until then we can fix all of our timeouts by just running the sampler less often, which produces fewer samples and therefore avoids the bad case in topological sort.