### PR TITLE
Update rules.rkt to include inverses.

### DIFF
--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
+                 )
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
@@ -378,8 +378,7 @@
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
                  [cube-mult (pow x 3) (* x (* x x))]
-                 [cube-prod-rev (* (pow x 3) (pow y 3)) (pow (* x y) 3)]
-                 [cube-div-rev (/ (pow x 3) (pow y 3)) (pow (/ x y) 3)])
+                 )
 
 (define-ruleset* cubes-transform
                  (arithmetic sound)
@@ -391,10 +390,7 @@
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
-(define-ruleset* cubes-transform-rev
-                 (arithmetic sound)
-                 #:type ([x real] [y real])
-                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
+
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)
@@ -438,12 +434,7 @@
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
 
-(define-ruleset* exp-factor-rev
-                 (exponents simplify sound)
-                 #:type ([a real] [b real])
-                 [exp-lft-cube-rev (pow (exp a) 3) (exp (* a 3))]
-                 [exp-sqrt-rev (sqrt (exp a)) (exp (/ a 2))]
-                 [exp-lft-sqr-rev (* (exp a) (exp a)) (exp (* a 2))])
+
 
 ; Powers
 (define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -163,7 +163,28 @@
                  [associate-/r/ (/ a (/ b c)) (* (/ a b) c)]
                  [associate-/l/ (/ (/ b c) a) (/ b (* c a))]
                  [associate-/l* (/ (* b c) a) (* b (/ c a))])
-
+                 
+; Identity
+(define-ruleset* id-reduce
+                 (arithmetic simplify sound)
+                 #:type ([a real])
+                 [remove-double-div (/ 1 (/ 1 a)) a]
+                 [rgt-mult-inverse (* a (/ 1 a)) 1]
+                 [lft-mult-inverse (* (/ 1 a) a) 1]
+                 [+-inverses (- a a) 0]
+                 [div0 (/ 0 a) 0]
+                 [mul0-lft (* 0 a) 0]
+                 [mul0-rgt (* a 0) 0]
+                 [*-inverses (/ a a) 1]
+                 [+-lft-identity (+ 0 a) a]
+                 [+-rgt-identity (+ a 0) a]
+                 [--rgt-identity (- a 0) a]
+                 [sub0-neg (- 0 a) (neg a)]
+                 [remove-double-neg (neg (neg a)) a]
+                 [*-lft-identity (* 1 a) a]
+                 [*-rgt-identity (* a 1) a]
+                 [/-rgt-identity (/ a 1) a]
+                 [mul-1-neg (* -1 a) (neg a)])
 ; Counting
 (define-ruleset* counting (arithmetic simplify sound) #:type ([x real]) [count-2 (+ x x) (* 2 x)])
 
@@ -184,7 +205,11 @@
                  [distribute-rgt-out-- (- (* b a) (* c a)) (* a (- b c))]
                  [distribute-lft1-in (+ (* b a) a) (* (+ b 1) a)]
                  [distribute-rgt1-in (+ a (* c a)) (* (+ c 1) a)])
-
+(define-ruleset* cancel-sign
+                 (arithmetic simplify sound)
+                 #:type ([a real] [b real] [c real])
+                 [cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
+                 [cancel-sign-sub-inv (- a (* b c)) (+ a (* (neg b) c))])
 ; Safe Distributiviity
 (define-ruleset* distributivity-fp-safe
                  (arithmetic simplify fp-safe sound)
@@ -239,33 +264,6 @@
                  #:type ([a real] [b real])
                  [flip-+ (+ a b) (/ (- (* a a) (* b b)) (- a b))]
                  [flip-- (- a b) (/ (- (* a a) (* b b)) (+ a b))])
-
-; Specialized numerical functions
-; TODO: These are technically rules over impls
-;
-; (define-ruleset* special-numerical-reduce
-;                  (numerics simplify)
-;                  #:type ([x real] [y real] [z real])
-;                  [log1p-expm1 (log1p (expm1 x)) x]
-;                  [hypot-1-def (sqrt (+ 1 (* y y))) (hypot 1 y)]
-;                  [fmm-def (- (* x y) z) (fma x y (neg z))]
-;                  [fmm-undef (fma x y (neg z)) (- (* x y) z)])
-
-; (define-ruleset* special-numerical-expand
-;                  (numerics)
-;                  #:type ([x real] [y real])
-;                  [log1p-expm1-u x (log1p (expm1 x))]
-;                  [expm1-log1p-u x (expm1 (log1p x))])
-
-; (define-ruleset* numerics-papers
-;                  (numerics)
-;                  #:type ([a real] [b real] [c real] [d real])
-;                  ;  "Further Analysis of Kahan's Algorithm for
-;                  ;   the Accurate Computation of 2x2 Determinants"
-;                  ;  Jeannerod et al., Mathematics of Computation, 2013
-;                  ;
-;                  ;  a * b - c * d  ===> fma(a, b, -(d * c)) + fma(-d, c, d * c)
-;                  [prod-diff (- (* a b) (* c d)) (+ (fma a b (neg (* d c))) (fma (neg d) c (* d c)))])
 
 ; Difference of cubes
 (define-ruleset*

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -163,7 +163,7 @@
                  [associate-/r/ (/ a (/ b c)) (* (/ a b) c)]
                  [associate-/l/ (/ (/ b c) a) (/ b (* c a))]
                  [associate-/l* (/ (* b c) a) (* b (/ c a))])
-                 
+
 ; Identity
 (define-ruleset* id-reduce
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -378,7 +378,8 @@
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
                  [cube-mult (pow x 3) (* x (* x x))]
-                 )
+                 [cube-prod-rev (* (pow x 3) (pow y 3)) (pow (* x y) 3)]
+                 [cube-div-rev (/ (pow x 3) (pow y 3)) (pow (/ x y) 3)])
 
 (define-ruleset* cubes-transform
                  (arithmetic sound)
@@ -391,10 +392,7 @@
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
 
-(define-ruleset* cubes-transform-rev
-                 (arithmetic sound)
-                 #:type ([x real] [y real])
-                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
+
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -541,11 +541,6 @@
                  [diff-log (- (log a) (log b)) (log (/ a b))]
                  [neg-log (neg (log a)) (log (/ 1 a))])
 
-(define-ruleset* log2-factor
-                 (exponents sound)
-                 #:type ([x real])
-                 [log2-expand (log2 x) (/ (log x) (log 2))]
-                 [log2-expand-rev (/ (log x) (log 2)) (log x 2)])
 
 ; Trigonometry
 (define-ruleset* trig-reduce-fp-sound
@@ -887,7 +882,6 @@
 (define-ruleset* ahtrig-expand-rev
                  (hyperbolic)
                  #:type ([x real])
-                 [asinh-2-rev (* 2 (asinh x)) (acosh (+ (* 2 (* x x)) 1))]
                  [acosh-2-rev (* 2 (acosh x)) (acosh (- (* 2 (* x x)) 1))])
 
 ;; Sound because it's about soundness over real numbers

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
+                 )
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
@@ -378,8 +378,7 @@
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
                  [cube-mult (pow x 3) (* x (* x x))]
-                 [cube-prod-rev (* (pow x 3) (pow y 3)) (pow (* x y) 3)]
-                 [cube-div-rev (/ (pow x 3) (pow y 3)) (pow (/ x y) 3)])
+                 )
 
 (define-ruleset* cubes-transform
                  (arithmetic sound)
@@ -391,10 +390,7 @@
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
-(define-ruleset* cubes-transform-rev
-                 (arithmetic sound)
-                 #:type ([x real] [y real])
-                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
+
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)
@@ -437,9 +433,13 @@
                  [exp-cbrt (exp (/ a 3)) (cbrt (exp a))]
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
-
-
-
+(define-ruleset* exp-factor-rev
+                 (exponents simplify sound)
+                 #:type ([a real] [b real])
+                 [exp-cbrt-rev (cbrt (exp a)) (exp (/ a 3))]
+                 [exp-lft-cube-rev (pow (exp a) 3) (exp (* a 3))]
+                 [exp-sqrt-rev (sqrt (exp a)) (exp (/ a 2))]
+                 [exp-lft-sqr-rev (* (exp a) (exp a)) (exp (* a 2))])
 ; Powers
 (define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -545,7 +545,7 @@
 
 (define-ruleset* log2-factor
                  (exponents sound)
-                 #:type ([a real] [b real])
+                 #:type ([x real])
                  [log2-expand (log2 x) (/ (log x) (log 2))]
                  [log2-expand-rev (/ (log x) (log 2)) (log x 2)])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -441,7 +441,6 @@
 (define-ruleset* exp-factor-rev
                  (exponents simplify sound)
                  #:type ([a real] [b real])
-                 [exp-cbrt-rev (cbrt (exp a)) (exp (/ a 3))]
                  [exp-lft-cube-rev (pow (exp a) 3) (exp (* a 3))]
                  [exp-sqrt-rev (sqrt (exp a)) (exp (/ a 2))]
                  [exp-lft-sqr-rev (* (exp a) (exp a)) (exp (* a 2))])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 )
+                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
@@ -390,7 +390,10 @@
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
-
+(define-ruleset* cubes-transform-rev
+                 (arithmetic sound)
+                 #:type ([x real] [y real])
+                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -541,7 +541,6 @@
                  [diff-log (- (log a) (log b)) (log (/ a b))]
                  [neg-log (neg (log a)) (log (/ 1 a))])
 
-
 ; Trigonometry
 (define-ruleset* trig-reduce-fp-sound
                  (trigonometry simplify fp-safe sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -713,6 +713,7 @@
 
 (define-ruleset* trig-expand-sound2-rev
                  (trigonometry sound)
+                 #:type ([x real] [y real])
                  [diff-cos-rev (* -2 (* (sin (/ (- x y) 2)) (sin (/ (+ x y) 2)))) (- (cos x) (cos y))]
                  [diff-sin-rev (* 2 (* (sin (/ (- x y) 2)) (cos (/ (+ x y) 2)))) (- (sin x) (sin y))]
                  [diff-atan-rev (atan2 (- x y) (+ 1 (* x y))) (- (atan x) (atan y))]

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
+                 )
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
@@ -390,6 +390,11 @@
                  [cbrt-undiv (/ (cbrt x) (cbrt y)) (cbrt (/ x y))]
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
+
+(define-ruleset* cubes-transform-rev
+                 (arithmetic sound)
+                 #:type ([x real] [y real])
+                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)
@@ -432,6 +437,8 @@
                  [exp-cbrt (exp (/ a 3)) (cbrt (exp a))]
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
+
+
 
 ; Powers
 (define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -391,6 +391,10 @@
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
 
+(define-ruleset* cubes-transform-rev
+                 (arithmetic sound)
+                 #:type ([x real] [y real])
+                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -430,7 +430,7 @@
                  [pow-base-0 (pow 0 a) 0])
 
 (define-ruleset* pow-transform-fp-safe
-                 (exponents fp-safe sound)
+                 (exponents sound)
                  #:type ([a real])
                  [inv-pow (/ 1 a) (pow a -1)])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -228,14 +228,14 @@
 (define-ruleset* cancel-sign-fp-safe
                  (arithmetic simplify fp-safe sound)
                  #:type ([a real] [b real] [c real])
-                 [cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
-                 [cancel-sub-sign (+ a (* (neg b) c)) (- a (* b c))])
+                 [fp-cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
+                 [fp-cancel-sub-sign (+ a (* (neg b) c)) (- a (* b c))])
 
 (define-ruleset* cancel-sign-fp-safe-rev
                  (arithmetic simplify fp-safe sound)
                  #:type ([a real] [b real] [c real])
-                 [cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
-                 [cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
+                 [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
+                 [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
 ; Difference of squares
 (define-ruleset* difference-of-squares-canonicalize

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 )
+                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -370,7 +370,7 @@
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
                  [cube-neg (pow (neg x) 3) (neg (pow x 3))]
-                 )
+                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
@@ -390,9 +390,6 @@
                  [cbrt-undiv (/ (cbrt x) (cbrt y)) (cbrt (/ x y))]
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
-
-
-
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -378,7 +378,8 @@
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
                  [cube-mult (pow x 3) (* x (* x x))]
-                 )
+                 [cube-prod-rev (* (pow x 3) (pow y 3)) (pow (* x y) 3)]
+                 [cube-div-rev (/ (pow x 3) (pow y 3)) (pow (/ x y) 3)])
 
 (define-ruleset* cubes-transform
                  (arithmetic sound)
@@ -389,11 +390,6 @@
                  [cbrt-undiv (/ (cbrt x) (cbrt y)) (cbrt (/ x y))]
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
-
-(define-ruleset* cubes-transform-rev
-                 (arithmetic sound)
-                 #:type ([x real] [y real])
-                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)
@@ -436,8 +432,6 @@
                  [exp-cbrt (exp (/ a 3)) (cbrt (exp a))]
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
-
-
 
 ; Powers
 (define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -136,10 +136,9 @@
      (define-ruleset* name groups #:type () [rname input output] ...)]
     [(define-ruleset* name groups #:type ([var type] ...) [rname input output] ...)
      (register-ruleset*! 'name 'groups `((var . type) ...) '((rname input output) ...))]))
-
 ; Commutativity
 (define-ruleset* commutativity
-                 (arithmetic simplify sound)
+                 (arithmetic simplify fp-safe sound)
                  #:type ([a real] [b real])
                  [+-commutative (+ a b) (+ b a)]
                  [*-commutative (* a b) (* b a)])
@@ -162,12 +161,17 @@
                  [associate-*l/ (* (/ a b) c) (/ (* a c) b)]
                  [associate-/r* (/ a (* b c)) (/ (/ a b) c)]
                  [associate-/r/ (/ a (/ b c)) (* (/ a b) c)]
-                 [associate-/l/ (/ (/ b c) a) (/ b (* a c))]
+                 [associate-/l/ (/ (/ b c) a) (/ b (* c a))]
                  [associate-/l* (/ (* b c) a) (* b (/ c a))])
 
 ; Counting
 (define-ruleset* counting (arithmetic simplify sound) #:type ([x real]) [count-2 (+ x x) (* 2 x)])
 
+(define-ruleset* counting-rev
+                 (arithmetic simplify sound)
+                 #:type ([x real])
+                 [2-split 2 (+ 1 1)]
+                 [count-2-rev (* 2 x) (+ x x)])
 ; Distributivity
 (define-ruleset* distributivity
                  (arithmetic simplify sound)
@@ -179,7 +183,12 @@
                  [distribute-rgt-out (+ (* b a) (* c a)) (* a (+ b c))]
                  [distribute-rgt-out-- (- (* b a) (* c a)) (* a (- b c))]
                  [distribute-lft1-in (+ (* b a) a) (* (+ b 1) a)]
-                 [distribute-rgt1-in (+ a (* c a)) (* (+ c 1) a)]
+                 [distribute-rgt1-in (+ a (* c a)) (* (+ c 1) a)])
+
+; Safe Distributiviity
+(define-ruleset* distributivity-fp-safe
+                 (arithmetic simplify fp-safe sound)
+                 #:type ([a real] [b real])
                  [distribute-lft-neg-in (neg (* a b)) (* (neg a) b)]
                  [distribute-rgt-neg-in (neg (* a b)) (* a (neg b))]
                  [distribute-lft-neg-out (* (neg a) b) (neg (* a b))]
@@ -191,11 +200,17 @@
                  [distribute-neg-frac (neg (/ a b)) (/ (neg a) b)]
                  [distribute-neg-frac2 (neg (/ a b)) (/ a (neg b))])
 
-(define-ruleset* cancel-sign
-                 (arithmetic simplify sound)
+(define-ruleset* cancel-sign-fp-safe
+                 (arithmetic simplify fp-safe sound)
                  #:type ([a real] [b real] [c real])
                  [cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
-                 [cancel-sign-sub-inv (- a (* b c)) (+ a (* (neg b) c))])
+                 [cancel-sub-sign (+ a (* (neg b) c)) (- a (* b c))])
+
+(define-ruleset* cancel-sign-fp-safe-rev
+                 (arithmetic simplify fp-safe sound)
+                 #:type ([a real] [b real] [c real])
+                 [cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
+                 [cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
 ; Difference of squares
 (define-ruleset* difference-of-squares-canonicalize
@@ -208,6 +223,12 @@
                  [difference-of-sqr--1 (+ (* a a) -1) (* (+ a 1) (- a 1))]
                  [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))])
 
+(define-ruleset* difference-of-squares-canonicalize-rev
+                 (polynomials simplify sound)
+                 #:type ([a real] [b real])
+                 [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
+                 [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
+                 [difference-of-squares-rev (* (+ a b) (- a b)) (- (* a a) (* b b))])
 (define-ruleset* sqr-pow-expand
                  (polynomials)
                  #:type ([a real] [b real])
@@ -219,48 +240,32 @@
                  [flip-+ (+ a b) (/ (- (* a a) (* b b)) (- a b))]
                  [flip-- (- a b) (/ (- (* a a) (* b b)) (+ a b))])
 
-; Identity
-(define-ruleset* id-reduce
-                 (arithmetic simplify sound)
-                 #:type ([a real])
-                 [remove-double-div (/ 1 (/ 1 a)) a]
-                 [rgt-mult-inverse (* a (/ 1 a)) 1]
-                 [lft-mult-inverse (* (/ 1 a) a) 1]
-                 [+-inverses (- a a) 0]
-                 [div0 (/ 0 a) 0]
-                 [mul0-lft (* 0 a) 0]
-                 [mul0-rgt (* a 0) 0]
-                 [*-inverses (/ a a) 1]
-                 [+-lft-identity (+ 0 a) a]
-                 [+-rgt-identity (+ a 0) a]
-                 [--rgt-identity (- a 0) a]
-                 [sub0-neg (- 0 a) (neg a)]
-                 [remove-double-neg (neg (neg a)) a]
-                 [*-lft-identity (* 1 a) a]
-                 [*-rgt-identity (* a 1) a]
-                 [/-rgt-identity (/ a 1) a]
-                 [mul-1-neg (* -1 a) (neg a)])
+; Specialized numerical functions
+; TODO: These are technically rules over impls
+;
+; (define-ruleset* special-numerical-reduce
+;                  (numerics simplify)
+;                  #:type ([x real] [y real] [z real])
+;                  [log1p-expm1 (log1p (expm1 x)) x]
+;                  [hypot-1-def (sqrt (+ 1 (* y y))) (hypot 1 y)]
+;                  [fmm-def (- (* x y) z) (fma x y (neg z))]
+;                  [fmm-undef (fma x y (neg z)) (- (* x y) z)])
 
-(define-ruleset* nan-transform
-                 (arithmetic simplify sound)
-                 #:type ([a real] [b real])
-                 [sub-neg (- a b) (+ a (neg b))]
-                 [unsub-neg (+ a (neg b)) (- a b)]
-                 [neg-sub0 (neg b) (- 0 b)]
-                 [neg-mul-1 (neg a) (* -1 a)])
+; (define-ruleset* special-numerical-expand
+;                  (numerics)
+;                  #:type ([x real] [y real])
+;                  [log1p-expm1-u x (log1p (expm1 x))]
+;                  [expm1-log1p-u x (expm1 (log1p x))])
 
-(define-ruleset* id-transform-safe
-                 (arithmetic sound)
-                 #:type ([a real] [b real])
-                 [div-inv (/ a b) (* a (/ 1 b))]
-                 [un-div-inv (* a (/ 1 b)) (/ a b)])
-
-(define-ruleset* id-transform-clear-num
-                 (arithmetic)
-                 #:type ([a real] [b real])
-                 [clear-num (/ a b) (/ 1 (/ b a))])
-
-(define-ruleset* id-transform (arithmetic sound) #:type ([a real]) [*-un-lft-identity a (* 1 a)])
+; (define-ruleset* numerics-papers
+;                  (numerics)
+;                  #:type ([a real] [b real] [c real] [d real])
+;                  ;  "Further Analysis of Kahan's Algorithm for
+;                  ;   the Accurate Computation of 2x2 Determinants"
+;                  ;  Jeannerod et al., Mathematics of Computation, 2013
+;                  ;
+;                  ;  a * b - c * d  ===> fma(a, b, -(d * c)) + fma(-d, c, d * c)
+;                  [prod-diff (- (* a b) (* c d)) (+ (fma a b (neg (* d c))) (fma (neg d) c (* d c)))])
 
 ; Difference of cubes
 (define-ruleset*
@@ -272,12 +277,25 @@
  [flip3-+ (+ a b) (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
  [flip3-- (- a b) (/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b))))])
 
+(define-ruleset*
+ difference-of-cubes-rev
+ (polynomials sound)
+ #:type ([a real] [b real])
+ [difference-cubes-rev (* (+ (* a a) (+ (* b b) (* a b))) (- a b)) (- (pow a 3) (pow b 3))]
+ [sum-cubes-rev (* (+ (* a a) (- (* b b) (* a b))) (+ a b)) (+ (pow a 3) (pow b 3))])
+
 ; Dealing with fractions
 (define-ruleset* fractions-distribute
                  (fractions simplify sound)
                  #:type ([a real] [b real] [c real] [d real])
                  [div-sub (/ (- a b) c) (- (/ a c) (/ b c))]
-                 [times-frac (/ (* a b) (* c d)) (* (/ a c) (/ b d))])
+                 [times-frac (/ (* a b) (* c d)) (* (/ a c) (/ b d))]
+                 [div-add (/ (+ a b) c) (+ (/ a c) (/ b c))])
+
+(define-ruleset* fractions-distribute-rev
+                 (fractions simplify sound)
+                 #:type ([a real] [b real] [c real] [d real])
+                 [div-add-rev (+ (/ a c) (/ b c)) (/ (+ a b) c)])
 
 (define-ruleset* fractions-transform
                  (fractions sound)
@@ -288,21 +306,33 @@
                  [frac-times (* (/ a b) (/ c d)) (/ (* a c) (* b d))]
                  [frac-2neg (/ a b) (/ (neg a) (neg b))])
 
+(define-ruleset* fractions-transform-rev
+                 (fractions sound)
+                 #:type ([a real] [b real] [c real] [d real])
+                 [frac-2neg-rev (/ (neg a) (neg b)) (/ a b)])
+
 ; Square root
 (define-ruleset* squares-reduce
                  (arithmetic simplify sound)
                  #:type ([x real])
                  [rem-square-sqrt (* (sqrt x) (sqrt x)) x]
-                 [rem-sqrt-square (sqrt (* x x)) (fabs x)])
+                 [rem-sqrt-square (sqrt (* x x)) (fabs x)]
+                 [rem-sqrt-square-rev (fabs x) (sqrt (* x x))])
 
 (define-ruleset* squares-reduce-fp-sound
-                 (arithmetic simplify sound)
+                 (arithmetic simplify fp-safe sound)
                  #:type ([x real])
                  [sqr-neg (* (neg x) (neg x)) (* x x)]
                  [sqr-abs (* (fabs x) (fabs x)) (* x x)])
 
+(define-ruleset* squares-reduce-fp-sound-rev
+                 (arithmetic simplify fp-safe sound)
+                 #:type ([x real])
+                 [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
+                 [sqr-neg-rev (* x x) (* (neg x) (neg x))])
+
 (define-ruleset* fabs-reduce
-                 (arithmetic simplify sound)
+                 (arithmetic simplify fp-safe sound)
                  #:type ([x real] [a real] [b real])
                  [fabs-fabs (fabs (fabs x)) (fabs x)]
                  [fabs-sub (fabs (- a b)) (fabs (- b a))]
@@ -312,7 +342,7 @@
                  [fabs-div (fabs (/ a b)) (/ (fabs a) (fabs b))])
 
 (define-ruleset* fabs-expand
-                 (arithmetic sound)
+                 (arithmetic fp-safe sound)
                  #:type ([x real] [a real] [b real])
                  [neg-fabs (fabs x) (fabs (neg x))]
                  [mul-fabs (* (fabs a) (fabs b)) (fabs (* a b))]
@@ -341,14 +371,17 @@
                  [rem-cbrt-cube (cbrt (pow x 3)) x]
                  [rem-3cbrt-lft (* (* (cbrt x) (cbrt x)) (cbrt x)) x]
                  [rem-3cbrt-rft (* (cbrt x) (* (cbrt x) (cbrt x))) x]
-                 [cube-neg (pow (neg x) 3) (neg (pow x 3))])
+                 [cube-neg (pow (neg x) 3) (neg (pow x 3))]
+                 [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
 
 (define-ruleset* cubes-distribute
                  (arithmetic simplify sound)
                  #:type ([x real] [y real])
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
-                 [cube-mult (pow x 3) (* x (* x x))])
+                 [cube-mult (pow x 3) (* x (* x x))]
+                 [cube-prod-rev (* (pow x 3) (pow y 3)) (pow (* x y) 3)]
+                 [cube-div-rev (/ (pow x 3) (pow y 3)) (pow (/ x y) 3)])
 
 (define-ruleset* cubes-transform
                  (arithmetic sound)
@@ -359,6 +392,11 @@
                  [cbrt-undiv (/ (cbrt x) (cbrt y)) (cbrt (/ x y))]
                  [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
+
+(define-ruleset* cubes-transform-rev
+                 (arithmetic sound)
+                 #:type ([x real] [y real])
+                 [add-cbrt-cube-rev (cbrt (* (* x x) x)) x])
 
 (define-ruleset* cubes-canonicalize
                  (arithmetic simplify sound)
@@ -377,7 +415,7 @@
                  [rem-log-exp (log (exp x)) x])
 
 (define-ruleset* exp-constants
-                 (exponents simplify sound)
+                 (exponents simplify fp-safe sound)
                  [exp-0 (exp 0) 1]
                  [exp-1-e (exp 1) (E)]
                  [1-exp 1 (exp 0)]
@@ -402,16 +440,29 @@
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
 
-; Powers
-(define-ruleset* pow-reduce
+(define-ruleset* exp-factor-rev
                  (exponents simplify sound)
+                 #:type ([a real] [b real])
+                 [exp-cbrt-rev (cbrt (exp a)) (exp (/ a 3))]
+                 [exp-lft-cube-rev (pow (exp a) 3) (exp (* a 3))]
+                 [exp-sqrt-rev (sqrt (exp a)) (exp (/ a 2))]
+                 [exp-lft-sqr-rev (* (exp a) (exp a)) (exp (* a 2))])
+
+; Powers
+(define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])
+
+(define-ruleset* pow-reduce-fp-safe
+                 (exponents simplify fp-safe sound)
                  #:type ([a real])
-                 [unpow-1 (pow a -1) (/ 1 a)]
-                 [unpow1 (pow a 1) a]
+                 [unpow1 (pow a 1) a])
+
+(define-ruleset* pow-reduce-fp-safe-nan
+                 (exponents simplify fp-safe-nan sound)
+                 #:type ([a real])
                  [unpow0 (pow a 0) 1]
                  [pow-base-1 (pow 1 a) 1])
 
-(define-ruleset* pow-expand (exponents sound) #:type ([a real]) [pow1 a (pow a 1)])
+(define-ruleset* pow-expand-fp-safe (exponents fp-safe sound) #:type ([a real]) [pow1 a (pow a 1)])
 
 (define-ruleset* pow-canonicalize
                  (exponents simplify sound)
@@ -422,6 +473,11 @@
                  [unpow3 (pow a 3) (* (* a a) a)]
                  [unpow1/3 (pow a 1/3) (cbrt a)]
                  [pow-plus (* (pow a b) a) (pow a (+ b 1))])
+
+(define-ruleset* pow-canonicalize-rev
+                 (exponents simplify sound)
+                 #:type ([a real] [b real])
+                 [pow-plus-rev (pow a (+ b 1)) (* (pow a b) a)])
 
 (define-ruleset* pow-transform-sound
                  (exponents sound)
@@ -449,8 +505,16 @@
                  [pow-pow (pow (pow a b) c) (pow a (* b c))]
                  [pow-unpow (pow a (* b c)) (pow (pow a b) c)]
                  [unpow-prod-up (pow a (+ b c)) (* (pow a b) (pow a c))]
-                 [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a))]
-                 [pow-base-0 (pow 0 a) 0]
+                 [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a))])
+
+(define-ruleset* pow-transform-fp-safe-nan
+                 (exponents simplify fp-safe-nan sound)
+                 #:type ([a real])
+                 [pow-base-0 (pow 0 a) 0])
+
+(define-ruleset* pow-transform-fp-safe
+                 (exponents fp-safe sound)
+                 #:type ([a real])
                  [inv-pow (/ 1 a) (pow a -1)])
 
 (define-ruleset* log-distribute-sound
@@ -467,6 +531,11 @@
                  [log-div (log (/ a b)) (- (log a) (log b))]
                  [log-pow (log (pow a b)) (* b (log a))])
 
+(define-ruleset* log-distribute-rev
+                 (exponents)
+                 #:type ([a real] [b real])
+                 [log-pow-rev (* b (log a)) (log (pow a b))])
+
 (define-ruleset* log-factor
                  (exponents sound)
                  #:type ([a real] [b real])
@@ -474,19 +543,40 @@
                  [diff-log (- (log a) (log b)) (log (/ a b))]
                  [neg-log (neg (log a)) (log (/ 1 a))])
 
+(define-ruleset* log2-factor
+                 (exponents sound)
+                 #:type ([a real] [b real])
+                 [log2-expand (log2 x) (/ (log x) (log 2))]
+                 [log2-expand-rev (/ (log x) (log 2)) (log x 2)])
+
 ; Trigonometry
 (define-ruleset* trig-reduce-fp-sound
-                 (trigonometry simplify sound)
+                 (trigonometry simplify fp-safe sound)
                  [sin-0 (sin 0) 0]
                  [cos-0 (cos 0) 1]
                  [tan-0 (tan 0) 0])
 
 (define-ruleset* trig-reduce-fp-sound-nan
-                 (trigonometry simplify sound)
+                 (trigonometry simplify fp-safe-nan sound)
                  #:type ([x real])
                  [sin-neg (sin (neg x)) (neg (sin x))]
                  [cos-neg (cos (neg x)) (cos x)]
                  [tan-neg (tan (neg x)) (neg (tan x))])
+
+(define-ruleset* trig-reduce-fp-sound-nan-rev
+                 (trigonometry simplify fp-safe-nan sound)
+                 #:type ([x real])
+                 [cos-neg-rev (cos x) (cos (neg x))]
+                 [sin-neg-rev (neg (sin x)) (sin (neg x))]
+                 [tan-neg-rev (neg (tan x)) (tan (neg x))])
+
+(define-ruleset* trig-expand-fp-safe
+                 (trignometry fp-safe sound)
+                 #:type ([x real])
+                 [sqr-sin-b (* (sin x) (sin x)) (- 1 (* (cos x) (cos x)))]
+                 [sqr-cos-b (* (cos x) (cos x)) (- 1 (* (sin x) (sin x)))]
+                 [sqr-cos-b-rev (- 1 (* (sin x) (sin x))) (* (cos x) (cos x))]
+                 [sqr-sin-b-rev (- 1 (* (cos x) (cos x))) (* (sin x) (sin x))])
 
 (define-ruleset*
  trig-inverses
@@ -499,6 +589,14 @@
  [asin-sin (asin (sin x)) (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2))]
  [acos-cos (acos (cos x)) (fabs (remainder x (* 2 (PI))))])
 
+(define-ruleset*
+ trig-inverses-rev
+ (trigonometry sound)
+ #:type ([x real])
+ [acos-cos-rev (fabs (remainder x (* 2 (PI)))) (acos (cos x))]
+ [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))]
+ [atan-tan-rev (remainder x (PI)) (atan (tan x))])
+
 (define-ruleset* trig-inverses-simplified
                  (trigonometry)
                  #:type ([x real])
@@ -506,7 +604,7 @@
                  [asin-sin-s (asin (sin x)) x]
                  [acos-cos-s (acos (cos x)) x])
 
-(define-ruleset* trig-reduce-sound
+(define-ruleset* trig-reduce-expressions
                  (trigonometry simplify sound)
                  #:type ([a real] [b real] [x real])
                  [cos-sin-sum (+ (* (cos a) (cos a)) (* (sin a) (sin a))) 1]
@@ -542,16 +640,35 @@
                  [hang-p-tan (/ (+ (sin a) (sin b)) (+ (cos a) (cos b))) (tan (/ (+ a b) 2))]
                  [hang-m-tan (/ (- (sin a) (sin b)) (+ (cos a) (cos b))) (tan (/ (- a b) 2))])
 
+(define-ruleset* trig-reduce-expressions-rev
+                 (trigonometry simplify sound)
+                 #:type ([a real] [b real] [x real])
+                 [1-sub-sin-rev (* (cos a) (cos a)) (- 1 (* (sin a) (sin a)))]
+                 [hang-m0-tan-rev (tan (/ (neg a) 2)) (/ (- 1 (cos a)) (neg (sin a)))]
+                 [hang-p0-tan-rev (tan (/ a 2)) (/ (- 1 (cos a)) (sin a))]
+                 [hang-0m-tan-rev (tan (/ (neg a) 2)) (/ (neg (sin a)) (+ 1 (cos a)))]
+                 [hang-0p-tan-rev (tan (/ a 2)) (/ (sin a) (+ 1 (cos a)))]
+                 [tan-+PI-rev (tan x) (tan (+ x (PI)))]
+                 [cos-+PI/2-rev (neg (sin x)) (cos (+ x (/ (PI) 2)))]
+                 [sin-+PI/2-rev (cos x) (sin (+ x (/ (PI) 2)))]
+                 [sin-+PI-rev (neg (sin x)) (sin (+ x (PI)))]
+                 [cos-+PI-rev (neg (cos x)) (cos (+ x (PI)))])
+
 (define-ruleset* trig-reduce
                  (trigonometry)
                  #:type ([a real] [b real] [x real])
-                 [tan-+PI/2 (tan (+ x (/ (PI) 2))) (/ -1 (tan x))])
+                 [neg-tan-+PI/2 (tan (+ x (/ (PI) 2))) (/ -1 (tan x))]
+                 [tan-+PI/2 (tan (+ (neg x) (/ (PI) 2))) (/ 1 (tan x))])
+
+(define-ruleset* trig-reduce-rev
+                 (trigonometry)
+                 #:type ([a real] [b real] [x real])
+                 [neg-tan-+PI/2-rev (/ -1 (tan x)) (tan (+ x (/ (PI) 2)))]
+                 [tan-+PI/2-rev (/ 1 (tan x)) (tan (+ (neg x) (/ (PI) 2)))])
 
 (define-ruleset* trig-expand-sound
                  (trigonometry sound)
                  #:type ([x real] [y real] [a real] [b real])
-                 [sqr-sin-b (* (sin x) (sin x)) (- 1 (* (cos x) (cos x)))]
-                 [sqr-cos-b (* (cos x) (cos x)) (- 1 (* (sin x) (sin x)))]
                  [sin-sum (sin (+ x y)) (+ (* (sin x) (cos y)) (* (cos x) (sin y)))]
                  [cos-sum (cos (+ x y)) (- (* (cos x) (cos y)) (* (sin x) (sin y)))]
                  [tan-sum (tan (+ x y)) (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y))))]
@@ -565,6 +682,15 @@
                  [cos-3 (cos (* 3 x)) (- (* 4 (pow (cos x) 3)) (* 3 (cos x)))]
                  [2-cos (- (* (cos x) (cos x)) (* (sin x) (sin x))) (cos (* 2 x))]
                  [3-cos (- (* 4 (pow (cos x) 3)) (* 3 (cos x))) (cos (* 3 x))])
+
+(define-ruleset* trig-expand-sound-rev
+                 (trigonometry sound)
+                 #:type ([x real] [y real] [a real] [b real])
+                 [cos-diff-rev (+ (* (cos x) (cos y)) (* (sin x) (sin y))) (cos (- x y))]
+                 [sin-diff-rev (- (* (sin x) (cos y)) (* (cos x) (sin y))) (sin (- x y))]
+                 [sin-sum-rev (+ (* (sin x) (cos y)) (* (cos x) (sin y))) (sin (+ x y))]
+                 [tan-sum-rev (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y)))) (tan (+ x y))]
+                 [cos-sum-rev (- (* (cos x) (cos y)) (* (sin x) (sin y))) (cos (+ x y))])
 
 (define-ruleset* trig-expand-sound2
                  (trigonometry sound)
@@ -584,6 +710,20 @@
                  [quot-tan (/ (sin x) (cos x)) (tan x)]
                  [tan-2 (tan (* 2 x)) (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x))))]
                  [2-tan (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x)))) (tan (* 2 x))])
+
+(define-ruleset* trig-expand-sound2-rev
+                 (trigonometry sound)
+                 [diff-cos-rev (* -2 (* (sin (/ (- x y) 2)) (sin (/ (+ x y) 2)))) (- (cos x) (cos y))]
+                 [diff-sin-rev (* 2 (* (sin (/ (- x y) 2)) (cos (/ (+ x y) 2)))) (- (sin x) (sin y))]
+                 [diff-atan-rev (atan2 (- x y) (+ 1 (* x y))) (- (atan x) (atan y))]
+                 [sum-sin-rev (* 2 (* (sin (/ (+ x y) 2)) (cos (/ (- x y) 2)))) (+ (sin x) (sin y))]
+                 [sum-cos-rev (* 2 (* (cos (/ (+ x y) 2)) (cos (/ (- x y) 2)))) (+ (cos x) (cos y))]
+                 [sum-atan-rev (atan2 (+ x y) (- 1 (* x y))) (+ (atan x) (atan y))]
+                 [sqr-cos-a-rev (+ 1/2 (* 1/2 (cos (* 2 x)))) (* (cos x) (cos x))]
+                 [sqr-sin-a-rev (- 1/2 (* 1/2 (cos (* 2 x)))) (* (sin x) (sin x))]
+                 [cos-mult-rev (/ (+ (cos (+ x y)) (cos (- x y))) 2) (* (cos x) (cos y))]
+                 [sin-mult-rev (/ (- (cos (- x y)) (cos (+ x y))) 2) (* (sin x) (sin y))]
+                 [sin-cos-mult-rev (/ (+ (sin (- x y)) (sin (+ x y))) 2) (* (sin x) (cos y))])
 
 (define-ruleset* trig-expand
                  (trigonometry)
@@ -606,6 +746,21 @@
                  [acos-neg (acos (neg x)) (- (PI) (acos x))]
                  [atan-neg (atan (neg x)) (neg (atan x))])
 
+(define-ruleset* atrig-expand-rev
+                 (trigonometry sound)
+                 #:type ([x real])
+                 [acos-asin-rev (- (/ (PI) 2) (asin x)) (acos x)]
+                 [asin-acos-rev (- (/ (PI) 2) (acos x)) (asin x)]
+                 [asin-neg-rev (neg (asin x)) (asin (neg x))]
+                 [atan-neg-rev (neg (atan x)) (atan (neg x))]
+                 [acos-neg-rev (- (PI) (acos x)) (acos (neg x))]
+                 [cos-atan-rev (/ 1 (sqrt (+ 1 (* x x)))) (cos (atan x))]
+                 [tan-acos-rev (/ (sqrt (- 1 (* x x))) x) (tan (acos x))]
+                 [tan-asin-rev (/ x (sqrt (- 1 (* x x)))) (tan (asin x))]
+                 [cos-asin-rev (sqrt (- 1 (* x x))) (cos (asin x))]
+                 [sin-atan-rev (/ x (sqrt (+ 1 (* x x)))) (sin (atan x))]
+                 [sin-acos-rev (sqrt (- 1 (* x x))) (sin (acos x))])
+
 ; Hyperbolic trigonometric functions
 (define-ruleset* htrig-reduce
                  (hyperbolic simplify sound)
@@ -619,16 +774,22 @@
                  [sinh-+-cosh (+ (cosh x) (sinh x)) (exp x)]
                  [sinh---cosh (- (cosh x) (sinh x)) (exp (neg x))])
 
+(define-ruleset* htrig-reduce-rev
+                 (hyperbolic simplify sound)
+                 #:type ([x real])
+                 [tanh-def-b-rev (/ (- (exp (* 2 x)) 1) (+ (exp (* 2 x)) 1)) (tanh x)]
+                 [tanh-def-c-rev (/ (- 1 (exp (* -2 x))) (+ 1 (exp (* -2 x)))) (tanh x)]
+                 [sinh-def-rev (/ (- (exp x) (exp (neg x))) 2) (sinh x)]
+                 [cosh-def-rev (/ (+ (exp x) (exp (neg x))) 2) (cosh x)]
+                 [sinh-+-cosh-rev (exp x) (+ (cosh x) (sinh x))]
+                 [sinh---cosh-rev (exp (neg x)) (- (cosh x) (sinh x))])
+
 (define-ruleset* htrig-expand-sound
                  (hyperbolic sound)
                  #:type ([x real] [y real])
-                 [sinh-neg (sinh (neg x)) (neg (sinh x))]
-                 [sinh-0 (sinh 0) 0]
-                 [cosh-neg (cosh (neg x)) (cosh x)]
-                 [cosh-0 (cosh 0) 1]
                  [sinh-undef (- (exp x) (exp (neg x))) (* 2 (sinh x))]
                  [cosh-undef (+ (exp x) (exp (neg x))) (* 2 (cosh x))]
-                 [tanh-undef (/ (- (exp x) (exp (neg x))) (+ (exp x) (exp (neg x)))) (tanh x)]
+                 [tanh-undef (/ (- (exp x) (exp (neg x))) (+ (exp x) (exp (neg x)))) (tanh x)] ;
                  [cosh-sum (cosh (+ x y)) (+ (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
                  [cosh-diff (cosh (- x y)) (- (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
                  [cosh-2 (cosh (* 2 x)) (+ (* (sinh x) (sinh x)) (* (cosh x) (cosh x)))]
@@ -645,10 +806,49 @@
                  [diff-cosh (- (cosh x) (cosh y)) (* 2 (* (sinh (/ (+ x y) 2)) (sinh (/ (- x y) 2))))]
                  [tanh-sum (tanh (+ x y)) (/ (+ (tanh x) (tanh y)) (+ 1 (* (tanh x) (tanh y))))])
 
+(define-ruleset*
+ htrig-expand-sound-rev
+ (hyperbolic sound)
+ #:type ([x real] [y real])
+ [sinh-undef-rev (* 2 (sinh x)) (- (exp x) (exp (neg x)))]
+ [cosh-undef-rev (* 2 (cosh x)) (+ (exp x) (exp (neg x)))]
+ [diff-cosh-rev (* 2 (* (sinh (/ (+ x y) 2)) (sinh (/ (- x y) 2)))) (- (cosh x) (cosh y))]
+ [diff-sinh-rev (* 2 (* (cosh (/ (+ x y) 2)) (sinh (/ (- x y) 2)))) (- (sinh x) (sinh y))]
+ [cosh-diff-rev (- (* (cosh x) (cosh y)) (* (sinh x) (sinh y))) (cosh (- x y))]
+ [sinh-diff-rev (- (* (sinh x) (cosh y)) (* (cosh x) (sinh y))) (sinh (- x y))]
+ [tanh-1/2-rev (/ (sinh x) (+ (cosh x) 1)) (tanh (/ x 2))]
+ [tanh-2-rev (/ (* 2 (tanh x)) (+ 1 (* (tanh x) (tanh x)))) (tanh (* 2 x))]
+ [sinh-1/2-rev (/ (sinh x) (sqrt (* 2 (+ (cosh x) 1)))) (sinh (/ x 2))]
+ [cosh-1/2-rev (sqrt (/ (+ (cosh x) 1) 2)) (cosh (/ x 2))]
+ [sinh-2-rev (* 2 (* (sinh x) (cosh x))) (sinh (* 2 x))]
+ [cosh-2-rev (+ (* (sinh x) (sinh x)) (* (cosh x) (cosh x))) (cosh (* 2 x))]
+ [sinh-sum-rev (+ (* (sinh x) (cosh y)) (* (cosh x) (sinh y))) (sinh (+ x y))]
+ [tanh-sum-rev (/ (+ (tanh x) (tanh y)) (+ 1 (* (tanh x) (tanh y)))) (tanh (+ x y))]
+ [cosh-sum-rev (+ (* (cosh x) (cosh y)) (* (sinh x) (sinh y))) (cosh (+ x y))]
+ [sum-cosh-rev (* 2 (* (cosh (/ (+ x y) 2)) (cosh (/ (- x y) 2)))) (+ (cosh x) (cosh y))]
+ [sum-sinh-rev (* 2 (* (sinh (/ (+ x y) 2)) (cosh (/ (- x y) 2)))) (+ (sinh x) (sinh y))])
+
 (define-ruleset* htrig-expand
                  (hyperbolic)
                  #:type ([x real] [y real])
-                 [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x))])
+                 [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x))]
+                 [tanh-1/2*-rev (/ (- (cosh x) 1) (sinh x)) (tanh (/ x 2))])
+
+(define-ruleset* htrig-expand-fp-safe
+                 (hyperbolic fp-safe sound)
+                 #:type ([x real])
+                 [sinh-neg (sinh (neg x)) (neg (sinh x))]
+                 [sinh-0 (sinh 0) 0]
+                 [sinh-0-rev 0 (sinh 0)]
+                 [cosh-neg (cosh (neg x)) (cosh x)]
+                 [cosh-0 (cosh 0) 1]
+                 [cosh-0-rev 1 (cosh 0)])
+
+(define-ruleset* htrig-expand-fp-safe-rev
+                 (hyperbolic fp-safe sound)
+                 #:type ([x real])
+                 [cosh-neg-rev (cosh x) (cosh (neg x))]
+                 [sinh-neg-rev (neg (sinh x)) (sinh (neg x))])
 
 (define-ruleset* ahtrig-expand-sound
                  (hyperbolic sound)
@@ -666,40 +866,30 @@
                  [tanh-acosh (tanh (acosh x)) (/ (sqrt (- (* x x) 1)) x)]
                  [tanh-atanh (tanh (atanh x)) x])
 
+(define-ruleset* ahtrig-expand-sound-simplify-rev
+                 (hyperbolic sound)
+                 #:type ([x real])
+                 [asinh-def-rev (log (+ x (sqrt (+ (* x x) 1)))) (asinh x)]
+                 [atanh-def-rev (/ (log (/ (+ 1 x) (- 1 x))) 2) (atanh x)]
+                 [acosh-def-rev (log (+ x (sqrt (- (* x x) 1)))) (acosh x)]
+                 [sinh-acosh-rev (sqrt (- (* x x) 1)) (sinh (acosh x))]
+                 [tanh-asinh-rev (/ x (sqrt (+ 1 (* x x)))) (tanh (asinh x))]
+                 [cosh-asinh-rev (sqrt (+ (* x x) 1)) (cosh (asinh x))]
+                 [sinh-atanh-rev (/ x (sqrt (- 1 (* x x)))) (sinh (atanh x))]
+                 [tanh-acosh-rev (/ (sqrt (- (* x x) 1)) x) (tanh (acosh x))]
+                 [cosh-atanh-rev (/ 1 (sqrt (- 1 (* x x)))) (cosh (atanh x))])
+
 (define-ruleset* ahtrig-expand
                  (hyperbolic)
                  #:type ([x real])
                  [asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x))]
                  [acosh-2 (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x))])
 
-(define-ruleset* erf-rules (special simplify) #:type ([x real]) [erf-odd (erf (neg x)) (neg (erf x))])
-
-; Specialized numerical functions
-; TODO: These are technically rules over impls
-;
-; (define-ruleset* special-numerical-reduce
-;                  (numerics simplify)
-;                  #:type ([x real] [y real] [z real])
-;                  [log1p-expm1 (log1p (expm1 x)) x]
-;                  [hypot-1-def (sqrt (+ 1 (* y y))) (hypot 1 y)]
-;                  [fmm-def (- (* x y) z) (fma x y (neg z))]
-;                  [fmm-undef (fma x y (neg z)) (- (* x y) z)])
-
-; (define-ruleset* special-numerical-expand
-;                  (numerics)
-;                  #:type ([x real] [y real])
-;                  [log1p-expm1-u x (log1p (expm1 x))]
-;                  [expm1-log1p-u x (expm1 (log1p x))])
-
-; (define-ruleset* numerics-papers
-;                  (numerics)
-;                  #:type ([a real] [b real] [c real] [d real])
-;                  ;  "Further Analysis of Kahan's Algorithm for
-;                  ;   the Accurate Computation of 2x2 Determinants"
-;                  ;  Jeannerod et al., Mathematics of Computation, 2013
-;                  ;
-;                  ;  a * b - c * d  ===> fma(a, b, -(d * c)) + fma(-d, c, d * c)
-;                  [prod-diff (- (* a b) (* c d)) (+ (fma a b (neg (* d c))) (fma (neg d) c (* d c)))])
+(define-ruleset* ahtrig-expand-rev
+                 (hyperbolic)
+                 #:type ([x real])
+                 [asinh-2-rev (* 2 (asinh x)) (acosh (+ (* 2 (* x x)) 1))]
+                 [acosh-2-rev (* 2 (acosh x)) (acosh (- (* 2 (* x x)) 1))])
 
 ;; Sound because it's about soundness over real numbers
 (define-ruleset* compare-reduce


### PR DESCRIPTION
Description:
This PR introduces the implementation of all inverse rules. The inverse rules allow the system to reverse operations in order to achieve a few goals. One goal is by adding inverse rules we hope to prove more expressions equal to one another so that they are in the same eclass. We also hope to further improve results as the quality of our rulesets improve with missing rules. There were previous issues due to a bug with using the default cost model but after that was fixed we now have better results

