### PR TITLE
Remove extra variable y.

### DIFF
--- a/bench/mathematics/logistic-regression.fpcore
+++ b/bench/mathematics/logistic-regression.fpcore
@@ -10,6 +10,6 @@
    
  (- (log (+ 1 (exp x))) (* x y)))
 
-(FPCore (x y)
+(FPCore (x)
  :name "Logistic function from Lakshay Garg"
  (- (/ 2 (+ 1 (exp (* -2 x)))) 1))


### PR DESCRIPTION
When running Herbie benchmarks through Odyssey's FPCore input I noticed this expression has an extra variable.
Issue  #1041 