### PR TITLE
Further clean up `localize.rkt`

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -229,14 +229,13 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test against conditionals expressions
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'invalid', '0.0')
-// TODO a bug in Rival
-// checkLocalErrorNode(localError7.tree, [0, 0],
-//   '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
+  '<=', '0.0', 'true', 'true', 'equal', '0.0')
+checkLocalErrorNode(localError7.tree, [0, 0],
+  '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
+  '0.05', '0.0', '0.05', '0.05', 'equal', '0.0')
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0')
+  'fma', '0.0', '-inf.0', '-inf.0', '+inf.0', '0.0')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -280,7 +280,6 @@
                [repr (in-list reprs-list)]
                [var (in-list exact-var-names)])
       (cond
-        [(number? spec) 0] ; HACK: unclear why numbers don't work in Rival but :shrug:
         [(equal? (representation-type repr) 'bool) 0] ; HACK: just ignore differences in booleans
         [else `(fabs (- ,spec ,var))])))
   (define delta-fn (eval-progs-real compare-specs (map (const delta-ctx) compare-specs)))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -266,10 +266,8 @@
 
   ;; And the absolute difference between the two
   (define exact-var-names
-    (for/list ([expr (in-list exprs-list)]
-               [n (in-naturals)])
-      ;; HACK: should generate unique, not just rare, symbol
-      (string->symbol (format "-exact-for-~a" n))))
+    (for/list ([expr (in-list exprs-list)])
+      (gensym 'exact)))
   (define delta-ctx
     (context (append (context-vars ctx) exact-var-names)
              (get-representation 'binary64)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -340,10 +340,12 @@
 
 (define (expr->json-tree expr ctx decorate)
   (define (make-json-tree subexpr)
-    (define args (if (list? subexpr) (rest subexpr) '()))
+    (define args
+      (if (list? subexpr)
+          (rest subexpr)
+          '()))
     (hash-union
-     (hasheq 'e (~s (expr-fpcore-operator subexpr ctx))
-             'children (map make-json-tree args))
+     (hasheq 'e (~s (expr-fpcore-operator subexpr ctx)) 'children (map make-json-tree args))
      (decorate subexpr)))
   (make-json-tree expr))
 

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -277,9 +277,9 @@
                [expr (in-list exprs-list)]
                [repr (in-list reprs-list)]
                [var (in-list exact-var-names)])
-      (cond
-        [(equal? (representation-type repr) 'bool) 0] ; HACK: just ignore differences in booleans
-        [else `(fabs (- ,spec ,var))])))
+      (match (representation-type repr)
+        ['bool 0] ; We can't subtract booleans so ignore them
+        ['real `(fabs (- ,spec ,var))])))
   (define delta-fn (eval-progs-real compare-specs (map (const delta-ctx) compare-specs)))
 
   (define expr-batch (progs->batch exprs-list))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require math/bigfloat)
+(require math/bigfloat
+         racket/hash)
 (require "../syntax/sugar.rkt"
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
@@ -334,14 +335,14 @@
   (match (prog->fpcore expr ctx)
     [(list '! props ... (list op args ...)) op]
     [(list op args ...) op]
-    [(? number? c) (exact->exact c)]
+    [(? number? c) (exact->inexact c)]
     [(? variable? c) c]))
 
 (define (expr->json-tree expr ctx decorate)
   (define (make-json-tree subexpr)
     (define args (if (list? subexpr) (rest subexpr) '()))
     (hash-union
-     (hasheq 'e (~s (expr-fpcore-operator subexpr))
+     (hasheq 'e (~s (expr-fpcore-operator subexpr ctx))
              'children (map make-json-tree args))
      (decorate subexpr)))
   (make-json-tree expr))
@@ -388,4 +389,4 @@
               [(? nan?) "invalid"]
               [_ abs-error])))
 
-  (make-json-tree expr ctx expr-data))
+  (expr->json-tree expr ctx expr-data))


### PR DESCRIPTION
This PR removes some hacks obsoleted by herbie-fp/rival#83 and also cleans up the code in various minor ways.