### PR TITLE
Fix the egg dumper file format

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -855,7 +855,7 @@
             (hash 'op
                   (~a (if (list? enode) (car enode) enode))
                   'children
-                  (if (list? enode) (map ~a (cdr enode)) '())
+                  (if (list? enode) (map (lambda (e) (format "~a.0" e)) (cdr enode)) '())
                   'eclass
                   (~a n)
                   'cost


### PR DESCRIPTION
The JSON egraph dumper I wrote didn't quite output things in the right format, which broke the extraction gym: https://github.com/egraphs-good/extraction-gym/issues/44

This fixes the dumper code. The already-committed data is fixed in a separate PR to that repo.