### PR TITLE
Don't output any timeline information for an empty timeline

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -27,6 +27,8 @@ assert.equal(timeline.length > 0, true)
 // Test with a likely missing job-id
 const badTimelineRSP = await fetch(makeEndpoint("/timeline/42069"), { method: 'GET' })
 assert.equal(badTimelineRSP.status, 404)
+const check_missing_job = await fetch(makeEndpoint(`/check-status/42069`), { method: 'GET' })
+assert.equal(check_missing_job.status, 202)
 
 // improve-start endpoint
 const URIencodedBody = "formula=" + encodeURIComponent(FPCoreFormula)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -370,10 +370,9 @@
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out)
-                 (display (apply string-append
-                                 (for/list ([entry timeline])
-                                   (format "Doing ~a\n" (hash-ref entry 'type))))
-                          out)))]))
+                 (when timeline
+                   (for ([entry timeline])
+                     (fprintf out "Doing ~a\n" (hash-ref entry 'type))))))]))
 
 (define (check-up req)
   (response/full (if (is-server-up) 200 500)


### PR DESCRIPTION
This PR fixes #1030, which was caused by a `timeline` of `#f`. I'm not sure when this case happens, @zaneenders perhaps you know.