### PR TITLE
Use server for `improve` command.

### DIFF
--- a/src/api/improve.rkt
+++ b/src/api/improve.rkt
@@ -3,7 +3,8 @@
          "../utils/common.rkt"
          "datafile.rkt"
          "sandbox.rkt"
-         "thread-pool.rkt")
+         "thread-pool.rkt"
+         "server.rkt")
 (provide run-improve)
 
 (define (print-outputs tests results p #:seed [seed #f])
@@ -33,7 +34,15 @@
 (define (run-improve input output #:threads [threads #f])
   (define seed (get-seed))
   (define tests (load-tests input))
-  (define results (get-test-results tests #:threads threads #:seed seed #:profile #f #:dir #f))
+  (start-job-server threads)
+  (define ids
+    (for/list ([test (in-list tests)])
+      (define command
+        (create-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f))
+      (start-job command)))
+  (define results
+    (for/list ([id ids])
+      (get-table-data-from-hash (wait-for-job id) "")))
 
   (if (equal? output "-")
       (print-outputs tests results (current-output-port) #:seed seed)


### PR DESCRIPTION
This PR moves the `improve` command over to using `server.rkt` as a step towards removing `thread-pool.rkt`.