### PR TITLE
`/analyze-hashed` endpoint using cached pcontext

### DIFF
--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -107,6 +107,17 @@ const errorsBody = {
     ], 0.12711304680349078]]
   })
 }
+
+console.log(sample['job'])
+const errors_hashed = await (await fetch(makeEndpoint("/api/analyze-hashed"), {
+  method: 'POST', body: JSON.stringify({
+    formula: FPCoreFormula2, sample_hash: sample['job']
+  })
+})).json()
+console.log(errors_hashed)
+assertIdAndPath(errors_hashed)
+assert.deepEqual(errors_hashed.points !== "CACHE MISS", true)
+
 const errors = await (await fetch(makeEndpoint("/api/analyze"), errorsBody)).json()
 assertIdAndPath(errors)
 assert.deepEqual(errors.points, [[[14.97651307489794], "2.3"]])

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -108,14 +108,13 @@ const errorsBody = {
   })
 }
 
-console.log(sample['job'])
 const errors_hashed = await (await fetch(makeEndpoint("/api/analyze-hashed"), {
   method: 'POST', body: JSON.stringify({
     formula: FPCoreFormula2, sample_hash: sample['job']
   })
 })).json()
-console.log(errors_hashed)
 assertIdAndPath(errors_hashed)
+assert.equal(Object.values(errors_hashed).length, 4);
 assert.deepEqual(errors_hashed.points !== "CACHE MISS", true)
 
 const errors = await (await fetch(makeEndpoint("/api/analyze"), errorsBody)).json()
@@ -239,14 +238,13 @@ const localError7 = await (await fetch(makeEndpoint("/api/localerror"), {
 })).json()
 // Test against conditionals expressions
 checkLocalErrorNode(localError7.tree, [0],
-  '<=', '0.0', 'true', 'true', 'invalid', '0.0')
-// TODO a bug in Rival
-// checkLocalErrorNode(localError7.tree, [0, 0],
-//   '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
+  '<=', '0.0', 'true', 'true', 'equal', '0.0')
+checkLocalErrorNode(localError7.tree, [0, 0],
+  '-', '61.2', '0.0', '1.1180339887498948e-135', '1.1180339887498948e-135', '61.16647760559045')
 checkLocalErrorNode(localError7.tree, [0, 1],
-  '0.05', '0.0', '0.05', '0.05', 'invalid', '0.0')
+  '0.05', '0.0', '0.05', '0.05', 'equal', '0.0')
 checkLocalErrorNode(localError7.tree, [2],
-  'fma', '0.0', '-inf.0', '-inf.0', 'invalid', '0.0')
+  'fma', '0.0', '-inf.0', '-inf.0', '+inf.0', '0.0')
 
 /// root: The root node of the local error tree.
 /// path: the path to get to the node you want to test.

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -58,7 +58,7 @@ assert.equal(checkStatus.statusText, 'Job complete')
 
 // up endpoint
 const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
-assert.equal('Down', up.statusText) // Herbie runs single thread on CI.
+assert.equal('Up', up.statusText) // Herbie runs single thread on CI.
 
 // Sample endpoint
 const sampleBody = {

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -58,8 +58,7 @@ assert.equal(checkStatus.statusText, 'Job complete')
 
 // up endpoint
 const up = await fetch(makeEndpoint("/up"), { method: 'GET' })
-assert.equal('Up', up.statusText)
-// TODO how do I test down state?
+assert.equal('Down', up.statusText) // Herbie runs single thread on CI.
 
 // Sample endpoint
 const sampleBody = {

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -66,7 +66,7 @@
                   [("api" "localerror") #:method "post" local-error-endpoint]
                   [("api" "alternatives") #:method "post" alternatives-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
-                  [("api" "mathjs") #:method "post" ->mathjs-endpoint]
+                  [("api" "mathjs") #:method "post" mathjs-endpoint]
                   [("api" "translate") #:method "post" translate-endpoint]
                   [("api" "start" "improve") #:method "post" improve-start]
                   [("api" "start" "sample") #:method "post" start-sample-endpoint]
@@ -325,7 +325,7 @@
                      #:pcontext #f
                      #:profile? #f
                      #:timeline-disabled? #f))
-       (body command))]
+       (body (_create-job0 'herbie-command command)))]
     [_
      (response/error "Demo Error"
                      `(p "You didn't specify a formula (or you specified several). "
@@ -336,8 +336,8 @@
 (define (improve-start req)
   (improve-common
    req
-   (λ (command)
-     (define job-id (start-job command))
+   (λ (action)
+     (define job-id (start-job action))
      (response/full 201
                     #"Job started"
                     (current-seconds)
@@ -385,8 +385,8 @@
 
 (define (improve req)
   (improve-common req
-                  (λ (command)
-                    (define job-id (start-job command))
+                  (λ (action)
+                    (define job-id (start-job action))
                     (wait-for-job job-id)
                     (redirect-to (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))
                                  see-other))
@@ -433,7 +433,9 @@
  ([sample-endpoint start-sample-endpoint] post-data)
  (define test (get-test post-data))
  (define seed (parse-seed post-data))
- (create-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+ (_create-job0
+  'herbie-command
+  (create-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t)))
 
 ; (create-job 'explanations (get-test post-data) #:seed (get-seed post-data) #:pcontext (get-pcontext post-data) #:profile? #f #:timeline-disabled? #t)
 (define (get-test post-data)
@@ -451,70 +453,72 @@
   (json->pcontext sample (test-context test)))
 
 (define-endpoint ([explanations-endpoint start-explanations-endpoint] post-data)
-                 (create-job 'explanations
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'explanations
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define-endpoint ([analyze-endpoint start-analyze-endpoint] post-data)
-                 (create-job 'errors
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'errors
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 ;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
 (define-endpoint ([exacts-endpoint start-exacts-endpoint] post-data)
-                 (create-job 'exacts
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'exacts
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define-endpoint ([calculate-endpoint start-calculate-endpoint] post-data)
-                 (create-job 'evaluate
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'evaluate
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define-endpoint ([local-error-endpoint start-local-error-endpoint] post-data)
-                 (create-job 'local-error
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'local-error
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define-endpoint ([alternatives-endpoint start-alternatives-endpoint] post-data)
-                 (create-job 'alternatives
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t))
+                 (_create-job0 'herbie-command
+                               (create-job 'alternatives
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (get-pcontext post-data)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define-endpoint ([cost-endpoint start-cost-endpoint] post-data)
-                 (create-job 'cost
-                             (get-test post-data)
-                             #:seed #f
-                             #:pcontext #f
-                             #:profile? #f
-                             #:timeline-disabled? #f))
+                 (_create-job0 'herbie-command
+                               (create-job 'cost
+                                           (get-test post-data)
+                                           #:seed #f
+                                           #:pcontext #f
+                                           #:profile? #f
+                                           #:timeline-disabled? #f)))
 
-(define ->mathjs-endpoint
-  (post-with-json-response (lambda (post-data)
-                             (define formula
-                               (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
-                             (eprintf "Converting to Math.js ~a..." formula)
-
-                             (define result (core->mathjs (syntax->datum formula)))
-                             (hasheq 'mathjs result))))
+(define-endpoint ([mathjs-endpoint start-mathjs-endpoint] post-data)
+                 (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
+                 (_create-job0 'translate (translate-job formula 'mathjs)))
 
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -516,35 +516,17 @@
                                            #:profile? #f
                                            #:timeline-disabled? #f)))
 
+;; TODO combine mathjs and translate endpoints and unify json output
 (define-endpoint ([mathjs-endpoint start-mathjs-endpoint] post-data)
                  (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
                  (_create-job0 'translate (translate-job formula 'mathjs)))
 
-(define translate-endpoint
-  (post-with-json-response (lambda (post-data)
-                             ; FPCore formula and target language
-                             (define formula (read (open-input-string (hash-ref post-data 'formula))))
-                             (eprintf "Translating formula: ~a...\n" formula)
-                             (define target-lang (hash-ref post-data 'language))
-                             (eprintf "Target language: ~a...\n" target-lang)
-                             ; Select the appropriate conversion function
-                             (define lang-converter
-                               (case target-lang
-                                 [("python") core->python]
-                                 [("c") core->c]
-                                 [("fortran") core->fortran]
-                                 [("java") core->java]
-                                 [("julia") core->julia]
-                                 [("matlab") core->matlab]
-                                 [("wls") core->wls]
-                                 [("tex") core->tex]
-                                 [("js") core->js]
-                                 [else (error "Unsupported target language:" target-lang)]))
-
-                             ; convert the expression
-                             (define converted (lang-converter formula "expr"))
-                             (eprintf "Converted Expression: \n~a...\n" converted)
-                             (hasheq 'result converted 'language target-lang))))
+(define-endpoint ([translate-endpoint start-translate-endpoint] post-data)
+                 (define formula (read (open-input-string (hash-ref post-data 'formula))))
+                 (eprintf "Translating formula: ~a...\n" formula)
+                 (define target-lang (hash-ref post-data 'language))
+                 (eprintf "Target language: ~a...\n" target-lang)
+                 (_create-job0 'translate (translate-job formula target-lang)))
 
 (define (run-demo #:quiet [quiet? #f]
                   #:threads [threads #f]

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -518,14 +518,12 @@
 
 ;; TODO combine mathjs and translate endpoints and unify json output
 (define-endpoint ([mathjs-endpoint start-mathjs-endpoint] post-data)
-                 (define formula (read-syntax 'web (open-input-string (hash-ref post-data 'formula))))
-                 (_create-job0 'translate (translate-job formula 'mathjs)))
+                 (_create-job0 'translate (translate-job (hash-ref post-data 'formula) 'mathjs)))
 
 (define-endpoint ([translate-endpoint start-translate-endpoint] post-data)
-                 (define formula (read (open-input-string (hash-ref post-data 'formula))))
-                 (eprintf "Translating formula: ~a...\n" formula)
                  (define target-lang (hash-ref post-data 'language))
-                 (eprintf "Target language: ~a...\n" target-lang)
+                 (define formula (hash-ref post-data 'formula))
+                 (eprintf "Translating ~a to language: ~a...\n" formula target-lang)
                  (_create-job0 'translate (translate-job formula target-lang)))
 
 (define (run-demo #:quiet [quiet? #f]

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -61,6 +61,7 @@
                   [("api" "sample") #:method "post" sample-endpoint]
                   [("api" "explanations") #:method "post" explanations-endpoint]
                   [("api" "analyze") #:method "post" analyze-endpoint]
+                  [("api" "analyze-hashed") #:method "post" analyze-hashed-endpoint]
                   [("api" "exacts") #:method "post" exacts-endpoint]
                   [("api" "calculate") #:method "post" calculate-endpoint]
                   [("api" "localerror") #:method "post" local-error-endpoint]
@@ -446,6 +447,15 @@
 ; The name get-seed is taken.
 (define (parse-seed post-data)
   (hash-ref post-data 'seed #f))
+
+(define-endpoint ([analyze-hashed-endpoint start-analyze-hashed-endpoint] post-data)
+                 (_create-job0 'herbie-command
+                               (create-job 'errors-hash
+                                           (get-test post-data)
+                                           #:seed (parse-seed post-data)
+                                           #:pcontext (hash-ref post-data 'sample_hash)
+                                           #:profile? #f
+                                           #:timeline-disabled? #t)))
 
 (define (get-pcontext post-data)
   (define test (get-test post-data))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -51,9 +51,9 @@
 (struct herbie-command (command test seed pcontext profile? timeline-disabled?) #:prefab)
 
 ; action-type 'herbie-command or 'translation
-(struct server-action (action-type associated-type))
+(struct server-action (action-type associated-type) #:prefab)
 
-(struct translate-job (fpcore to-language))
+(struct translate-job (fpcore to-language) #:prefab)
 
 (define (_create-job0 server-action-type associated-type)
   (match server-action-type
@@ -101,6 +101,7 @@
   (log "Getting result for job: ~a.\n" job-id)
   (manager-ask 'result job-id))
 
+; Invlaid to ask for timeline of a 'translate job.
 (define (get-timeline-for job-id)
   (log "Getting timeline for job: ~a.\n" job-id)
   (manager-ask 'timeline job-id))
@@ -125,29 +126,17 @@
     ['herbie-command
      (define command (server-action-associated-type action))
      (define job-id (compute-job-id command))
-     (manager-tell 'start manager command job-id)
-     (log "Job ~a, Qed up for program: ~a\n" job-id (test-name (herbie-command-test command)))
+     (manager-tell 'start manager action job-id)
+     (log "Qed up herbie command ~a for job ~a program: ~a\n"
+          (herbie-command-command command)
+          job-id
+          (test-name (herbie-command-test command)))
      job-id]
     ['translate
      (match-define (translate-job fpcore to-language) (server-action-associated-type action))
-     (eprintf "Converting ~a to ~a.\n" fpcore to-language)
+     (log "Qed up translation Job: ~a to ~a.\n" fpcore to-language)
      (define job-hash (compute-job-id (translate-job fpcore to-language)))
-     (define result
-       (match to-language
-         ['mathjs (hasheq 'mathjs (core->mathjs (syntax->datum fpcore)))]
-         ["python" (hasheq 'result (core->python fpcore "expr") 'language to-language)]
-         ["c" (hasheq 'result (core->c fpcore "expr") 'language to-language)]
-         ["fortran" (hasheq 'result (core->fortran fpcore "expr") 'language to-language)]
-         ["java" (hasheq 'result (core->java fpcore "expr") 'language to-language)]
-         ["julia" (hasheq 'result (core->julia fpcore "expr") 'language to-language)]
-         ["matlab" (hasheq 'result (core->matlab fpcore "expr") 'language to-language)]
-         ["wls" (hasheq 'result (core->wls fpcore "expr") 'language to-language)]
-         ["tex" (hasheq 'result (core->tex fpcore "expr") 'language to-language)]
-         ["js" (hasheq 'result (core->js fpcore "expr") 'language to-language)]
-         [_ (error "Unsupported target language:" to-language)]))
-     (eprintf "Converted Expression: \n~a...\n" result)
-     (eprintf "job-hash: ~a, ~a\n" job-hash result)
-     (hash-set! completed-translations job-hash result)
+     (manager-tell 'start manager action job-hash)
      job-hash]))
 
 (define (wait-for-job job-id)
@@ -160,8 +149,33 @@
   (if manager
       (place-channel-put manager (list* msg args))
       (match (list* msg args)
-        [(list 'start hash-false command job-id)
-         (hash-set! completed-work job-id (herbie-do-server-job command job-id))])))
+        [(list 'start hash-false action job-id)
+         (match (server-action-action-type action)
+           ['herbie-command
+            (define command (server-action-associated-type action))
+            (hash-set! completed-work job-id (herbie-do-server-job command job-id))]
+           ['translate
+            (match-define (translate-job fpcore to-language) (server-action-associated-type action))
+            (define result (do-translation->json fpcore to-language))
+            (log "Converted Expression: \n~a...\n" result)
+            (hash-set! completed-translations job-id result)])])))
+
+; Translate and return the expected Odyssey json format.
+(define (do-translation->json formula to-language)
+  (eprintf "formual: ~a\n" formula)
+  (define input (read (open-input-string formula)))
+  (match to-language
+    ['mathjs (hasheq 'mathjs (core->mathjs input))]
+    ["python" (hasheq 'result (core->python input "expr") 'language to-language)]
+    ["c" (hasheq 'result (core->c input "expr") 'language to-language)]
+    ["fortran" (hasheq 'result (core->fortran input "expr") 'language to-language)]
+    ["java" (hasheq 'result (core->java input "expr") 'language to-language)]
+    ["julia" (hasheq 'result (core->julia input "expr") 'language to-language)]
+    ["matlab" (hasheq 'result (core->matlab input "expr") 'language to-language)]
+    ["wls" (hasheq 'result (core->wls input "expr") 'language to-language)]
+    ["tex" (hasheq 'result (core->tex input "expr") 'language to-language)]
+    ["js" (hasheq 'result (core->js input "expr") 'language to-language)]
+    [_ (error "Unsupported target language:" to-language)]))
 
 (define (manager-ask msg . args)
   (log "Asking manager: ~a, ~a.\n" msg args)
@@ -170,17 +184,15 @@
       (match (list* msg args) ; public commands
         [(list 'wait hash-false job-id)
          (define result (hash-ref completed-work job-id #f))
-         ; check if the job is completed or not.
          (match result
            [#f
             (match (hash-ref completed-translations job-id #f)
-              [#f (log "Translation not found\n")]
+              [#f (log "Job ~a not complete\n" job-id)]
               [t
                (log "Done waiting for translation: ~a\n" job-id)
                t])]
            [result
             (log "Done waiting for job: ~a\n" job-id)
-            ; we have a result to send.
             result])]
         [(list 'result job-id) (hash-ref completed-work job-id #f)]
         [(list 'timeline job-id) (hash-ref completed-work job-id #f)]
@@ -208,6 +220,7 @@
       [_ (error 'compute-result "unknown command ~a" kind)]))
   out-result)
 
+;; These are split for the 'improve call.
 (define completed-work (make-hash))
 (define completed-translations (make-hash))
 
@@ -274,8 +287,6 @@
                           (parameterize ([params fresh] ...)
                             body ...))))]))
 
-(struct work-item (command id))
-
 (define (make-manager worker-count)
   (place/context*
    ch
@@ -303,25 +314,32 @@
    (for ([i (in-naturals)])
      ;  (eprintf "manager msg ~a handled\n" i)
      (match (place-channel-get ch)
-       [(list 'start self command job-id)
-        ; Check if the work has been completed already if not assign the work.
-        (if (hash-has-key? completed-work job-id)
-            (place-channel-put self (list 'send job-id (hash-ref completed-work job-id)))
-            (place-channel-put self (list 'queue self job-id command)))]
-       [(list 'queue self job-id command)
-        (set! job-queue (append job-queue (list (work-item command job-id))))
+       [(list 'start self action job-id)
+        (match (server-action-action-type action)
+          ; Check if the work has been completed already if not assign the work.
+          ['herbie-command ; Check herbie jobs
+           (if (hash-has-key? completed-work job-id)
+               (place-channel-put self (list 'send job-id (hash-ref completed-work job-id)))
+               (place-channel-put self (list 'queue self job-id action)))]
+          ['translate ; Check translations
+           (if (hash-has-key? completed-translations job-id)
+               (place-channel-put self (list 'send job-id (hash-ref completed-translations job-id)))
+               (place-channel-put self (list 'queue self job-id action)))])]
+       [(list 'queue self job-id action)
+        (log "Queuing: ~a\n" job-id)
+        (set! job-queue (append job-queue (list (list action job-id))))
         (place-channel-put self (list 'assign self))]
        [(list 'assign self)
+        (log "Assigning work\n")
         (define reassigned (make-hash))
         (for ([(wid worker) (in-hash waiting-workers)]
-              [job (in-list job-queue)])
-          (log "Starting worker [~a] on [~a].\n"
-               (work-item-id job)
-               (test-name (herbie-command-test (work-item-command job))))
+              [work (in-list job-queue)])
+          (match-define (list action job-id) work)
+          (log "Starting worker ~a\n" job-id)
           ; Check if the job is already in progress.
-          (unless (hash-has-key? current-jobs (work-item-id job))
-            (hash-set! current-jobs (work-item-id job) wid)
-            (place-channel-put worker (list 'apply self (work-item-command job) (work-item-id job)))
+          (unless (hash-has-key? current-jobs job-id)
+            (hash-set! current-jobs job-id wid)
+            (place-channel-put worker (list 'apply self action job-id))
             (hash-set! reassigned wid worker)
             (hash-set! busy-workers wid worker)))
         ; remove X many jobs from the Q and update waiting-workers
@@ -329,9 +347,11 @@
           (hash-remove! waiting-workers wid)
           (set! job-queue (cdr job-queue)))]
        ; Job is finished save work and free worker. Move work to 'send state.
-       [(list 'finished self wid job-id result)
+       [(list 'finished self wid job-id type result)
         (log "Job ~a finished, saving result.\n" job-id)
-        (hash-set! completed-work job-id result)
+        (match type
+          ['herbie-command (hash-set! completed-work job-id result)]
+          ['translate (hash-set! completed-translations job-id result)])
 
         ; move worker to waiting list
         (hash-remove! current-jobs job-id)
@@ -350,8 +370,10 @@
         (match result
           [#f
            (match (hash-ref completed-translations job-id #f)
-             [#f (eprintf "Translation not found\n")]
-             [t (place-channel-put self (list 'send job-id t))])]
+             [#f (log "Translation not found\n")]
+             [t
+              (log "Done waiting for translation job: ~a\n" job-id)
+              (place-channel-put self (list 'send job-id t))])]
           [result
            (log "Done waiting for job: ~a\n" job-id)
            ; we have a result to send.
@@ -413,23 +435,44 @@
    (define current-job-id #f)
    (for ([_ (in-naturals)])
      (match (place-channel-get ch)
-       [(list 'apply manager command job-id)
-        (set! timeline (*timeline*))
+       [(list 'apply manager action job-id)
         (set! current-job-id job-id)
-        (log "[~a] working on [~a].\n" job-id (test-name (herbie-command-test command)))
-        (thread-send worker-thread (work manager worker-id job-id command))]
-       [(list 'timeline handler)
+        (match (server-action-action-type action)
+          ['herbie-command
+           (define command (server-action-associated-type action))
+           (set! timeline (*timeline*))
+           (log "[~a] working on [~a].\n" job-id (test-name (herbie-command-test command)))
+           (thread-send worker-thread (work manager worker-id job-id action))]
+          ['translate
+           (log "[~a] translating...\n" job-id)
+           (thread-send worker-thread (work manager worker-id job-id action))])]
+       [(list 'timeline handler) ;; Ignore timelines for Translations?
         (log "Timeline requested from worker[~a] for job ~a\n" worker-id current-job-id)
         (place-channel-put handler (reverse (unbox timeline)))]))))
 
 (struct work (manager worker-id job-id job))
 
 (define (run-job job-info)
-  (match-define (work manager worker-id job-id command) job-info)
-  (log "run-job: ~a, ~a\n" worker-id job-id)
-  (define out-result (herbie-do-server-job command job-id))
-  (log "Job: ~a finished, returning work to manager\n" job-id)
-  (place-channel-put manager (list 'finished manager worker-id job-id out-result)))
+  (match-define (work manager worker-id job-id action) job-info)
+  (match (server-action-action-type action)
+    ['herbie-command
+     (define command (server-action-associated-type action))
+     (log "run-job: ~a, ~a\n" worker-id job-id)
+     (define out-result (herbie-do-server-job command job-id))
+     (log "Job: ~a finished, returning work to manager\n" job-id)
+     (place-channel-put
+      manager
+      (list 'finished manager worker-id job-id (server-action-action-type action) out-result))]
+    ['translate
+     (match-define (translate-job fpcore to-language) (server-action-associated-type action))
+     (log "Translate Job: ~a finished, returning work to manager\n" job-id)
+     (place-channel-put manager
+                        (list 'finished
+                              manager
+                              worker-id
+                              job-id
+                              (server-action-action-type action)
+                              (do-translation->json fpcore to-language)))]))
 
 (define (make-explanation-result herbie-result job-id)
   (define explanations (job-result-backend herbie-result))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -168,7 +168,7 @@
 (define (is-server-up)
   (if manager
       (not (sync/timeout 0 manager-dead-event))
-      #f))
+      #t))
 
 (define (start-job-server job-cap)
   (when job-cap

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -42,7 +42,7 @@
 (define *demo-output* (make-parameter false))
 
 ; verbose logging for debugging
-(define verbose #t) ; Maybe change to log-level and use 'verbose?
+(define verbose #f) ; Maybe change to log-levelc and use 'verbose?
 (define (log msg . args)
   (when verbose
     (apply eprintf msg args)))
@@ -212,6 +212,7 @@
       ['evaluate (make-calculate-result herbie-result job-id)]
       ['cost (make-cost-result herbie-result job-id)]
       ['errors (make-error-result herbie-result job-id)]
+      ['errors-hash (make-error-hash-result herbie-result job-id)]
       ['exacts (make-exacts-result herbie-result job-id)]
       ['improve (make-improve-result herbie-result test job-id)]
       ['local-error (make-local-error-result herbie-result job-id)]
@@ -223,6 +224,7 @@
 ;; These are split for the 'improve call.
 (define completed-work (make-hash))
 (define completed-translations (make-hash))
+(define pcontext-cache (make-hash))
 
 (define (manager-ask-with-callback msg args)
   (define-values (a b) (place-channel))
@@ -253,15 +255,33 @@
 
 (define (wrapper-run-herbie cmd job-id)
   (print-job-message (herbie-command-command cmd) job-id (test-name (herbie-command-test cmd)))
-  (define result
-    (run-herbie (herbie-command-command cmd)
-                (herbie-command-test cmd)
-                #:seed (herbie-command-seed cmd)
-                #:pcontext (herbie-command-pcontext cmd)
-                #:profile? (herbie-command-profile? cmd)
-                #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
-  (eprintf "Herbie completed job: ~a\n" job-id)
-  result)
+  (match (herbie-command-command cmd)
+    ['errors-hash
+     (define idk (hash-ref pcontext-cache (herbie-command-pcontext cmd) #f))
+     (eprintf "HERE!!! ~a\n" pcontext-cache)
+     (match idk
+       [#f (job-result 'errors-hash #f #f #f #f #f #f)]
+       [pctx
+        (define p_context (json->pcontext pctx (test-context (herbie-command-test cmd))))
+        (define result
+          (run-herbie 'exacts
+                      (herbie-command-test cmd)
+                      #:seed (herbie-command-seed cmd)
+                      #:pcontext p_context
+                      #:profile? (herbie-command-profile? cmd)
+                      #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
+        (eprintf "Herbie completed job: ~a\n" job-id)
+        result])]
+    [_
+     (define result
+       (run-herbie (herbie-command-command cmd)
+                   (herbie-command-test cmd)
+                   #:seed (herbie-command-seed cmd)
+                   #:pcontext (herbie-command-pcontext cmd)
+                   #:profile? (herbie-command-profile? cmd)
+                   #:timeline-disabled? (herbie-command-timeline-disabled? cmd)))
+     (eprintf "Herbie completed job: ~a\n" job-id)
+     result]))
 
 (define (print-job-message command job-id job-str)
   (define job-label
@@ -270,6 +290,7 @@
       ['evaluate "Evaluation"]
       ['cost "Computing"]
       ['errors "Analyze"]
+      ['errors-hash "Hashed Analyze"]
       ['exacts "Ground truth"]
       ['improve "Improve"]
       ['local-error "Local error"]
@@ -498,14 +519,9 @@
 (define (make-sample-result herbie-result test job-id)
   (define pctx (job-result-backend herbie-result))
   (define repr (context-repr (test-context test)))
-  (hasheq 'command
-          (get-command herbie-result)
-          'points
-          (pcontext->json pctx repr)
-          'job
-          job-id
-          'path
-          (make-path job-id)))
+  (define jcontext (pcontext->json pctx repr))
+  (hash-set! pcontext-cache job-id jcontext)
+  (hasheq 'command (get-command herbie-result) 'points jcontext 'job job-id 'path (make-path job-id)))
 
 (define (make-calculate-result herbie-result job-id)
   (hasheq 'command
@@ -526,6 +542,18 @@
           job-id
           'path
           (make-path job-id)))
+
+(define (make-error-hash-result herbie-result job-id)
+  (if (job-result-backend herbie-result)
+      (make-error-result herbie-result job-id)
+      (hasheq 'command
+              (get-command herbie-result)
+              'points
+              "CACHE MISS"
+              'job
+              job-id
+              'path
+              (make-path job-id))))
 
 (define (make-error-result herbie-result job-id)
   (define errs

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -153,6 +153,22 @@
          (match (server-action-action-type action)
            ['herbie-command
             (define command (server-action-associated-type action))
+            (match-define (herbie-command type test seed pcontext profile? timeline-disabled?)
+              command)
+            (match type
+              ['errors-hash
+               (when (hash-has-key? completed-work pcontext)
+                 (set! command
+                       (herbie-command 'errors
+                                       test
+                                       seed
+                                       (json->pcontext (hash-ref (hash-ref completed-work pcontext)
+                                                                 'points)
+                                                       (test-context test))
+                                       profile?
+                                       timeline-disabled?))
+                 (set! action (server-action 'herbie-command command)))]
+              [_ empty])
             (hash-set! completed-work job-id (herbie-do-server-job command job-id))]
            ['translate
             (match-define (translate-job fpcore to-language) (server-action-associated-type action))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -131,13 +131,24 @@
     ['translate
      (match-define (translate-job fpcore to-language) (server-action-associated-type action))
      (eprintf "Converting ~a to ~a.\n" fpcore to-language)
-     (match to-language
-       ['mathjs
-        (define job-hash (compute-job-id (translate-job fpcore to-language)))
-        (define result (hasheq 'mathjs (core->mathjs (syntax->datum fpcore))))
-        (eprintf "job-hash: ~a, ~a\n" job-hash result)
-        (hash-set! completed-translations job-hash result)
-        job-hash])]))
+     (define job-hash (compute-job-id (translate-job fpcore to-language)))
+     (define result
+       (match to-language
+         ['mathjs (hasheq 'mathjs (core->mathjs (syntax->datum fpcore)))]
+         ["python" (hasheq 'result (core->python fpcore "expr") 'language to-language)]
+         ["c" (hasheq 'result (core->c fpcore "expr") 'language to-language)]
+         ["fortran" (hasheq 'result (core->fortran fpcore "expr") 'language to-language)]
+         ["java" (hasheq 'result (core->java fpcore "expr") 'language to-language)]
+         ["julia" (hasheq 'result (core->julia fpcore "expr") 'language to-language)]
+         ["matlab" (hasheq 'result (core->matlab fpcore "expr") 'language to-language)]
+         ["wls" (hasheq 'result (core->wls fpcore "expr") 'language to-language)]
+         ["tex" (hasheq 'result (core->tex fpcore "expr") 'language to-language)]
+         ["js" (hasheq 'result (core->js fpcore "expr") 'language to-language)]
+         [_ (error "Unsupported target language:" to-language)]))
+     (eprintf "Converted Expression: \n~a...\n" result)
+     (eprintf "job-hash: ~a, ~a\n" job-hash result)
+     (hash-set! completed-translations job-hash result)
+     job-hash]))
 
 (define (wait-for-job job-id)
   (define finished-result (manager-ask 'wait manager job-id))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -131,14 +131,10 @@
   (if manager
       (manager-ask-with-callback msg args)
       (match (list* msg args) ; public commands
-        [(list 'wait hash-false job-id)
-         (hash-ref completed-work job-id)]
-        [(list 'result job-id)
-         (hash-ref completed-work job-id #f)]
-        [(list 'timeline job-id)
-         (hash-ref completed-work job-id #f)]
-        [(list 'check job-id)
-         (if (hash-ref completed-work job-id #f) job-id #f)]
+        [(list 'wait hash-false job-id) (hash-ref completed-work job-id)]
+        [(list 'result job-id) (hash-ref completed-work job-id #f)]
+        [(list 'timeline job-id) (hash-ref completed-work job-id #f)]
+        [(list 'check job-id) (if (hash-ref completed-work job-id #f) job-id #f)]
         [(list 'count) (list 0 0)]
         [(list 'improve)
          (for/list ([(job-id result) (in-hash completed-work)]

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -119,11 +119,50 @@
 
 (define (manager-tell msg . args)
   (log "Telling manager: ~a, ~a.\n" msg args)
-  (place-channel-put manager (list* msg args)))
+  (if manager
+      (place-channel-put manager (list* msg args))
+      (match msg
+        ['start
+         (match-define (list hash-false command job-id) args)
+         (hash-set! completed-work job-id (herbie-do-server-job command job-id))])))
 
 (define (manager-ask msg . args)
   (log "Asking manager: ~a, ~a.\n" msg args)
-  (manager-ask-with-callback msg args))
+  (if manager
+      (manager-ask-with-callback msg args)
+      (match (list* msg args) ; public commands
+        [(list 'wait hash-false job-id)
+         (hash-ref completed-work job-id)]
+        [(list 'result job-id)
+         (hash-ref completed-work job-id #f)]
+        [(list 'timeline job-id)
+         (hash-ref completed-work job-id #f)]
+        [(list 'check job-id)
+         (if (hash-ref completed-work job-id #f) job-id #f)]
+        [(list 'count) (list 0 0)]
+        [(list 'improve)
+         (for/list ([(job-id result) (in-hash completed-work)]
+                    #:when (equal? (hash-ref result 'command) "improve"))
+           (get-table-data-from-hash result (make-path job-id)))])))
+
+(define (herbie-do-server-job command job-id)
+  (define herbie-result (wrapper-run-herbie command job-id))
+  (match-define (job-result kind test status time _ _ backend) herbie-result)
+  (define out-result
+    (match kind
+      ['alternatives (make-alternatives-result herbie-result test job-id)]
+      ['evaluate (make-calculate-result herbie-result job-id)]
+      ['cost (make-cost-result herbie-result job-id)]
+      ['errors (make-error-result herbie-result job-id)]
+      ['exacts (make-exacts-result herbie-result job-id)]
+      ['improve (make-improve-result herbie-result test job-id)]
+      ['local-error (make-local-error-result herbie-result job-id)]
+      ['explanations (make-explanation-result herbie-result job-id)]
+      ['sample (make-sample-result herbie-result test job-id)]
+      [_ (error 'compute-result "unknown command ~a" kind)]))
+  out-result)
+
+(define completed-work (make-hash))
 
 (define (manager-ask-with-callback msg args)
   (define-values (a b) (place-channel))
@@ -131,14 +170,15 @@
   (place-channel-get a))
 
 (define (is-server-up)
-  (not (sync/timeout 0 manager-dead-event)))
+  (if manager
+      (not (sync/timeout 0 manager-dead-event))
+      #f))
 
 (define (start-job-server job-cap)
-  (unless job-cap
-    (set! job-cap (processor-count)))
-  (define r (make-manager job-cap))
-  (set! manager-dead-event (place-dead-evt r))
-  (set! manager r))
+  (when job-cap
+    (define r (make-manager job-cap))
+    (set! manager-dead-event (place-dead-evt r))
+    (set! manager r)))
 
 (define manager #f)
 (define manager-dead-event #f)
@@ -204,7 +244,6 @@
    (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
      (load-herbie-plugins))
    ; not sure if the above code is actaully needed.
-   (define completed-work (make-hash))
    (define busy-workers (make-hash))
    (define waiting-workers (make-hash))
    (define current-jobs (make-hash))
@@ -336,20 +375,7 @@
 (define (run-job job-info)
   (match-define (work manager worker-id job-id command) job-info)
   (log "run-job: ~a, ~a\n" worker-id job-id)
-  (define herbie-result (wrapper-run-herbie command job-id))
-  (match-define (job-result kind test status time _ _ backend) herbie-result)
-  (define out-result
-    (match kind
-      ['alternatives (make-alternatives-result herbie-result test job-id)]
-      ['evaluate (make-calculate-result herbie-result job-id)]
-      ['cost (make-cost-result herbie-result job-id)]
-      ['errors (make-error-result herbie-result job-id)]
-      ['exacts (make-exacts-result herbie-result job-id)]
-      ['improve (make-improve-result herbie-result test job-id)]
-      ['local-error (make-local-error-result herbie-result job-id)]
-      ['explanations (make-explanation-result herbie-result job-id)]
-      ['sample (make-sample-result herbie-result test job-id)]
-      [_ (error 'compute-result "unknown command ~a" kind)]))
+  (define out-result (herbie-do-server-job command job-id))
   (log "Job: ~a finished, returning work to manager\n" job-id)
   (place-channel-put manager (list 'finished manager worker-id job-id out-result)))
 


### PR DESCRIPTION
This introduces a `/analyze-hashed` endpoint for Odyssey to avoid sending the pcontext back and forth. This should fix #1048 