### PR TITLE
Fix for issue 1058

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -179,7 +179,7 @@
   (define test-pcontext* (preprocess-pcontext (*context*) test-pcontext preprocessing))
   (when seed
     (set-seed! seed))
-  (list alternatives test-pcontext test-pcontext*))
+  (list alternatives test-pcontext test-pcontext* preprocessing))
 
 ;; Improvement backend for generating reports
 ;; A more heavyweight version of `get-alternatives`
@@ -224,6 +224,7 @@
 
   ;; compute error/cost for output expression
   (define end-exprs (map alt-expr end-alts))
+
   (define end-train-errs (flip-lists (batch-errors end-exprs train-pcontext ctx)))
   (define end-test-errs (flip-lists (batch-errors end-exprs test-pcontext* ctx)))
   (define end-alts-data (map alt-analysis end-alts end-train-errs end-test-errs))
@@ -283,7 +284,10 @@
         (timeline-event! 'start) ; Prevents the timeline from being empty.
         (define result
           (match command
-            ['alternatives (get-alternatives test pcontext seed)]
+            ['alternatives
+             (define out (get-alternatives test pcontext seed))
+             (eprintf "~a: result: ~a\n" command (first out))
+             out]
             ['evaluate (get-calculation test pcontext)]
             ['cost (get-cost test)]
             ['errors (get-errors test pcontext)]

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -507,7 +507,6 @@
                ([analysis end])
                (match-define (alt-analysis alt train-errors test-errs) analysis)
                (values alt train-errors test-errs (alt-cost alt repr))))
-
   (define alts-histories
     (for/list ([alt end-alts])
       (render-history alt (first pcontexts) (second pcontexts) (test-context test))))
@@ -545,7 +544,8 @@
   (define vars (test-vars test))
   (define repr (test-output-repr test))
 
-  (match-define (list altns test-pcontext processed-pcontext) (job-result-backend herbie-result))
+  (match-define (list altns test-pcontext processed-pcontext preprocessing)
+    (job-result-backend herbie-result))
   (define splitpoints
     (for/list ([alt altns])
       (for/list ([var vars])
@@ -556,8 +556,14 @@
             '()))))
 
   (define fpcores
-    (for/list ([altn altns])
-      (~a (program->fpcore (alt-expr altn) (test-context test)))))
+    (for/list ([expr (map alt-expr altns)])
+      (define out (fpcore-with-preprocessing expr
+                                                 (test-context test)
+                                                 #:ident (test-identifier test)
+                                                 #:instructions preprocessing))
+      (~s  out)))
+
+  (eprintf "alts: ~a\n" fpcores)
 
   (define histories
     (for/list ([altn altns])


### PR DESCRIPTION
This PR is working on #1058.

⚠️ I gotta hit pause on this for a few days. But I have a hunch this might be a bit more complicated as I don't know if Odyssey supports Preprocessing right now. 

If you look at the Diff the the `/alternatives` route ignores preprocessing right now. I have some hacks and copied code to try and get this to work but running into the following error from the proceeding mathjs call..
```
Converting to Math.js #<syntax:web::1 "x_m = (fabs.f64 x)\n(FPCore (x_m) :precision binary64 x_m)">...Error handling request: match: no matching clause for "x_m = (fabs.f64 x)\n(FPCore (x_m) :precision binary64 x_m)"
  location...:
   src/reports/core2mathjs.rkt:155:6
  context...:
   /Users/zane/.scribe/Projects/herbie/src/reports/core2mathjs.rkt:149:0: core->mathjs
   /Users/zane/.scribe/Projects/herbie/src/api/demo.rkt:511:27
   /Users/zane/.scribe/Projects/herbie/src/api/demo.rkt:240:2
   /opt/homebrew/Cellar/minimal-racket/8.15/share/racket/collects/racket/contract/private/arrow-higher-order.rkt:375:33
   [repeats 1 more time]
   /opt/homebrew/opt/minimal-racket/share/racket/pkgs/web-server-lib/web-server/dispatchers/dispatch-servlets.rkt:63:2
   /opt/homebrew/opt/minimal-racket/share/racket/pkgs/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt:141:2
```
I'm not sure where and what the fix should be yet but I know what the problem is. 

Below is the correct view on the `demo` the Edward pointed out in the issue.

<img width="801" alt="Screenshot 2024-11-21 at 6 44 34 PM" src="https://github.com/user-attachments/assets/d4cf0f67-4933-42b8-8c22-790a6fac37d2">
