### PR TITLE
Concrete Values for Odyssey

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -178,16 +178,16 @@ const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
 // avg_error, actual_value, exact_value, absolute_difference, ulps_error
 // root node
 checkLocalErrorNode(localError5.tree, [],
-  '-', '0.0', '1.0', '1.0', 'equal', '0.0')
+  '-', '0.0', '1.0', '1.0', '1e-50', '0.0')
 // left sqrt
 checkLocalErrorNode(localError5.tree, [0],
-  'sqrt', '0.0', '1.0', '1.0', 'equal', '0.0')
+  'sqrt', '0.0', '1.0', '1.0', '5e-101', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError5.tree, [1],
-  'sqrt', '0.0', '1e-50', '1e-50', 'equal', '0.0')
+  'sqrt', '0.0', '1e-50', '1e-50', '2.379726195519099e-68', '0.0')
 // plus 
 checkLocalErrorNode(localError5.tree, [0, 0],
-  '+', '0.0', '1.0', '1.0', 'equal', '0.0')
+  '+', '0.0', '1.0', '1.0', '1e-100', '0.0')
 // var x
 checkLocalErrorNode(localError5.tree, [0, 0, 0],
   'x', '0.0', '1e-100', '1e-100', 'equal', '0.0')
@@ -207,20 +207,21 @@ checkLocalErrorNode(localError6.tree, [],
   '-', '61.7', '0.0', '5e-51', '5e-51', '61.74124908607812')
 // left sqrt
 checkLocalErrorNode(localError6.tree, [0],
-  'sqrt', '0.0', '1e+50', '1e+50', 'equal', '0.0')
+  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError6.tree, [1],
-  'sqrt', '0.0', '1e+50', '1e+50', 'equal', '0.0')
+  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '0.0')
 // plus 
 checkLocalErrorNode(localError6.tree, [0, 0],
-  '+', '0.0', '1e+100', '1e+100', 'equal', '0.0')
+  '+', '0.0', '1e+100', '1e+100', '1.0', '0.0')
 // var x
 checkLocalErrorNode(localError6.tree, [0, 0, 0],
   'x', '0.0', '1e+100', '1e+100', 'equal', '0.0')
 // literal 1
 checkLocalErrorNode(localError6.tree, [0, 0, 1],
   '1.0', '0.0', '1.0', '1.0', 'equal', '0.0')
-// Test a large number `2e269` to trigger NaN in fma.
+
+// Test a large number `2e269` to trigger NaNs in local error
 const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
   method: 'POST', body: JSON.stringify({
     formula: FPCoreFormula3, sample: [[[2e269], ignoredValue]], seed: 5
@@ -228,13 +229,13 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test against conditionals
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'equal', '0.0')
+  '<=', '0.0', 'true', 'true', 'invalid', '0.0')
 // Test that inexact values display using input syntax not fraction
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', 'equal', '0.0')
+  '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
 // Test for NaN error
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'equal', '0.0') // invalid rival output
+  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0') // invalid rival output
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -230,8 +230,9 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 // Test against conditionals expressions
 checkLocalErrorNode(localError7.tree, [0],
   '<=', '0.0', 'true', 'true', 'invalid', '0.0')
-checkLocalErrorNode(localError7.tree, [0, 0],
-  '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
+// TODO a bug in Rival
+// checkLocalErrorNode(localError7.tree, [0, 0],
+//   '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
 checkLocalErrorNode(localError7.tree, [0, 1],
   '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
 checkLocalErrorNode(localError7.tree, [2],

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -175,20 +175,26 @@ const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
     formula: FPCoreFormula, sample: [[[1e-100], ignoredValue]], seed: 5
   })
 })).json()
-const rootMinusNode = localError5.tree
-const leftSQRT = localError5.tree['children'][0]
-const rightSQRT = localError5.tree['children'][1]
-const plusNode = localError5.tree['children'][0]['children'][0]
-const xNode = localError5.tree['children'][0]['children'][0]['children'][0]
-const oneNode = localError5.tree['children'][0]['children'][0]['children'][1]
 
-//        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
-assertCheckNode(rootMinusNode, '-', '1.0', '0.0', '1.0', '-1e-50', 1)
-assertCheckNode(leftSQRT, 'sqrt', '1.0', '0.0', '1.0', '5e-101', 1)
-assertCheckNode(rightSQRT, 'sqrt', '1e-50', '0.0', '1e-50', '2.379726195519099e-68', 1)
-assertCheckNode(plusNode, '+', '1.0', '0.0', '1.0', '1e-100', 1)
-assertCheckNode(xNode, 'x', '1e-100', '0.0', '1e-100', '0', 1)
-assertCheckNode(oneNode, '1.0', '1.0', '0.0', '1.0', '-0.0', 1)
+// avg_error, actual_value, exact_value, absolute_error, ulps_error
+// root node
+checkLocalErrorNode(localError5.tree, [],
+  '-', '0.0', '1.0', '1.0', '1e-50', '1')
+// left sqrt
+checkLocalErrorNode(localError5.tree, [0],
+  'sqrt', '0.0', '1.0', '1.0', '5e-101', '1')
+// right sqrt 
+checkLocalErrorNode(localError5.tree, [1],
+  'sqrt', '0.0', '1e-50', '1e-50', '2.379726195519099e-68', '1')
+// plus 
+checkLocalErrorNode(localError5.tree, [0, 0],
+  '+', '0.0', '1.0', '1.0', '1e-100', '1')
+// var x
+checkLocalErrorNode(localError5.tree, [0, 0, 0],
+  'x', '0.0', '1e-100', '1e-100', '0.0', '1')
+// literal 1
+checkLocalErrorNode(localError5.tree, [0, 0, 1],
+  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -196,35 +202,54 @@ const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
     formula: FPCoreFormula, sample: [[[1e100], ignoredValue]], seed: 5
   })
 })).json()
-const rootMinusNode6 = localError6.tree
-const leftSQRT6 = localError6.tree['children'][0]
-const rightSQRT6 = localError6.tree['children'][1]
-const plusNode6 = localError6.tree['children'][0]['children'][0]
-const xNode6 = localError6.tree['children'][0]['children'][0]['children'][0]
-const oneNode6 = localError6.tree['children'][0]['children'][0]['children'][1]
-//        node, name, approx_value, avg_error, exact_value, true_error_value, ulps_error
-assertCheckNode(rootMinusNode6, '-', '0.0', '61.7', '5e-51', '-7.78383463033115e-68', 3854499065107888000)
-assertCheckNode(leftSQRT6, 'sqrt', '1e+50', '0.0', '1e+50', '-6.834625285603891e+33', 1)
-assertCheckNode(rightSQRT6, 'sqrt', '1e+50', '0.0', '1e+50', '-6.834625285603891e+33', 1)
-assertCheckNode(plusNode6, '+', '1e+100', '0.0', '1e+100', '1.0', 1)
-assertCheckNode(xNode6, 'x', '1e+100', '0.0', '1e+100', '0', 1)
-assertCheckNode(oneNode6, '1.0', '1.0', '0.0', '1.0', '-0.0', 1)
+// avg_error, actual_value, exact_value, absolute_error, ulps_error
+// root node
+checkLocalErrorNode(localError6.tree, [],
+  '-', '61.7', '0.0', '5e-51', '7.78383463033115e-68', '3854499065107888160')
+// left sqrt
+checkLocalErrorNode(localError6.tree, [0],
+  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '1')
+// right sqrt 
+checkLocalErrorNode(localError6.tree, [1],
+  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '1')
+// plus 
+checkLocalErrorNode(localError6.tree, [0, 0],
+  '+', '0.0', '1e+100', '1e+100', '1.0', '1')
+// var x
+checkLocalErrorNode(localError6.tree, [0, 0, 0],
+  'x', '0.0', '1e+100', '1e+100', '0.0', '1')
+// literal 1
+checkLocalErrorNode(localError6.tree, [0, 0, 1],
+  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
 
-function assertCheckNode(node, name, approx, avg_error, exact_value, true_error_value, ulps_error) {
+/// root: The root node of the local error tree.
+/// path: the path to get to the node you want to test.
+/// name: Name of the node you are testing
+/// avg_error: Average Error
+/// actual_value: Value of the node
+/// absolute_error: The ABS of the error at the node |approx - exact|
+/// ulps_error: ulps of error at this node.
+function checkLocalErrorNode(root, path, name,
+  avg_error, actual_value, exact_value, absolute_error, ulps_error) {
+  const node = getNodeFromPath(root, path)
+  console.log(node) // TODO delete me
   assert.equal(node['e'], name)
-  assert.equal(node['approx-value'][0], approx)
   assert.equal(node['avg-error'], avg_error)
+  assert.equal(node['actual-value'][0], actual_value)
   assert.equal(node['exact-value'][0], exact_value)
-  assert.equal(node['true-error-value'][0], true_error_value)
+  assert.equal(node['absolute-error'][0], absolute_error)
   assert.equal(node['ulps-error'][0], ulps_error)
 }
 
-// TODO if statements
-// const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
-//   method: 'POST', body: JSON.stringify({
-//     formula: FPCoreFormula3, sample: [[[1e100], ignoredValue]], seed: 5
-//   })
-// })).json()
+function getNodeFromPath(node, path) {
+  if (path.length > 0) {
+    const index = path.shift()
+    const child = node['children'][index]
+    return getNodeFromPath(child, path)
+  } else {
+    return node
+  }
+}
 
 // Alternatives endpoint
 const altBody = {

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -175,25 +175,25 @@ const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
   })
 })).json()
 
-// avg_error, actual_value, exact_value, absolute_error, ulps_error
+// avg_error, actual_value, exact_value, absolute_difference, ulps_error
 // root node
 checkLocalErrorNode(localError5.tree, [],
-  '-', '0.0', '1.0', '1.0', '0.0', '0.0')
+  '-', '0.0', '1.0', '1.0', 'equal', '0.0')
 // left sqrt
 checkLocalErrorNode(localError5.tree, [0],
-  'sqrt', '0.0', '1.0', '1.0', '0.0', '0.0')
+  'sqrt', '0.0', '1.0', '1.0', 'equal', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError5.tree, [1],
-  'sqrt', '0.0', '1e-50', '1e-50', '0.0', '0.0')
+  'sqrt', '0.0', '1e-50', '1e-50', 'equal', '0.0')
 // plus 
 checkLocalErrorNode(localError5.tree, [0, 0],
-  '+', '0.0', '1.0', '1.0', '0.0', '0.0')
+  '+', '0.0', '1.0', '1.0', 'equal', '0.0')
 // var x
 checkLocalErrorNode(localError5.tree, [0, 0, 0],
-  'x', '0.0', '1e-100', '1e-100', '0', '0.0')
+  'x', '0.0', '1e-100', '1e-100', 'equal', '0.0')
 // literal 1
 checkLocalErrorNode(localError5.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '0.0')
+  '1.0', '0.0', '1.0', '1.0', 'equal', '0.0')
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -207,20 +207,19 @@ checkLocalErrorNode(localError6.tree, [],
   '-', '61.7', '0.0', '5e-51', '5e-51', '61.74124908607812')
 // left sqrt
 checkLocalErrorNode(localError6.tree, [0],
-  'sqrt', '0.0', '1e+50', '1e+50', '0.0', '0.0')
+  'sqrt', '0.0', '1e+50', '1e+50', 'equal', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError6.tree, [1],
-  'sqrt', '0.0', '1e+50', '1e+50', '0.0', '0.0')
+  'sqrt', '0.0', '1e+50', '1e+50', 'equal', '0.0')
 // plus 
 checkLocalErrorNode(localError6.tree, [0, 0],
-  '+', '0.0', '1e+100', '1e+100', '0.0', '0.0')
+  '+', '0.0', '1e+100', '1e+100', 'equal', '0.0')
 // var x
 checkLocalErrorNode(localError6.tree, [0, 0, 0],
-  'x', '0.0', '1e+100', '1e+100', '0', '0.0')
+  'x', '0.0', '1e+100', '1e+100', 'equal', '0.0')
 // literal 1
 checkLocalErrorNode(localError6.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '0.0')
-
+  '1.0', '0.0', '1.0', '1.0', 'equal', '0.0')
 // Test a large number `2e269` to trigger NaN in fma.
 const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
   method: 'POST', body: JSON.stringify({
@@ -229,30 +228,31 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test against conditionals
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'true', '0.0')
+  '<=', '0.0', 'true', 'true', 'equal', '0.0')
 // Test that inexact values display using input syntax not fraction
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', '0.0', '0.0')
+  '0.05', '0.0', '0.05', '0.05', 'equal', '0.0')
 // Test for NaN error
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'NaN', '0.0')
+  'fma', '0.0', '-inf.0', '-inf.0', 'equal', '0.0') // invalid rival output
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.
 /// name: Name of the node you are testing
 /// avg_error: Average Error
 /// actual_value: Value of the node
-/// absolute_error: The ABS of the error at the node |approx - exact|
+/// absolute_difference: The ABS of the error at the node |approx - exact|
 /// ulps_error: ulps of error at this node.
 function checkLocalErrorNode(root, path, name,
-  avg_error, actual_value, exact_value, absolute_error, ulps_error) {
+  avg_error, actual_value, exact_value, absolute_difference, ulps_error) {
   const node = getNodeFromPath(root, path)
+  // console.log(node) // Helpful for seeing which node is failing a test
   assert.equal(node['e'], name)
   assert.equal(node['avg-error'], avg_error)
-  assert.equal(node['actual-value'][0], actual_value)
-  assert.equal(node['exact-value'][0], exact_value)
-  assert.equal(node['absolute-error'][0], absolute_error)
-  assert.equal(node['ulps-error'][0], ulps_error)
+  assert.equal(node['actual-value'], actual_value)
+  assert.equal(node['exact-value'], exact_value)
+  assert.equal(node['abs-error-difference'], absolute_difference)
+  assert.equal(node['ulps-error'], ulps_error)
 }
 
 function getNodeFromPath(node, path) {

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -191,10 +191,10 @@ checkLocalErrorNode(localError5.tree, [0, 0],
   '+', '0.0', '1.0', '1.0', '1e-100', '1')
 // var x
 checkLocalErrorNode(localError5.tree, [0, 0, 0],
-  'x', '0.0', '1e-100', '1e-100', '0.0', '1')
+  'x', '0.0', '1e-100', '1e-100', '0', '1')
 // literal 1
 checkLocalErrorNode(localError5.tree, [0, 0, 1],
-  '1', '0.0', '1.0', '1.0', '0.0', '1')
+  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -217,10 +217,26 @@ checkLocalErrorNode(localError6.tree, [0, 0],
   '+', '0.0', '1e+100', '1e+100', '1.0', '1')
 // var x
 checkLocalErrorNode(localError6.tree, [0, 0, 0],
-  'x', '0.0', '1e+100', '1e+100', '0.0', '1')
+  'x', '0.0', '1e+100', '1e+100', '0', '1')
 // literal 1
 checkLocalErrorNode(localError6.tree, [0, 0, 1],
-  '1', '0.0', '1.0', '1.0', '0.0', '1')
+  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
+
+// Test a large number `2e269` to trigger NaN in fma.
+const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula3, sample: [[[2e269], ignoredValue]], seed: 5
+  })
+})).json()
+// Test against conditionals
+checkLocalErrorNode(localError7.tree, [0],
+  '<=', '0.0', 'true', 'true', 'true', '1')
+// Test that inexact values display using input syntax not fraction
+checkLocalErrorNode(localError7.tree, [0, 1],
+  '0.05', '0.0', '0.05', '0.05', '0.0', '1')
+// Test for NaN error
+checkLocalErrorNode(localError7.tree, [2],
+  'fma', '0.0', '-inf.0', '-inf.0', 'NaN', '1')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -1,7 +1,6 @@
 import { strict as assert } from 'node:assert';  // use strict equality everywhere 
 
 // Future TODO: before this API becomes set in stone/offered publicly, we should change the results of these methods to be just the output data rather than duplicating input values.
-
 // Reusable testing data
 const SAMPLE_SIZE = 8000
 const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
@@ -179,22 +178,22 @@ const localError5 = await (await fetch(makeEndpoint("/api/localerror"), {
 // avg_error, actual_value, exact_value, absolute_error, ulps_error
 // root node
 checkLocalErrorNode(localError5.tree, [],
-  '-', '0.0', '1.0', '1.0', '1e-50', '1')
+  '-', '0.0', '1.0', '1.0', '0.0', '0.0')
 // left sqrt
 checkLocalErrorNode(localError5.tree, [0],
-  'sqrt', '0.0', '1.0', '1.0', '5e-101', '1')
+  'sqrt', '0.0', '1.0', '1.0', '0.0', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError5.tree, [1],
-  'sqrt', '0.0', '1e-50', '1e-50', '2.379726195519099e-68', '1')
+  'sqrt', '0.0', '1e-50', '1e-50', '0.0', '0.0')
 // plus 
 checkLocalErrorNode(localError5.tree, [0, 0],
-  '+', '0.0', '1.0', '1.0', '1e-100', '1')
+  '+', '0.0', '1.0', '1.0', '0.0', '0.0')
 // var x
 checkLocalErrorNode(localError5.tree, [0, 0, 0],
-  'x', '0.0', '1e-100', '1e-100', '0', '1')
+  'x', '0.0', '1e-100', '1e-100', '0', '0.0')
 // literal 1
 checkLocalErrorNode(localError5.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
+  '1.0', '0.0', '1.0', '1.0', '0.0', '0.0')
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -205,22 +204,22 @@ const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
 // avg_error, actual_value, exact_value, absolute_error, ulps_error
 // root node
 checkLocalErrorNode(localError6.tree, [],
-  '-', '61.7', '0.0', '5e-51', '7.78383463033115e-68', '3854499065107888160')
+  '-', '61.7', '0.0', '5e-51', '5e-51', '61.74124908607812')
 // left sqrt
 checkLocalErrorNode(localError6.tree, [0],
-  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '1')
+  'sqrt', '0.0', '1e+50', '1e+50', '0.0', '0.0')
 // right sqrt 
 checkLocalErrorNode(localError6.tree, [1],
-  'sqrt', '0.0', '1e+50', '1e+50', '6.834625285603891e+33', '1')
+  'sqrt', '0.0', '1e+50', '1e+50', '0.0', '0.0')
 // plus 
 checkLocalErrorNode(localError6.tree, [0, 0],
-  '+', '0.0', '1e+100', '1e+100', '1.0', '1')
+  '+', '0.0', '1e+100', '1e+100', '0.0', '0.0')
 // var x
 checkLocalErrorNode(localError6.tree, [0, 0, 0],
-  'x', '0.0', '1e+100', '1e+100', '0', '1')
+  'x', '0.0', '1e+100', '1e+100', '0', '0.0')
 // literal 1
 checkLocalErrorNode(localError6.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
+  '1.0', '0.0', '1.0', '1.0', '0.0', '0.0')
 
 // Test a large number `2e269` to trigger NaN in fma.
 const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -230,13 +229,13 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test against conditionals
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'true', '1')
+  '<=', '0.0', 'true', 'true', 'true', '0.0')
 // Test that inexact values display using input syntax not fraction
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', '0.0', '1')
+  '0.05', '0.0', '0.05', '0.05', '0.0', '0.0')
 // Test for NaN error
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'NaN', '1')
+  'fma', '0.0', '-inf.0', '-inf.0', 'NaN', '0.0')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -227,21 +227,22 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
     formula: FPCoreFormula3, sample: [[[2e269], ignoredValue]], seed: 5
   })
 })).json()
-// Test against conditionals
+// Test against conditionals expressions
 checkLocalErrorNode(localError7.tree, [0],
   '<=', '0.0', 'true', 'true', 'invalid', '0.0')
-// Test that inexact values display using input syntax not fraction
+checkLocalErrorNode(localError7.tree, [0, 0],
+  '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
 checkLocalErrorNode(localError7.tree, [0, 1],
   '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
-// Test for NaN error
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0') // invalid rival output
+  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.
 /// name: Name of the node you are testing
 /// avg_error: Average Error
 /// actual_value: Value of the node
+/// exact_value: The correct evaluation of the expression
 /// absolute_difference: The ABS of the error at the node |approx - exact|
 /// ulps_error: ulps of error at this node.
 function checkLocalErrorNode(root, path, name,

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -194,7 +194,7 @@ checkLocalErrorNode(localError5.tree, [0, 0, 0],
   'x', '0.0', '1e-100', '1e-100', '0.0', '1')
 // literal 1
 checkLocalErrorNode(localError5.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
+  '1', '0.0', '1.0', '1.0', '0.0', '1')
 
 // '(FPCore (1e100) (- (sqrt (+ x 1)) (sqrt x)))'
 const localError6 = await (await fetch(makeEndpoint("/api/localerror"), {
@@ -220,7 +220,7 @@ checkLocalErrorNode(localError6.tree, [0, 0, 0],
   'x', '0.0', '1e+100', '1e+100', '0.0', '1')
 // literal 1
 checkLocalErrorNode(localError6.tree, [0, 0, 1],
-  '1.0', '0.0', '1.0', '1.0', '0.0', '1')
+  '1', '0.0', '1.0', '1.0', '0.0', '1')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.
@@ -232,7 +232,6 @@ checkLocalErrorNode(localError6.tree, [0, 0, 1],
 function checkLocalErrorNode(root, path, name,
   avg_error, actual_value, exact_value, absolute_error, ulps_error) {
   const node = getNodeFromPath(root, path)
-  console.log(node) // TODO delete me
   assert.equal(node['e'], name)
   assert.equal(node['avg-error'], avg_error)
   assert.equal(node['actual-value'][0], actual_value)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -143,7 +143,7 @@
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
   (*pcontext* test-pcontext)
-  (local-error-as-tree test (*context*)))
+  (local-error-as-tree (test-input test) (*context*)))
 
 (define (get-explanations test pcontext)
   (unless pcontext

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -40,16 +40,10 @@
     [else #t]))
 
 (define (actual-errors expr pcontext)
-
-  (define errs
+  (match-define (cons subexprs pt-errorss)
     (parameterize ([*pcontext* pcontext])
-      (first (compute-local-errors (list (all-subexpressions expr)) (*context*)))))
-
-  (define pruned (make-hash))
-  (for ([(k v) (in-hash errs)])
-    (hash-set! pruned k (hash-ref v 'errs)))
-  (define idk (flip-lists (hash->list pruned)))
-  (match-define (cons subexprs pt-errorss) idk)
+      (flip-lists (hash->list (first (compute-local-errors (list (all-subexpressions expr))
+                                                           (*context*)))))))
 
   (define pt-worst-subexpr
     (append* (reap [sow]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -351,6 +351,14 @@
                   (if (equal? (representation-type (impl-info f 'otype)) 'bool)
                       exact
                       (compute-abs-error actual exact current-ctx pt (repr-of expr ctx)))]))]))
+      (define precent-accurate
+        (match node-ulp-difference
+          ['invalid 'invalid]
+          ['unsamplable 'unsamplable]
+          [value
+           (* (- 1
+                 (/ (ulps->bits node-ulp-difference) (representation-total-bits (repr-of expr ctx))))
+              100)]))
       (hash-set! data-hash
                  root
                  (hasheq 'e
@@ -366,14 +374,7 @@
                          'abs-error-difference
                          abs-error
                          'percent-accuracy
-                         (match node-ulp-difference
-                           ['invalid 'invalid]
-                           ['unsamplable 'unsamplable]
-                           [value
-                            (* (- 1
-                                  (/ (ulps->bits node-ulp-difference)
-                                     (representation-total-bits (repr-of expr ctx))))
-                               100)])))))
+                         precent-accurate))))
 
   (define (translate-booleans value)
     (match value
@@ -385,7 +386,7 @@
     (define data (hash-ref data-hash root))
     (define expr (hash-ref data 'e))
     (define abs-error (~s (translate-booleans (hash-ref data 'abs-error-difference))))
-    (define ulp-error (~s (translate-booleans (ulps->bits (hash-ref data 'ulps-error)))))
+    (define ulp-error (~s (ulps->bits (hash-ref data 'ulps-error)))) ; unused by Odyssey
     (define avg-error (format-bits (errors-score (list (hash-ref data 'ulps-error)))))
     (define exact-error (~s (translate-booleans (hash-ref data 'exact-value))))
     (define actual-error (~s (translate-booleans (hash-ref data 'actual-value))))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -291,6 +291,11 @@
     ;; Really only gets called with one point in pcontext from Odyssey
     (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
       (list->vector (apply subexprs-fn pt))))
+  ;; TODO combine loops over pcontext
+  (define actuals-from-points
+    ;; Really only gets called with one point in pcontext from Odyssey
+    (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
+      (apply actual-value-fn pt)))
 
   (define (true-error-for spec exact ctx pt)
     ; TODO pass in the list of of specs and exacts and ctxs and apply that function to pts
@@ -306,44 +311,14 @@
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [exacts (in-vector exacts-from-points)]
+        [actuals (in-vector actuals-from-points)]
         [pt-idx (in-naturals)])
-    (for ([c-spec (in-vector spec-vec)]
+    (for ([expr (in-list exprs-list)]
+          [c-spec (in-vector spec-vec)]
           [c-ctx (in-list ctx-list)]
           [root (in-vector roots)]
-          [exact exacts]
-          [expr-idx (in-naturals)])
-      (eprintf "node: ~a\n" (vector-ref nodes root))
-      (define true-error
-        (match (vector-ref nodes root)
-          [(? literal?)
-           (eprintf "spec: ~a\n" c-spec)
-           exact]
-          [(? variable?) 1]
-          ; compare the exact against it's impl substitution.
-          [(approx _ impl) (true-error-from impl exact pt)]
-          [`(if ,c ,ift ,iff)
-           (set! previous_node_condition #t)
-           (if exact
-               (true-error-from ift exact pt)
-               (true-error-from iff exact pt))]
-          [(list f args ...)
-           (define local previous_node_condition)
-           (when previous_node_condition
-             (set! previous_node_condition #f))
-           (if local
-               exact
-               (true-error-for c-spec exact c-ctx pt))]))
-      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx true-error)))
-
-  (for ([(pt ex) (in-pcontext (*pcontext*))]
-        [pt-idx (in-naturals)]
-        [exacts (in-vector exacts-from-points)])
-    (define actuals (apply actual-value-fn pt))
-
-    (for ([expr (in-list exprs-list)]
-          [root (in-vector roots)]
-          [exact (in-vector exacts)]
           [actual (in-vector actuals)]
+          [exact (in-vector exacts)]
           [expr-idx (in-naturals)])
       (define err
         (match (vector-ref nodes root)
@@ -360,9 +335,28 @@
                (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference exact approx repr)]))
+      (define true-error
+        (match (vector-ref nodes root)
+          [(? literal?) exact]
+          [(? variable?) 1]
+          ; compare the exact against it's impl substitution.
+          [(approx _ impl) (true-error-from impl exact pt)]
+          [`(if ,c ,ift ,iff)
+           (set! previous_node_condition #t)
+           (if exact
+               (true-error-from ift exact pt)
+               (true-error-from iff exact pt))]
+          [(list f args ...)
+           (define local previous_node_condition)
+           (when previous_node_condition
+             (set! previous_node_condition #f))
+           (if local
+               exact
+               (true-error-for c-spec exact c-ctx pt))]))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref errs expr-idx) pt-idx err)
-      (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)))
+      (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)
+      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx true-error)))
 
   (define n 0)
   (for/list ([subexprs (in-list subexprss)])
@@ -434,7 +428,7 @@
                  (format-bits (errors-score (first err)))
                  'exact-value
                  (map ~s (first exact))
-                 'approx-value
+                 'actual-value
                  (map ~s (first actual))
                  'true-error-value
                  (map ~s (first true-error))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -293,8 +293,6 @@
     (define approx-ctx (vector-ref ctx-vec i))
     (compute-abs-error approx-spec exact approx-ctx pt repr))
 
-  (define previous_node_if? #f)
-
   (define data-hash (make-hash))
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
@@ -330,15 +328,11 @@
           [(? variable?) 0]
           [(approx _ impl) (absolute-error-for impl exact pt current-repr)]
           [`(if ,c ,ift ,iff)
-           (set! previous_node_if? #t)
            (if exact
                (absolute-error-for ift exact pt current-repr)
                (absolute-error-for iff exact pt current-repr))]
           [(list f args ...)
-           (define local previous_node_if?)
-           (when previous_node_if?
-             (set! previous_node_if? #f))
-           (if local
+           (if (equal? (representation-type (impl-info f 'otype)) 'bool)
                exact
                (compute-abs-error current-spec exact current-ctx pt current-repr))]))
       (hash-set! data-hash

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -250,12 +250,12 @@
 ;; and returns the error information as an S-expr in the
 ;; same shape as `prog`
 (define (local-error-as-tree test ctx)
+  (define fpcore (prog->fpcore (test-input test) (test-context test)))
   (define subexprss (list (all-subexpressions (test-input test))))
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
-
   (define repr-hash
     (make-immutable-hash (map (lambda (e ctx) (cons e (context-repr ctx))) exprs-list ctx-list)))
 
@@ -280,14 +280,18 @@
                 ([(pt ex) (in-pcontext (*pcontext*))])
       (apply actual-value-fn pt)))
 
-  (define (compute-true-error spec exact ctx pt)
+  (define (compute-abs-error spec exact ctx pt repr)
     ;; TODO compute in batches and evalutate propigated errors from rival.
-    (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
+    (define true-error (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
+    (define bf-true-error ((representation-repr->bf repr) true-error))
+    (define abs-error (bfabs bf-true-error))
+    (define abs-error-out (value->json (bigfloat->flonum abs-error) repr))
+    abs-error-out)
 
-  (define (absolute-error-for i exact pt)
+  (define (absolute-error-for i exact pt repr)
     (define approx-spec (vector-ref spec-vec i))
     (define approx-ctx (vector-ref ctx-vec i))
-    (compute-true-error approx-spec exact approx-ctx pt))
+    (compute-abs-error approx-spec exact approx-ctx pt repr))
 
   (define previous_node_if? #f)
 
@@ -296,13 +300,15 @@
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [exacts (in-vector exacts-from-points)]
         [actuals (in-vector actuals-from-points)])
-    (for ([expr (in-list exprs-list)]
+    (for ([expr-syntax (in-list (all-subexpressions fpcore))]
+          [expr (in-list exprs-list)]
           [current-spec (in-vector spec-vec)]
           [current-ctx (in-list ctx-list)]
           [root (in-vector roots)]
           [actual (in-vector actuals)]
           [exact (in-vector exacts)])
       (define node (vector-ref nodes root))
+      (define current-repr (hash-ref repr-hash expr))
       (define local-error
         (match node
           [(? literal?) 1]
@@ -318,32 +324,29 @@
                (vector-ref exacts (vector-member idx roots))))
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference exact approx repr)]))
-      (define true-error
+      (define abs-error
         (match node
-          [(? literal?) (compute-true-error current-spec exact current-ctx pt)]
+          [(? literal?) (compute-abs-error current-spec exact current-ctx pt current-repr)]
           [(? variable?) 0]
-          [(approx _ impl) (absolute-error-for impl exact pt)]
+          [(approx _ impl) (absolute-error-for impl exact pt current-repr)]
           [`(if ,c ,ift ,iff)
            (set! previous_node_if? #t)
            (if exact
-               (absolute-error-for ift exact pt)
-               (absolute-error-for iff exact pt))]
+               (absolute-error-for ift exact pt current-repr)
+               (absolute-error-for iff exact pt current-repr))]
           [(list f args ...)
            (define local previous_node_if?)
            (when previous_node_if?
              (set! previous_node_if? #f))
            (if local
                exact
-               (compute-true-error current-spec exact current-ctx pt))]))
-      (define current-repr (hash-ref repr-hash expr))
-      (define abs-error (bfabs ((representation-repr->bf current-repr) true-error)))
-      (define abs-error-out (value->json (bigfloat->flonum abs-error) current-repr))
+               (compute-abs-error current-spec exact current-ctx pt current-repr))]))
       (hash-set! data-hash
                  root
                  (hasheq 'e ;; String shenanigans to persevere current output.
-                         (~s (if (pair? current-spec)
-                                 (first current-spec)
-                                 current-spec))
+                         (~s (if (pair? expr-syntax)
+                                 (first expr-syntax)
+                                 expr-syntax))
                          'ulps-error
                          local-error
                          'exact-value
@@ -351,41 +354,55 @@
                          'actual-value
                          actual
                          'absolute-error
-                         abs-error-out))))
+                         abs-error))))
+
+  (define (translate-booleans value)
+    (match value
+      [#t 'true]
+      [#f 'false]
+      [v v]))
 
   (define (make-hash-for root)
     ;; TODO Remove extra array from JSON output so we don't need `(map ~s (list ...)) -> (~s ...)`
     (define data (hash-ref data-hash root))
-    (define node (vector-ref nodes root))
-    (match node
+    (define expr (hash-ref data 'e))
+    (define abs-error (translate-booleans (hash-ref data 'absolute-error)))
+    (define ulp-error (map ~s (list (translate-booleans (hash-ref data 'ulps-error)))))
+    (define avg-error (format-bits (errors-score (list (hash-ref data 'ulps-error)))))
+    (define exact-error (map ~s (list (translate-booleans (hash-ref data 'exact-value)))))
+    (define actual-error (map ~s (list (translate-booleans (hash-ref data 'actual-value)))))
+    (match abs-error ; check for errors and send as string
+      [(? hash? abs-error-hash) (set! abs-error (list (hash-ref abs-error-hash 'value)))]
+      [error-value (set! abs-error (map ~s (list error-value)))])
+    (match (vector-ref nodes root)
       [(list op args ...)
        (hasheq 'e
-               (hash-ref data 'e)
+               expr
                'ulps-error
-               (map ~s (list (hash-ref data 'ulps-error)))
+               ulp-error
                'avg-error
-               (format-bits (errors-score (list (hash-ref data 'ulps-error))))
+               avg-error
                'exact-value
-               (map ~s (list (hash-ref data 'exact-value)))
+               exact-error
                'actual-value
-               (map ~s (list (hash-ref data 'actual-value)))
+               actual-error
                'absolute-error
-               (map ~s (list (hash-ref data 'absolute-error)))
+               abs-error
                'children
-               (map make-hash-for args))] ; ???
+               (map make-hash-for args))]
       [_
        (hasheq 'e
-               (hash-ref data 'e)
+               expr
                'ulps-error
-               (map ~s (list (hash-ref data 'ulps-error)))
+               ulp-error
                'avg-error
-               (format-bits (errors-score (list (hash-ref data 'ulps-error))))
+               avg-error
                'exact-value
-               (map ~s (list (hash-ref data 'exact-value)))
+               exact-error
                'actual-value
-               (map ~s (list (hash-ref data 'actual-value)))
+               actual-error
                'absolute-error
-               (map ~s (list (hash-ref data 'absolute-error)))
+               abs-error
                'children
                '())]))
 

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -251,8 +251,7 @@
 ;; same shape as `prog`
 (define (local-error-as-tree test ctx)
   (define fpcore (prog->fpcore (test-input test) (test-context test)))
-  (define subexprss (list (all-subexpressions (test-input test))))
-  (define exprs-list (append* subexprss)) ; unroll subexprss
+  (define exprs-list (all-subexpressions (test-input test)))
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
@@ -266,11 +265,9 @@
   (define nodes (batch-nodes expr-batch))
   (define roots (batch-roots expr-batch))
 
-  ; TODO don't ignore the status code from make-real-compiler in eval-progs-real
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
   (define actual-value-fn (compile-progs exprs-list ctx))
 
-  ;; Combine loops over pcontext to use for/vectors?
   (define exacts-from-points
     (for/vector #:length (pcontext-length (*pcontext*))
                 ([(pt ex) (in-pcontext (*pcontext*))])
@@ -337,7 +334,7 @@
                (compute-abs-error current-spec exact current-ctx pt current-repr))]))
       (hash-set! data-hash
                  root
-                 (hasheq 'e ;; String shenanigans to persevere current output.
+                 (hasheq 'e
                          (~s (if (pair? expr-syntax)
                                  (first expr-syntax)
                                  expr-syntax))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -156,15 +156,8 @@
   (define subexprss (map all-subexpressions exprs))
   (define errss (compute-local-errors subexprss ctx))
 
-  (define pruned-list
-    (for/list ([h (in-list errss)])
-      (define pruned (make-hash))
-      (for ([(k v) (in-hash h)])
-        (hash-set! pruned k (hash-ref v 'errs)))
-      pruned))
-
   (for/list ([_ (in-list exprs)]
-             [errs (in-list pruned-list)])
+             [errs (in-list errss)])
     (sort (sort (for/list ([(subexpr err) (in-hash errs)]
                            #:when (or (list? subexpr) (approx? subexpr)))
                   (cons err subexpr))
@@ -175,6 +168,71 @@
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-local-errors subexprss ctx)
+  (define exprs-list (append* subexprss)) ; unroll subexprss
+  (define ctx-list
+    (for/list ([subexpr (in-list exprs-list)])
+      (struct-copy context ctx [repr (repr-of subexpr ctx)])))
+
+  (define expr-batch (progs->batch exprs-list))
+  (define nodes (batch-nodes expr-batch))
+  (define roots (batch-roots expr-batch))
+
+  (define subexprs-fn (eval-progs-real (map prog->spec exprs-list) ctx-list))
+  (define actual-value-fn (compile-progs exprs-list ctx))
+
+  (define errs
+    (for/vector #:length (vector-length roots)
+                ([node (in-vector roots)])
+      (make-vector (pcontext-length (*pcontext*)))))
+
+  (define exacts-out
+    (for/vector #:length (vector-length roots)
+                ([node (in-vector roots)])
+      (make-vector (pcontext-length (*pcontext*)))))
+
+  (define actuals-out
+    (for/vector #:length (vector-length roots)
+                ([node (in-vector roots)])
+      (make-vector (pcontext-length (*pcontext*)))))
+
+  (for ([(pt ex) (in-pcontext (*pcontext*))]
+        [pt-idx (in-naturals)])
+
+    (define exacts (list->vector (apply subexprs-fn pt)))
+    (define actuals (apply actual-value-fn pt))
+
+    (for ([expr (in-list exprs-list)]
+          [root (in-vector roots)]
+          [exact (in-vector exacts)]
+          [actual (in-vector actuals)]
+          [expr-idx (in-naturals)])
+      (define err
+        (match (vector-ref nodes root)
+          [(? literal?) 1]
+          [(? variable?) 1]
+          [(approx _ impl)
+           (define repr (repr-of expr ctx))
+           (ulp-difference exact (vector-ref exacts (vector-member impl roots)) repr)]
+          [`(if ,c ,ift ,iff) 1]
+          [(list f args ...)
+           (define repr (impl-info f 'otype))
+           (define argapprox
+             (for/list ([idx (in-list args)])
+               (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
+           (define approx (apply (impl-info f 'fl) argapprox))
+           (ulp-difference exact approx repr)]))
+      (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
+      (vector-set! (vector-ref errs expr-idx) pt-idx err)
+      (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)))
+
+  (define n 0)
+  (for/list ([subexprs (in-list subexprss)])
+    (for*/hash ([subexpr (in-list subexprs)])
+      (begin0 (values subexpr (vector->list (vector-ref errs n)))
+        (set! n (add1 n))))))
+
+; Compute local error or each sampled point at each node in `prog`.
+(define (compute-errors subexprss ctx)
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
@@ -249,7 +307,7 @@
 ;; and returns the error information as an S-expr in the
 ;; same shape as `prog`
 (define (local-error-as-tree test ctx)
-  (define errs (first (compute-local-errors (list (all-subexpressions (test-input test))) ctx)))
+  (define errs (first (compute-errors (list (all-subexpressions (test-input test))) ctx)))
 
   (define local-error
     (let loop ([expr (test-input test)])

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -273,6 +273,7 @@
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
   (define actual-value-fn (compile-progs exprs-list ctx))
 
+  ;; TODO clean up allocations
   (define local-errors
     (for/vector #:length (vector-length roots)
                 ([node (in-vector roots)])
@@ -331,7 +332,6 @@
           [actual (in-vector actuals)]
           [exact (in-vector exacts)]
           [expr-idx (in-naturals)])
-      (define ulp-error 1)
       (define local-error
         (match (vector-ref nodes root)
           [(? literal?) 1]
@@ -367,7 +367,6 @@
       (define current-repr (hash-ref repr-hash expr))
       (define abs-error (bfabs ((representation-repr->bf current-repr) error-difference)))
       (define abs-error-out (value->json (bigfloat->flonum abs-error) current-repr))
-      (vector-set! (vector-ref ulps-out expr-idx) pt-idx ulp-error)
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref local-errors expr-idx) pt-idx local-error)
       (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)
@@ -378,9 +377,7 @@
     (first (for/list ([subexprs (in-list subexprss)])
              (for*/hash ([subexpr (in-list subexprs)])
                (begin0 (values subexpr
-                               (hasheq 'ulp-errors
-                                       (vector->list (vector-ref ulps-out n))
-                                       'local-errors
+                               (hasheq 'local-errors
                                        (vector->list (vector-ref local-errors n))
                                        'exact-values
                                        (vector->list (vector-ref exacts-out n))
@@ -389,14 +386,6 @@
                                        'absolute-error
                                        (vector->list (vector-ref abs-error-outs n))))
                  (set! n (add1 n)))))))
-
-  (define ulp-error-values
-    (let loop ([expr (test-input test)])
-      (define expr-info (hash-ref err-tree expr))
-      (define err-list (hash-ref expr-info 'ulp-errors))
-      (match expr
-        [(list op args ...) (cons err-list (map loop args))]
-        [_ (list err-list)])))
 
   (define local-error-values
     (let loop ([expr (test-input test)])
@@ -432,7 +421,6 @@
 
   (define tree
     (let loop ([expr (prog->fpcore (test-input test) (test-context test))]
-               [ulp-error ulp-error-values]
                [local-error local-error-values]
                [exact exact-values]
                [actual actual-values]
@@ -443,7 +431,7 @@
          (hasheq 'e
                  (~a op)
                  'ulps-error
-                 (map ~s (first ulp-error))
+                 (map ~s (first local-error))
                  'avg-error
                  (format-bits (errors-score (first local-error)))
                  'exact-value
@@ -455,7 +443,6 @@
                  'children
                  (map loop
                       args
-                      (rest ulp-error)
                       (rest local-error)
                       (rest exact)
                       (rest actual)
@@ -465,7 +452,7 @@
          (hasheq 'e
                  (~a expr)
                  'ulps-error
-                 (map ~s (first ulp-error))
+                 (map ~s (first local-error))
                  'avg-error
                  (format-bits (errors-score (first local-error)))
                  'exact-value

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -249,8 +249,11 @@
   (define ctxs (list ctx))
   (check-equal? (first (apply (eval-progs-real specs ctxs) pt)) 1.0))
 
-; Compute local error or each sampled point at each node in `prog`.
-(define (compute-errors subexprss ctx)
+;; Compute the local error of every subexpression of `prog`
+;; and returns the error information as an S-expr in the
+;; same shape as `prog`
+(define (local-error-as-tree test ctx)
+  (define subexprss (list (all-subexpressions (test-input test))))
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
@@ -266,13 +269,12 @@
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
   (define actual-value-fn (compile-progs exprs-list ctx))
 
-  ; TODO way too much allocation for what we are doing.
-  (define errs
+  (define ulps-error
     (for/vector #:length (vector-length roots)
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
-  (define true-errors-out
+  (define abs-error-out
     (for/vector #:length (vector-length roots)
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
@@ -287,26 +289,26 @@
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
+  ;; TODO combine loops over pcontext for/vectors?
   (define exacts-from-points
-    ;; Really only gets called with one point in pcontext from Odyssey
-    (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
+    (for/vector #:length (pcontext-length (*pcontext*))
+                ([(pt ex) (in-pcontext (*pcontext*))])
       (list->vector (apply subexprs-fn pt))))
-  ;; TODO combine loops over pcontext
   (define actuals-from-points
-    ;; Really only gets called with one point in pcontext from Odyssey
-    (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
+    (for/vector #:length (pcontext-length (*pcontext*))
+                ([(pt ex) (in-pcontext (*pcontext*))])
       (apply actual-value-fn pt)))
 
-  (define (true-error-for spec exact ctx pt)
-    ; TODO pass in the list of of specs and exacts and ctxs and apply that function to pts
-    (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
+  (define (absolute-error spec exact ctx pt)
+    (define s (list `(- ,spec ,exact)))
+    (define c (list ctx))
+    (first (apply (eval-progs-real s c) pt)))
 
-  (define (true-error-from i exact pt)
+  (define (absolute-error-for i exact pt)
     (define approx-spec (vector-ref spec-vec i))
     (define approx-ctx (vector-ref ctx-vec i))
-    (true-error-for approx-spec exact approx-ctx pt))
+    (absolute-error approx-spec exact approx-ctx pt))
 
-  ;; Set to skip evaluate the second part expresion of an if condition.
   (define previous_node_condition #f)
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
@@ -332,64 +334,57 @@
            (define repr (impl-info f 'otype))
            (define argapprox
              (for/list ([idx (in-list args)])
-               (vector-ref exacts (vector-member idx roots)))) ; arg's index mapping to exact
+               (vector-ref exacts (vector-member idx roots))))
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference exact approx repr)]))
-      (define true-error
+      (define abs-error
         (match (vector-ref nodes root)
-          [(? literal?) exact]
-          [(? variable?) 1]
-          ; compare the exact against it's impl substitution.
-          [(approx _ impl) (true-error-from impl exact pt)]
+          [(? literal?) (absolute-error c-spec exact c-ctx pt)]
+          [(? variable?) 0]
+          [(approx _ impl) (absolute-error-for impl exact pt)]
           [`(if ,c ,ift ,iff)
            (set! previous_node_condition #t)
            (if exact
-               (true-error-from ift exact pt)
-               (true-error-from iff exact pt))]
+               (absolute-error-for ift exact pt)
+               (absolute-error-for iff exact pt))]
           [(list f args ...)
            (define local previous_node_condition)
            (when previous_node_condition
              (set! previous_node_condition #f))
            (if local
                exact
-               (true-error-for c-spec exact c-ctx pt))]))
+               (absolute-error c-spec exact c-ctx pt))]))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
-      (vector-set! (vector-ref errs expr-idx) pt-idx err)
+      (vector-set! (vector-ref ulps-error expr-idx) pt-idx err)
       (vector-set! (vector-ref actuals-out expr-idx) pt-idx actual)
-      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx true-error)))
+      (vector-set! (vector-ref abs-error-out expr-idx) pt-idx abs-error)))
 
   (define n 0)
-  (for/list ([subexprs (in-list subexprss)])
-    (for*/hash ([subexpr (in-list subexprs)])
-      (begin0 (values subexpr
-                      (hasheq 'errs
-                              (vector->list (vector-ref errs n))
-                              'exact-values
-                              (vector->list (vector-ref exacts-out n))
-                              'actual-values
-                              (vector->list (vector-ref actuals-out n))
-                              'true-error-value
-                              (vector->list (vector-ref true-errors-out n))))
-        (set! n (add1 n))))))
+  (define err-tree
+    (first (for/list ([subexprs (in-list subexprss)])
+             (for*/hash ([subexpr (in-list subexprs)])
+               (begin0 (values subexpr
+                               (hasheq 'ulps-of-error
+                                       (vector->list (vector-ref ulps-error n))
+                                       'exact-values
+                                       (vector->list (vector-ref exacts-out n))
+                                       'actual-values
+                                       (vector->list (vector-ref actuals-out n))
+                                       'absolute-error
+                                       (vector->list (vector-ref abs-error-out n))))
+                 (set! n (add1 n)))))))
 
-;; Compute the local error of every subexpression of `prog`
-;; and returns the error information as an S-expr in the
-;; same shape as `prog`
-(define (local-error-as-tree test ctx)
-  (define sub-exprs (list (all-subexpressions (test-input test))))
-  (define errs (first (compute-errors sub-exprs ctx)))
-
-  (define local-error
+  (define ulps-of-error
     (let loop ([expr (test-input test)])
-      (define expr-info (hash-ref errs expr))
-      (define err-list (hash-ref expr-info 'errs))
+      (define expr-info (hash-ref err-tree expr))
+      (define err-list (hash-ref expr-info 'ulps-of-error))
       (match expr
         [(list op args ...) (cons err-list (map loop args))]
         [_ (list err-list)])))
 
   (define exact-values
     (let loop ([expr (test-input test)])
-      (define expr-info (hash-ref errs expr))
+      (define expr-info (hash-ref err-tree expr))
       (define exacts-list (hash-ref expr-info 'exact-values))
       (match expr
         [(list op args ...) (cons exacts-list (map loop args))]
@@ -397,7 +392,7 @@
 
   (define actual-values
     (let loop ([expr (test-input test)])
-      (define expr-info (hash-ref errs expr))
+      (define expr-info (hash-ref err-tree expr))
       (define actual-list (hash-ref expr-info 'actual-values))
       (match expr
         [(list op args ...) (cons actual-list (map loop args))]
@@ -405,15 +400,15 @@
 
   (define true-error-values
     (let loop ([expr (test-input test)])
-      (define expr-info (hash-ref errs expr))
-      (define actual-list (hash-ref expr-info 'true-error-value))
+      (define expr-info (hash-ref err-tree expr))
+      (define true-error-list (hash-ref expr-info 'absolute-error))
       (match expr
-        [(list op args ...) (cons actual-list (map loop args))]
-        [_ (list actual-list)])))
+        [(list op args ...) (cons true-error-list (map loop args))]
+        [_ (list true-error-list)])))
 
   (define tree
     (let loop ([expr (prog->fpcore (test-input test) (test-context test))]
-               [err local-error]
+               [ulp ulps-of-error]
                [exact exact-values]
                [actual actual-values]
                [true-error true-error-values])
@@ -423,30 +418,30 @@
          (hasheq 'e
                  (~a op)
                  'ulps-error
-                 (map ~s (first err))
+                 (map ~s (first ulp))
                  'avg-error
-                 (format-bits (errors-score (first err)))
+                 (format-bits (errors-score (first ulp)))
                  'exact-value
                  (map ~s (first exact))
                  'actual-value
                  (map ~s (first actual))
-                 'true-error-value
+                 'absolute-error
                  (map ~s (first true-error))
                  'children
-                 (map loop args (rest err) (rest exact) (rest actual) (rest true-error)))]
+                 (map loop args (rest ulp) (rest exact) (rest actual) (rest true-error)))]
         ;; err => (List (listof Integer))
         [_
          (hasheq 'e
                  (~a expr)
                  'ulps-error
-                 (map ~s (first err))
+                 (map ~s (first ulp))
                  'avg-error
-                 (format-bits (errors-score (first err)))
+                 (format-bits (errors-score (first ulp)))
                  'exact-value
                  (map ~s (first exact))
                  'actual-value
                  (map ~s (first actual))
-                 'true-error-value
+                 'absolute-error
                  (map ~s (first true-error))
                  'children
                  '())])))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -240,14 +240,11 @@
         (set! n (add1 n))))))
 
 (module+ test
-  ; Test that we can comptue the true value for n amount of points in the expression.
   (define ctx (make-debug-context '(x y)))
   (define spec `(- (sqrt (+ x 1)) (sqrt y)))
   (define pt `(1e-100 1e-100))
   (define exact 1e-50)
-  (define specs (list `(- ,spec ,exact)))
-  (define ctxs (list ctx))
-  (check-equal? (first (apply (eval-progs-real specs ctxs) pt)) 1.0))
+  (check-equal? (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)) 1.0))
 
 ;; Compute the local error of every subexpression of `prog`
 ;; and returns the error information as an S-expr in the
@@ -284,11 +281,6 @@
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
-  (define ulps-out
-    (for/vector #:length (vector-length roots)
-                ([node (in-vector roots)])
-      (make-vector (pcontext-length (*pcontext*)))))
-
   (define exacts-out
     (for/vector #:length (vector-length roots)
                 ([node (in-vector roots)])
@@ -309,25 +301,24 @@
                 ([(pt ex) (in-pcontext (*pcontext*))])
       (apply actual-value-fn pt)))
 
-  (define (absolute-error spec exact ctx pt)
-    (define s (list `(- ,spec ,exact)))
-    (define c (list ctx))
-    (first (apply (eval-progs-real s c) pt)))
+  (define (compute-true-error spec exact ctx pt)
+    ;; TODO compute in batches and evalutate propigated errors from rival.
+    (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
 
   (define (absolute-error-for i exact pt)
     (define approx-spec (vector-ref spec-vec i))
     (define approx-ctx (vector-ref ctx-vec i))
-    (absolute-error approx-spec exact approx-ctx pt))
+    (compute-true-error approx-spec exact approx-ctx pt))
 
-  (define previous_node_condition #f)
+  (define previous_node_if? #f)
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [exacts (in-vector exacts-from-points)]
         [actuals (in-vector actuals-from-points)]
         [pt-idx (in-naturals)])
     (for ([expr (in-list exprs-list)]
-          [c-spec (in-vector spec-vec)]
-          [c-ctx (in-list ctx-list)]
+          [current-spec (in-vector spec-vec)]
+          [current-ctx (in-list ctx-list)]
           [root (in-vector roots)]
           [actual (in-vector actuals)]
           [exact (in-vector exacts)]
@@ -347,25 +338,25 @@
                (vector-ref exacts (vector-member idx roots))))
            (define approx (apply (impl-info f 'fl) argapprox))
            (ulp-difference exact approx repr)]))
-      (define error-difference
+      (define true-error
         (match (vector-ref nodes root)
-          [(? literal?) (absolute-error c-spec exact c-ctx pt)]
+          [(? literal?) (compute-true-error current-spec exact current-ctx pt)]
           [(? variable?) 0]
           [(approx _ impl) (absolute-error-for impl exact pt)]
           [`(if ,c ,ift ,iff)
-           (set! previous_node_condition #t)
+           (set! previous_node_if? #t)
            (if exact
                (absolute-error-for ift exact pt)
                (absolute-error-for iff exact pt))]
           [(list f args ...)
-           (define local previous_node_condition)
-           (when previous_node_condition
-             (set! previous_node_condition #f))
+           (define local previous_node_if?)
+           (when previous_node_if?
+             (set! previous_node_if? #f))
            (if local
                exact
-               (absolute-error c-spec exact c-ctx pt))]))
+               (compute-true-error current-spec exact current-ctx pt))]))
       (define current-repr (hash-ref repr-hash expr))
-      (define abs-error (bfabs ((representation-repr->bf current-repr) error-difference)))
+      (define abs-error (bfabs ((representation-repr->bf current-repr) true-error)))
       (define abs-error-out (value->json (bigfloat->flonum abs-error) current-repr))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref local-errors expr-idx) pt-idx local-error)
@@ -441,12 +432,7 @@
                  'absolute-error
                  (map ~s (first true-error))
                  'children
-                 (map loop
-                      args
-                      (rest local-error)
-                      (rest exact)
-                      (rest actual)
-                      (rest true-error)))]
+                 (map loop args (rest local-error) (rest exact) (rest actual) (rest true-error)))]
         ;; err => (List (listof Integer))
         [_
          (hasheq 'e

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -239,25 +239,15 @@
       (begin0 (values subexpr (vector->list (vector-ref errs n)))
         (set! n (add1 n))))))
 
-(define (true-error-for spec ctx exact)
-  (define specs (list `(- ,spec ,exact)))
-  (define ctxs (list ctx))
-  (define compiler (make-real-compiler specs ctxs))
-  (define bad-pt
-    (for/list ([ctx* (in-list ctxs)]) ; copied from eval-progs-real
-      ((representation-bf->repr (context-repr ctx*)) +nan.bf)))
-  (define (<eval-true-error> . pt)
-    (define-values (_ exs) (apply real-apply compiler pt))
-    (or (first exs) bad-pt)) ;; should only be one value
-  <eval-true-error>)
-
 (module+ test
   ; Test that we can comptue the true value for n amount of points in the expression.
   (define ctx (make-debug-context '(x y)))
   (define spec `(- (sqrt (+ x 1)) (sqrt y)))
   (define pt `(1e-100 1e-100))
   (define exact 1e-50)
-  (check-equal? ((true-error-for spec ctx exact) pt) 1.0))
+  (define specs (list `(- ,spec ,exact)))
+  (define ctxs (list ctx))
+  (check-equal? (first (apply (eval-progs-real specs ctxs) pt)) 1.0))
 
 ; Compute local error or each sampled point at each node in `prog`.
 (define (compute-errors subexprss ctx)
@@ -294,31 +284,25 @@
                 ([node (in-vector roots)])
       (make-vector (pcontext-length (*pcontext*)))))
 
-  (for ([(pt ex) (in-pcontext (*pcontext*))]
-        [pt-idx (in-naturals)])
-    (define exacts (list->vector (apply subexprs-fn pt)))
-    (define actuals (apply actual-value-fn pt))
-    (for ([cur-spec (in-list spec-list)]
-          [cur-ctx (in-list ctx-list)]
-          [expr (in-list exprs-list)]
-          [root (in-vector roots)]
+  (define exacts-from-points
+    ;; Really only gets called with one point in pcontext from Odyssey
+    (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
+      (list->vector (apply subexprs-fn pt))))
+
+  ;; So much data layout inverting
+  (for ([c-spec (in-list spec-list)]
+        [c-ctx (in-list ctx-list)]
+        [exacts (in-vector exacts-from-points)]
+        [expr-idx (in-naturals)])
+    (for ([(pt ex) (in-pcontext (*pcontext*))]
           [exact (in-vector exacts)]
-          [actual (in-vector actuals)]
-          [expr-idx (in-naturals)])
-      (match (vector-ref nodes root)
-        [(? literal?) (eprintf "literal: ~a\n" cur-spec)]
-        [(? variable?) (eprintf "variable: ~a\n" cur-spec)]
-        [(approx approx-spec impl) (eprintf "approx: ~a\n" cur-spec)]
-        [`(if ,c ,ift ,iff) (eprintf "if: ~a\n" cur-spec)]
-        [(list f args ...) (eprintf "f: ~a\n" cur-spec)])
-      (eprintf "inputs: ~a, ~a, ~a, ~a\n" cur-ctx cur-spec pt exact)
-      (define true-error ((true-error-for cur-spec cur-ctx exact) pt))
-      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx true-error)))
+          [pt-idx (in-naturals)])
+      (define t (first (apply (eval-progs-real (list `(- ,c-spec ,exact)) (list c-ctx)) pt)))
+      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx t)))
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
-        [pt-idx (in-naturals)])
-
-    (define exacts (list->vector (apply subexprs-fn pt)))
+        [pt-idx (in-naturals)]
+        [exacts (in-vector exacts-from-points)])
     (define actuals (apply actual-value-fn pt))
 
     (for ([expr (in-list exprs-list)]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -255,7 +255,9 @@
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)])
       (struct-copy context ctx [repr (repr-of subexpr ctx)])))
+  (define ctx-vec (list->vector ctx-list))
   (define spec-list (map prog->spec exprs-list))
+  (define spec-vec (list->vector spec-list))
   (define expr-batch (progs->batch exprs-list))
   (define nodes (batch-nodes expr-batch))
   (define roots (batch-roots expr-batch))
@@ -264,6 +266,7 @@
   (define subexprs-fn (eval-progs-real spec-list ctx-list))
   (define actual-value-fn (compile-progs exprs-list ctx))
 
+  ; TODO way too much allocation for what we are doing.
   (define errs
     (for/vector #:length (vector-length roots)
                 ([node (in-vector roots)])
@@ -289,16 +292,48 @@
     (for/vector ([(pt ex) (in-pcontext (*pcontext*))])
       (list->vector (apply subexprs-fn pt))))
 
-  ;; So much data layout inverting
-  (for ([c-spec (in-list spec-list)]
-        [c-ctx (in-list ctx-list)]
+  (define (true-error-for spec exact ctx pt)
+    ; TODO pass in the list of of specs and exacts and ctxs and apply that function to pts
+    (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
+
+  (define (true-error-from i exact pt)
+    (define approx-spec (vector-ref spec-vec i))
+    (define approx-ctx (vector-ref ctx-vec i))
+    (true-error-for approx-spec exact approx-ctx pt))
+
+  ;; Set to skip evaluate the second part expresion of an if condition.
+  (define previous_node_condition #f)
+
+  (for ([(pt ex) (in-pcontext (*pcontext*))]
         [exacts (in-vector exacts-from-points)]
-        [expr-idx (in-naturals)])
-    (for ([(pt ex) (in-pcontext (*pcontext*))]
-          [exact (in-vector exacts)]
-          [pt-idx (in-naturals)])
-      (define t (first (apply (eval-progs-real (list `(- ,c-spec ,exact)) (list c-ctx)) pt)))
-      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx t)))
+        [pt-idx (in-naturals)])
+    (for ([c-spec (in-vector spec-vec)]
+          [c-ctx (in-list ctx-list)]
+          [root (in-vector roots)]
+          [exact exacts]
+          [expr-idx (in-naturals)])
+      (eprintf "node: ~a\n" (vector-ref nodes root))
+      (define true-error
+        (match (vector-ref nodes root)
+          [(? literal?)
+           (eprintf "spec: ~a\n" c-spec)
+           exact]
+          [(? variable?) 1]
+          ; compare the exact against it's impl substitution.
+          [(approx _ impl) (true-error-from impl exact pt)]
+          [`(if ,c ,ift ,iff)
+           (set! previous_node_condition #t)
+           (if exact
+               (true-error-from ift exact pt)
+               (true-error-from iff exact pt))]
+          [(list f args ...)
+           (define local previous_node_condition)
+           (when previous_node_condition
+             (set! previous_node_condition #f))
+           (if local
+               exact
+               (true-error-for c-spec exact c-ctx pt))]))
+      (vector-set! (vector-ref true-errors-out expr-idx) pt-idx true-error)))
 
   (for ([(pt ex) (in-pcontext (*pcontext*))]
         [pt-idx (in-naturals)]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -277,9 +277,9 @@
                 ([(pt ex) (in-pcontext (*pcontext*))])
       (apply actual-value-fn pt)))
 
-  (define (compute-abs-error spec exact ctx pt repr)
+  (define (compute-abs-error actual exact ctx pt repr)
     ;; TODO compute in batches and evalutate propigated errors from rival.
-    (define true-error (first (apply (eval-progs-real (list `(- ,spec ,exact)) (list ctx)) pt)))
+    (define true-error (first (apply (eval-progs-real (list `(- ,actual ,exact)) (list ctx)) pt)))
     (define bf-true-error ((representation-repr->bf repr) true-error))
     (define abs-error (bfabs bf-true-error))
     (define abs-error-out (value->json (bigfloat->flonum abs-error) repr))
@@ -297,7 +297,6 @@
         [actuals (in-vector actuals-from-points)])
     (for ([expr-syntax (in-list (all-subexpressions fpcore))]
           [expr (in-list exprs-list)]
-          [current-spec (in-vector spec-vec)]
           [current-ctx (in-list ctx-list)]
           [root (in-vector roots)]
           [actual (in-vector actuals)]
@@ -310,7 +309,7 @@
           [(? variable?) 1]
           [(approx _ impl)
            (define repr (repr-of expr ctx))
-           (ulp-difference exact (vector-ref exacts (vector-member impl roots)) repr)]
+           (ulp-difference exact actual repr)]
           [`(if ,c ,ift ,iff) 1]
           [(list f args ...)
            (define repr (impl-info f 'otype))
@@ -321,7 +320,7 @@
            (ulp-difference exact approx repr)]))
       (define abs-error
         (match node
-          [(? literal?) (compute-abs-error current-spec exact current-ctx pt current-repr)]
+          [(? literal?) (compute-abs-error actual exact current-ctx pt current-repr)]
           [(? variable?) 0]
           [(approx _ impl) (absolute-error-for impl exact pt current-repr)]
           [`(if ,c ,ift ,iff)
@@ -331,7 +330,7 @@
           [(list f args ...)
            (if (equal? (representation-type (impl-info f 'otype)) 'bool)
                exact
-               (compute-abs-error current-spec exact current-ctx pt current-repr))]))
+               (compute-abs-error actual exact current-ctx pt current-repr))]))
       (hash-set! data-hash
                  root
                  (hasheq 'e
@@ -358,7 +357,7 @@
     (define data (hash-ref data-hash root))
     (define expr (hash-ref data 'e))
     (define abs-error (translate-booleans (hash-ref data 'absolute-error)))
-    (define ulp-error (map ~s (list (translate-booleans (hash-ref data 'ulps-error)))))
+    (define ulp-error (map ~s (list (translate-booleans (ulps->bits (hash-ref data 'ulps-error))))))
     (define avg-error (format-bits (errors-score (list (hash-ref data 'ulps-error)))))
     (define exact-error (map ~s (list (translate-booleans (hash-ref data 'exact-value)))))
     (define actual-error (map ~s (list (translate-booleans (hash-ref data 'actual-value)))))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -12,6 +12,7 @@
          (struct-out context)
          *context*
          context-extend
+         context-append
          context-lookup)
 
 (module+ internals
@@ -133,6 +134,12 @@
                ctx
                [vars (cons var (context-vars ctx))]
                [var-reprs (cons repr (context-var-reprs ctx))]))
+
+(define (context-append ctx var repr)
+  (struct-copy context
+               ctx
+               [vars (append (context-vars ctx) (list var))]
+               [var-reprs (append (context-var-reprs ctx) (list repr))]))
 
 (define (context-lookup ctx var)
   (dict-ref (map cons (context-vars ctx) (context-var-reprs ctx)) var))


### PR DESCRIPTION
Updates the Local Error endpoint to include more information for Odyssey to consume. This PR also splits the code path away from `compute-local-errors` consumed by the core of Herbie. The current implementation is incomplete and incorrect so this PR aims to correct and improve on the current version both in correctness and surfacing more useful information. 

Local error tree nodes include
- average error: `(format-bits (errors-score ulp-error))`
- exact value: Computed against the spec of the node, using `eval-progs-real`.
- actual value: Computed against the program, using `compile-progs`.
- absolute error: Distance between the `exact` and the `actual` value `| actual - exact |`.
- ulps of error: Uses existing code from `compute-local-errors`.

For Odyssey to consume this new API it needs this [PR](https://github.com/herbie-fp/odyssey/pull/184)

Note about errors from Rival. Currently, these are just converted to strings and shipped to Odyssey instead of the value. This isn't great it doesn't crash the UI from my testing with benchmarks like det44 and others with exceptional values like `inf` and `nan`.  My goal with this PR is to not cause Odyssey in particular the mermaid parser to crash from `#hash` or other types leaking through the JSON.

The Following performance improvements could be made, when testing with `det44` it does take a noticeable amount of time for samples to come back, even with Odyssey only requesting one `pt` at a time.
Possible Performance  improvements:
- Batch evaluate errors.
- Vectors instead of hash maps

TODO:
- [ ] add test cases from Det44

Next PR:
- [ ] Remove the nested `hash` in the next PR. 
- [ ] Fix 51/64 bit error bug.