### PR TITLE
Split out core localize from Odyssey localize.

### DIFF
--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -40,16 +40,10 @@
     [else #t]))
 
 (define (actual-errors expr pcontext)
-
-  (define errs
+  (match-define (cons subexprs pt-errorss)
     (parameterize ([*pcontext* pcontext])
-      (first (compute-local-errors (list (all-subexpressions expr)) (*context*)))))
-
-  (define pruned (make-hash))
-  (for ([(k v) (in-hash errs)])
-    (hash-set! pruned k (hash-ref v 'errs)))
-  (define idk (flip-lists (hash->list pruned)))
-  (match-define (cons subexprs pt-errorss) idk)
+      (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
+                                                           (*context*)))))))
 
   (define pt-worst-subexpr
     (append* (reap [sow]


### PR DESCRIPTION
This PR splits the local error function used for Odyessy out from the code path used in the core so as I compute more data to display on Odyssey I don't slow down the core.