### PR TITLE
Splitting the Egglog Herbie Interface

### DIFF
--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -133,7 +133,6 @@
 ;;  - multi extraction: `(multi . <extractor>)`
 ;;  - proofs: `(proofs . ((<start> . <end>) ...))`
 
-
 ;; TODO : Need to run egglog to get the actual ids per
 (define (run-egglog-single-extractor runner extractor) ; single expression extraction
   (define curr-batch (egg-runner-batch runner))
@@ -168,7 +167,6 @@
              [end (in-list end-exprs)])
     #f))
 
-
 ; ; 1. ask within egglog program what is id
 ; ; 2. Extract expression from each expr
 ; ; TODO: if i have  two expressions how di i know if they are in the same e-class
@@ -180,7 +178,6 @@
   (for/list ([start (in-list start-exprs)]
              [end (in-list end-exprs)])
     #f))
-
 
 (define (prelude #:mixed-egraph? [mixed-egraph? #t])
   (load-herbie-builtins)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -160,11 +160,7 @@
 ;; there is some value that herbie has which indicates we could not
 ;; find a proof. Might be (list #f #f ....)
 (define (run-egglog-proofs runner rws) ; proof extraction
-  (define start-exprs (map car rws))
-  (define end-exprs (map cadr rws))
-
-  (for/list ([start (in-list start-exprs)]
-             [end (in-list end-exprs)])
+  (for/list ([(start-expr end-expr) (in-dict rws)])
     #f))
 
 ; ; 1. ask within egglog program what is id
@@ -172,11 +168,7 @@
 ; ; TODO: if i have  two expressions how di i know if they are in the same e-class
 ; ; if we are outside of egglog
 (define (run-egglog-equal? runner expr-pairs) ; term equality?
-  (define start-exprs (map car expr-pairs))
-  (define end-exprs (map cadr expr-pairs))
-
-  (for/list ([start (in-list start-exprs)]
-             [end (in-list end-exprs)])
+  (for/list ([(start-expr end-expr) (in-dict expr-pairs)])
     #f))
 
 (define (prelude #:mixed-egraph? [mixed-egraph? #t])

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -160,7 +160,7 @@
   ; batchrefss is a (listof (listof batchref))
   (define batchrefss
     (if (member 'egglog generate-flags)
-        (run-egglog runner `(multi . ,extractor))
+        (run-egglog-multi-extractor runner extractor)
         (run-egg runner `(multi . ,extractor))))
 
   ; apply changelists

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -121,7 +121,7 @@
 
   (define equal?-lst
     (if (member 'egglog generate-flags)
-        (run-egglog runner `(equal? . ,expr-pairs))
+        (run-egglog-equal? runner expr-pairs)
         (run-egg runner `(equal? . ,expr-pairs))))
 
   ;; collect equalities

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -28,7 +28,7 @@
   (define generate-flags (hash-ref all-flags 'generate))
   (define simplifieds
     (if (member 'egglog generate-flags)
-        (run-egglog runner (cons 'single extractor))
+        (run-egglog-single-extractor runner extractor)
         (run-egg runner (cons 'single extractor))))
 
   (define out

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -122,7 +122,7 @@
     (define generate-flags (hash-ref all-flags 'generate))
     (define proofs
       (if (member 'egglog generate-flags)
-          (run-egglog runner `(proofs . ,rws))
+          (run-egglog-proofs runner rws)
           (run-egg runner `(proofs . ,rws))))
 
     (values runner (map cons rws proofs))))


### PR DESCRIPTION
**Description:**
This PR splits the `run-egglog` interface into 4 parts.

The main goal is to simplify the API and not be dependent on matching the `cmd` argument, but calling the ideal method for getting back the output.

Updates are also made across different files `patch.rkt`, `simplify.rkt`, `soundiness.rkt`, `preprocess.rkt`.