### PR TITLE
Use the same cost model throughout `cost-opportunity`

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -55,12 +55,10 @@
       [(list 'if cond ift iff) (+ 1 (rec cond) (rec ift) (rec iff))]
       [(list (? impl-exists? impl) args ...)
        (match (pow-impl-args impl args)
-         [(cons _ e)
+         [(cons _ (literal e _))
           #:when (fraction-with-odd-denominator? e)
           +inf.0]
          [_ (apply + 1 (map rec args))])]
-      [(list 'pow b e)
-       (if (fraction-with-odd-denominator? e) +inf.0 (+ 1 (rec b) (rec e)))]
       [(list _ args ...) (apply + 1 (map rec args))])))
 
 (define (batch-localize-costs exprs ctx)
@@ -105,7 +103,9 @@
 
   ; platform-based expression cost
   (define cost-proc
-    (if (*egraph-platform-cost*) (platform-cost-proc (*active-platform*)) default-cost-proc))
+    (if (*egraph-platform-cost*)
+        (platform-cost-proc (*active-platform*))
+        default-cost-proc))
   (define (expr->cost expr)
     (cost-proc expr (repr-of expr ctx)))
 
@@ -119,8 +119,10 @@
       (for/list ([child (in-list children)])
         (expr->cost (hash-ref expr->simplest child))))
     (unless (>= start-cost best-cost)
-      (error 'cost-opportunity "Initial expression ~a is better than final expression ~a\n"
-             subexpr (hash-ref expr->simplest subexpr)))
+      (error 'cost-opportunity
+             "Initial expression ~a is better than final expression ~a\n"
+             subexpr
+             (hash-ref expr->simplest subexpr)))
     ; compute cost opportunity
     (- (apply - start-cost start-child-costs) (apply - best-cost best-child-costs)))
 

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -129,7 +129,9 @@
     ; However, we rearrange to handle infinities:
     (define a (apply + start-cost best-child-costs))
     (define b (apply + best-cost start-child-costs))
-    (if (= a b) 0 (- a b))) ; This `if` statement handles `inf - inf`
+    (if (= a b)
+        0
+        (- a b))) ; This `if` statement handles `inf - inf`
 
   ; rank subexpressions by cost opportunity
   (define localize-costss

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -124,7 +124,9 @@
              subexpr
              (hash-ref expr->simplest subexpr)))
     ; compute cost opportunity
-    (- (apply - start-cost start-child-costs) (apply - best-cost best-child-costs)))
+    (define a (apply - start-cost start-child-costs))
+    (define b (apply - best-cost best-child-costs))
+    (if (= a b) 0 (- a b))) ; This `if` statement handles `inf - inf`
 
   ; rank subexpressions by cost opportunity
   (define localize-costss

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -123,9 +123,12 @@
              "Initial expression ~a is better than final expression ~a\n"
              subexpr
              (hash-ref expr->simplest subexpr)))
-    ; compute cost opportunity
-    (define a (apply - start-cost start-child-costs))
-    (define b (apply - best-cost best-child-costs))
+
+    ; Cost opportunity would normally be:
+    ;   (start cost - start child costs) - (best cost - best child costs)
+    ; However, we rearrange to handle infinities:
+    (define a (apply + start-cost best-child-costs))
+    (define b (apply + best-cost start-child-costs))
     (if (= a b) 0 (- a b))) ; This `if` statement handles `inf - inf`
 
   ; rank subexpressions by cost opportunity

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -31,6 +31,38 @@
     [((cons '() rest) outputs) (cons '() (regroup-nested rest outputs))]
     [('() '()) '()]))
 
+(define (fraction-with-odd-denominator? frac)
+  (and (rational? frac) (let ([denom (denominator frac)]) (and (> denom 1) (odd? denom)))))
+
+(define (pow-impl-args impl args)
+  (define vars (impl-info impl 'vars))
+  (match (impl-info impl 'spec)
+    [(list 'pow b e)
+     #:when (set-member? vars e)
+     (define env (map cons vars args))
+     (define b* (dict-ref env b b))
+     (define e* (dict-ref env e e))
+     (cons b* e*)]
+    [_ #f]))
+
+(define (default-cost-proc expr _)
+  (let rec ([expr expr])
+    (match expr
+      [(literal _ _) 1]
+      [(? symbol?) 1]
+      ; approx node
+      [(approx _ impl) (rec impl)]
+      [(list 'if cond ift iff) (+ 1 (rec cond) (rec ift) (rec iff))]
+      [(list (? impl-exists? impl) args ...)
+       (match (pow-impl-args impl args)
+         [(cons _ e)
+          #:when (fraction-with-odd-denominator? e)
+          +inf.0]
+         [_ (apply + 1 (map rec args))])]
+      [(list 'pow b e)
+       (if (fraction-with-odd-denominator? e) +inf.0 (+ 1 (rec b) (rec e)))]
+      [(list _ args ...) (apply + 1 (map rec args))])))
+
 (define (batch-localize-costs exprs ctx)
   (define subexprss (map all-subexpressions exprs))
   (define progs (apply append subexprss))
@@ -72,7 +104,8 @@
     (hash-set! expr->simplest subexpr simplified))
 
   ; platform-based expression cost
-  (define cost-proc (platform-cost-proc (*active-platform*)))
+  (define cost-proc
+    (if (*egraph-platform-cost*) (platform-cost-proc (*active-platform*)) default-cost-proc))
   (define (expr->cost expr)
     (cost-proc expr (repr-of expr ctx)))
 
@@ -85,6 +118,9 @@
     (define best-child-costs
       (for/list ([child (in-list children)])
         (expr->cost (hash-ref expr->simplest child))))
+    (unless (>= start-cost best-cost)
+      (error 'cost-opportunity "Initial expression ~a is better than final expression ~a\n"
+             subexpr (hash-ref expr->simplest subexpr)))
     ; compute cost opportunity
     (- (apply - start-cost start-child-costs) (apply - best-cost best-child-costs)))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -184,7 +184,10 @@
                  #:when true
                  [(cost-diff expr) (in-dict loc-costs)]
                  [_ (in-range (*localize-expressions-limit*))])
-        (timeline-push! 'locations (~a expr) "cost-diff" (if (infinite? cost-diff) "Infinite" cost-diff))
+        (timeline-push! 'locations
+                        (~a expr)
+                        "cost-diff"
+                        (if (infinite? cost-diff) "Infinite" cost-diff))
         expr))
     (set! localized-exprs (remove-duplicates (append localized-exprs cost-localized))))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -184,7 +184,7 @@
                  #:when true
                  [(cost-diff expr) (in-dict loc-costs)]
                  [_ (in-range (*localize-expressions-limit*))])
-        (timeline-push! 'locations (~a expr) "cost-diff" cost-diff)
+        (timeline-push! 'locations (~a expr) "cost-diff" (if (infinite? cost-diff) "Infinite" cost-diff))
         expr))
     (set! localized-exprs (remove-duplicates (append localized-exprs cost-localized))))
 


### PR DESCRIPTION
The `cost-opportunity` heuristic uses the cost model in two ways. First, the cost model is passed to the egraph to find the simplest form of any given expression. And then, the cost model is used again to compute cost opportunity.

The bug is that we were using different cost models for these two phases; default cost model for building the egraph and platform cost model for computing cost opportunity. This lead to weird stuff like the cost opportunity of a node being negative.

The fix is to use the same cost model for both phases; the code does that though note that it is a little ugly in that it duplicates some existing code.