### PR TITLE
Update resyntax-autofixer.yml

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Install dependencies"
         run: make install
       - name: Create a Resyntax pull request
-        uses: jackfirth/create-resyntax-pull-request@v0.4.1
+        uses: jackfirth/create-resyntax-pull-request@v0.4.2
         with:
           private-key: ${{ secrets.RESYNTAX_APP_PRIVATE_KEY }}
           max-fixes: '5'


### PR DESCRIPTION
I fixed a bug that prevented the autofixer from working on repositories that don't use `master` as their default branch. Seems that's why the workflow failed over the weekend.