### PR TITLE
Revert change to report-page for NaN% bug.

### DIFF
--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -446,10 +446,21 @@ function buildTableContents(jsonData, otherJsonData, filterFunction) {
     return rows
 }
 
+function getMinimum(target) {
+    if (target === false) {
+        return false
+    }
+
+    return target.reduce((minA, current) => {
+        const currentA = current[1];
+        return currentA < minA ? currentA : minA;
+    }, Infinity);
+}
+
 // HACK I kinda hate this split lambda function, Zane
 function buildRow(test, other) {
     var row
-    var smallestTarget = test.target && Math.min.apply(Math, test.target)
+    var smallestTarget = getMinimum(test.target)
 
     eitherOr(test, other,
         (function () {
@@ -819,8 +830,8 @@ function makeFilterFunction() {
 
             // Diff Target Accuracy
             if (radioState == "targetAcc") {
-                var smallestBase = baseData.target && Math.min.apply(Math, baseData.target)
-                var smallestDiff = diffData.target && Math.min.apply(Math, diffData.target)
+                var smallestBase = getMinimum(baseData.target)
+                var smallestDiff = getMinimum(diffData.target)
                 
                 const t = smallestBase / baseData.bits
                 const o = smallestDiff / diffData.bits


### PR DESCRIPTION
![Screenshot 2024-11-22 at 6 38 43 PM](https://github.com/user-attachments/assets/0e612e83-1f33-4c4d-86de-d89bf2c931d1)
This PR reverts one of the changes from #1060 that resulted in the NaN% bug above.

[Current Nightly](https://nightly.cs.washington.edu/reports/herbie/1732447436:nightly:main:c2c6fd5ab9/)
[After change](https://nightly.cs.washington.edu/reports/herbie/1732553559:nightly:zane-revert-report-js:d153e0945a/)