### PR TITLE
Fix null annotations `(! expr)` in desugaring

### DIFF
--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -267,7 +267,10 @@
          (match expr
            [(list '! props ... (list op _ ...))
             ; rounding context updated parent context
-            (define prop-dict* (apply dict-set prop-dict props))
+            (define prop-dict*
+              (if (not (null? props))
+                  (apply dict-set prop-dict props)
+                  prop-dict))
             (get-fpcore-impl op prop-dict* (impl-info impl 'itype))]
            ; rounding context inherited from parent context
            [(list op _ ...) (get-fpcore-impl op prop-dict (impl-info impl 'itype))]))


### PR DESCRIPTION
This PR fixes #1019. Looks like we handled null annotations correctly in one code path but not in another.