### PR TITLE
Add and check for CORS headers.

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -229,14 +229,14 @@ const localError7 = await (await fetchAndCheckRSPHeaders("/api/localerror", {
 })).json()
 // Test against conditionals expressions
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'invalid', '0.0')
+  '<=', '0.0', 'true', 'true', 'equal', '0.0')
 // TODO a bug in Rival
 // checkLocalErrorNode(localError7.tree, [0, 0],
 //   '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
+  '0.05', '0.0', '0.05', '0.05', 'equal', '0.0')
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0')
+  'fma', '0.0', '-inf.0', '-inf.0', '+inf.0', '0.0')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -345,7 +345,7 @@ async function fetchAndCheckRSPHeaders(endpoint, body) {
     console.log("Missing CORS header on rsp:")
     console.log(rsp)
   }
-  assert.equal(header, '* always')
+  assert.equal(header, '*')
   return rsp
 }
 

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -95,7 +95,8 @@
                #"OK"
                (current-seconds)
                #"text"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
+               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out)
                  (with-handlers ([exn:fail? (page-error-handler result-hash page out)])
                    (make-page page out result-hash (*demo-output*) #f))))]
@@ -114,7 +115,8 @@
                #"OK"
                (current-seconds)
                #"text"
-               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count)))))
+               (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out) (write-datafile out info)))]))
 
 (define url (compose add-prefix url*))
@@ -254,14 +256,14 @@
                   #"Bad Request"
                   (current-seconds)
                   APPLICATION/JSON-MIME-TYPE
-                  (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                  (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                   (λ (op) (write-json resp op)))
         (response 200
                   #"OK"
                   (current-seconds)
                   APPLICATION/JSON-MIME-TYPE
                   (filter values
-                          (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
+                          (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always"))
                                 (and (hash-has-key? resp 'job)
                                      (header #"X-Herbie-Job-ID"
                                              (string->bytes/utf-8 (hash-ref resp 'job))))))
@@ -284,7 +286,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out) `()))]
     [job-result
      (response 201
@@ -293,7 +295,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out) (write-json job-result out)))]))
 
 (define (improve-common req body go-back)
@@ -344,7 +346,8 @@
                     #"text/plain"
                     (list (header #"Location" (string->bytes/utf-8 (url check-status job-id)))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id)))
+                          (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
+                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                     '()))
    (url main)))
 
@@ -360,7 +363,7 @@
                                    (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                           (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                     '())]
     [timeline
      (response 202
@@ -368,7 +371,7 @@
                (current-seconds)
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out)
                  (when timeline
                    (for ([entry timeline])
@@ -380,7 +383,7 @@
                  (current-seconds)
                  #"text/plain"
                  (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                  '()))
 
 (define (improve req)
@@ -401,7 +404,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out) `()))]
     [job-result
      (response 201
@@ -410,7 +413,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                (λ (out) (write-json (hash-ref job-result 'timeline) out)))]))
 
 ; Macro for defining async and sync versions of an endpoint.

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -96,7 +96,7 @@
                (current-seconds)
                #"text"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out)
                  (with-handlers ([exn:fail? (page-error-handler result-hash page out)])
                    (make-page page out result-hash (*demo-output*) #f))))]
@@ -116,7 +116,7 @@
                (current-seconds)
                #"text"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out) (write-datafile out info)))]))
 
 (define url (compose add-prefix url*))
@@ -256,7 +256,7 @@
                   #"Bad Request"
                   (current-seconds)
                   APPLICATION/JSON-MIME-TYPE
-                  (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                  (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                   (λ (op) (write-json resp op)))
         (response
          200
@@ -264,7 +264,7 @@
          (current-seconds)
          APPLICATION/JSON-MIME-TYPE
          (filter values
-                 (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always"))
+                 (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
                        (and (hash-has-key? resp 'job)
                             (header #"X-Herbie-Job-ID" (string->bytes/utf-8 (hash-ref resp 'job))))))
          (λ (op) (write-json resp op))))))
@@ -286,7 +286,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out) `()))]
     [job-result
      (response 201
@@ -295,7 +295,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out) (write-json job-result out)))]))
 
 (define (improve-common req body go-back)
@@ -347,7 +347,7 @@
                     (list (header #"Location" (string->bytes/utf-8 (url check-status job-id)))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                           (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                     '()))
    (url main)))
 
@@ -363,7 +363,7 @@
                                    (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))))
                           (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                           (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                          (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                     '())]
     [timeline
      (response 202
@@ -371,7 +371,7 @@
                (current-seconds)
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out)
                  (when timeline
                    (for ([entry timeline])
@@ -383,7 +383,7 @@
                  (current-seconds)
                  #"text/plain"
                  (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
-                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                       (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                  '()))
 
 (define (improve req)
@@ -404,7 +404,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out) `()))]
     [job-result
      (response 201
@@ -413,7 +413,7 @@
                #"text/plain"
                (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))
                      (header #"X-Herbie-Job-ID" (string->bytes/utf-8 job-id))
-                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
+                     (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                (λ (out) (write-json (hash-ref job-result 'timeline) out)))]))
 
 ; Macro for defining async and sync versions of an endpoint.

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -258,16 +258,16 @@
                   APPLICATION/JSON-MIME-TYPE
                   (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*")))
                   (λ (op) (write-json resp op)))
-        (response
-         200
-         #"OK"
-         (current-seconds)
-         APPLICATION/JSON-MIME-TYPE
-         (filter values
-                 (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
-                       (and (hash-has-key? resp 'job)
-                            (header #"X-Herbie-Job-ID" (string->bytes/utf-8 (hash-ref resp 'job))))))
-         (λ (op) (write-json resp op))))))
+        (response 200
+                  #"OK"
+                  (current-seconds)
+                  APPLICATION/JSON-MIME-TYPE
+                  (filter values
+                          (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "*"))
+                                (and (hash-has-key? resp 'job)
+                                     (header #"X-Herbie-Job-ID"
+                                             (string->bytes/utf-8 (hash-ref resp 'job))))))
+                  (λ (op) (write-json resp op))))))
 
 (define (response/error title body)
   (response/full 400

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -258,16 +258,16 @@
                   APPLICATION/JSON-MIME-TYPE
                   (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always")))
                   (λ (op) (write-json resp op)))
-        (response 200
-                  #"OK"
-                  (current-seconds)
-                  APPLICATION/JSON-MIME-TYPE
-                  (filter values
-                          (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always"))
-                                (and (hash-has-key? resp 'job)
-                                     (header #"X-Herbie-Job-ID"
-                                             (string->bytes/utf-8 (hash-ref resp 'job))))))
-                  (λ (op) (write-json resp op))))))
+        (response
+         200
+         #"OK"
+         (current-seconds)
+         APPLICATION/JSON-MIME-TYPE
+         (filter values
+                 (list (header #"Access-Control-Allow-Origin" (string->bytes/utf-8 "* always"))
+                       (and (hash-has-key? resp 'job)
+                            (header #"X-Herbie-Job-ID" (string->bytes/utf-8 (hash-ref resp 'job))))))
+         (λ (op) (write-json resp op))))))
 
 (define (response/error title body)
   (response/full 400


### PR DESCRIPTION
This PR updates the endpoints of the `demo` server to use the `Access-Control-Allow-Origin * always` header in an effort to close issues #1048 and [Odyssey 183](https://github.com/herbie-fp/odyssey/issues/183)