### PR TITLE
Removing duplicates in alternatives

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -116,9 +116,7 @@
   (timeline-event! 'series)
   (timeline-push! 'inputs (map ~a starting-exprs))
 
-  (define approxs
-    (remove-duplicates (taylor-alts starting-exprs altns global-batch)
-                       #:key (λ (x) (batchref-idx (alt-expr x)))))
+  (define approxs (taylor-alts starting-exprs altns global-batch))
 
   (timeline-push! 'outputs (map ~a (map (compose debatchref alt-expr) approxs)))
   (timeline-push! 'count (length altns) (length approxs))
@@ -188,4 +186,4 @@
   ; Recursive rewrite
   (define rewritten (if (flag-set? 'generate 'rr) (run-rr start-altns global-batch) '()))
 
-  (append approximations rewritten))
+  (remove-duplicates (append approximations rewritten) #:key (λ (x) (batchref-idx (alt-expr x)))))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -116,7 +116,9 @@
   (timeline-event! 'series)
   (timeline-push! 'inputs (map ~a starting-exprs))
 
-  (define approxs (taylor-alts starting-exprs altns global-batch))
+  (define approxs
+    (remove-duplicates (taylor-alts starting-exprs altns global-batch)
+                       #:key (λ (x) (batchref-idx (alt-expr x)))))
 
   (timeline-push! 'outputs (map ~a (map (compose debatchref alt-expr) approxs)))
   (timeline-push! 'count (length altns) (length approxs))


### PR DESCRIPTION
This branch is built on top of #990. 
The addition on this branch is: removing duplicates in alternatives after taylor expansions and once all the rewritings are done.
Particularly speaking, at the `generate-candidates` function `remove-duplicates` is introduced. 
And since all the rewrites are stored as a `batchref` - we can easily figure out duplicates just by analyzing `batchref-idx` - the parent node a batchref refers to.
The update introduces ~11 mins of speedup.