### PR TITLE
Ongoing cleanup PR, merged intermittently

### DIFF
--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -43,16 +43,14 @@
 
 ; Note, this message should not be reached.
 (define fallback-message
-  (string-append
-   "Error: unable to load the 'egg-math' library\n"
-   "Please file a bug at https://github.com/herbie-fp/herbie/issues\n"))
+  (string-append "Error: unable to load the 'egg-math' library\n"
+                 "Please file a bug at https://github.com/herbie-fp/herbie/issues\n"))
 
 ; Note, refering to ARM as Apple Silicon to match Racket download page.
 (define rosetta-message
-  (string-append
-   "Error: You are running the 'x86' version of Racket via 'Rosetta' emulation.\n"
-   "  Please use the 'Apple Silicon' version of Racket instead.\n"
-   "You can install it from https://download.racket-lang.org\n"))
+  (string-append "Error: You are running the 'x86' version of Racket via 'Rosetta' emulation.\n"
+                 "  Please use the 'Apple Silicon' version of Racket instead.\n"
+                 "You can install it from https://download.racket-lang.org\n"))
 
 (define (handle-eggmath-import-failure)
   (define error-message (if (running-on-rosetta?) rosetta-message fallback-message))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -44,13 +44,13 @@
 ; Note, this message should not be reached.
 (define fallback-message
   (string-append "Error: unable to load the 'egg-math' library\n"
-                 "Please file a bug at https://github.com/herbie-fp/herbie/issues\n"))
+                 "Please file a bug at https://github.com/herbie-fp/herbie/issues"))
 
 ; Note, refering to ARM as Apple Silicon to match Racket download page.
 (define rosetta-message
   (string-append "Error: You are running the 'x86' version of Racket via 'Rosetta' emulation.\n"
                  "  Please use the 'Apple Silicon' version of Racket instead.\n"
-                 "You can install it from https://download.racket-lang.org\n"))
+                 "You can install it from https://download.racket-lang.org"))
 
 (define (handle-eggmath-import-failure)
   (define error-message (if (running-on-rosetta?) rosetta-message fallback-message))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -43,17 +43,16 @@
 
 ; Note, this message should not be reached.
 (define fallback-message
-  (string-join (list "Error: unable to load the 'egg-math' library"
-                     "Please file a bug at https://github.com/herbie-fp/herbie/issues")
-               "\n"))
+  (string-append
+   "Error: unable to load the 'egg-math' library\n"
+   "Please file a bug at https://github.com/herbie-fp/herbie/issues\n"))
 
 ; Note, refering to ARM as Apple Silicon to match Racket download page.
 (define rosetta-message
-  (string-join '("Error: You are running the 'x86' version of Racket via 'Rosetta'"
-                 "emulation. To run Herbie, you need to use the 'Apple Silicon'"
-                 "version of Racket."
-                 "You can install it here: https://download.racket-lang.org")
-               "\n"))
+  (string-append
+   "Error: You are running the 'x86' version of Racket via 'Rosetta' emulation.\n"
+   "  Please use the 'Apple Silicon' version of Racket instead.\n"
+   "You can install it from https://download.racket-lang.org\n"))
 
 (define (handle-eggmath-import-failure)
   (define error-message (if (running-on-rosetta?) rosetta-message fallback-message))

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -3,7 +3,7 @@
 # exit immediately upon first error
 set -e -x
 
-CORES=6
+CORES=2
 SEED=$(date "+%Y%j")
 
 # determine physical directory of this script

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -3,7 +3,7 @@
 # exit immediately upon first error
 set -e -x
 
-CORES=2
+CORES=4 # Raising this doesn't seem to speed up nightlies
 SEED=$(date "+%Y%j")
 
 # determine physical directory of this script

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -3,9 +3,7 @@
 # exit immediately upon first error
 set -e -x
 
-# lowered number of cores from 6 to 4 to avoid pagetable error
-# caused by heavy use of FFI by eggmath.rkt
-CORES=12
+CORES=6
 SEED=$(date "+%Y%j")
 
 # determine physical directory of this script

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -5,7 +5,7 @@ set -e -x
 
 # lowered number of cores from 6 to 4 to avoid pagetable error
 # caused by heavy use of FFI by eggmath.rkt
-CORES=4
+CORES=12
 SEED=$(date "+%Y%j")
 
 # determine physical directory of this script

--- a/infra/run.sh
+++ b/infra/run.sh
@@ -65,7 +65,9 @@ else
   dirs=""
   for bench in $BENCH/*; do
     name=$(basename "$bench" .fpcore)
+    date
     run "$bench" "$name" $ARGS
+    date
     if [ "$?" -eq 0 ]; then
       dirs="$dirs $name";
     fi
@@ -73,5 +75,7 @@ else
 
   # merge reports
   echo "merging $dirs"
+  date
   racket -y infra/merge.rkt --name "$(basename $BENCH .fpcore)" "$OUTDIR" $dirs
+  date
 fi

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -268,8 +268,7 @@
         [_ (error 'run-herbie "command ~a timed out" command)])))
 
   (define (compute-result test)
-    (parameterize ([*timeline-disabled* timeline-disabled?]
-                   [*warnings-disabled* false])
+    (parameterize ([*timeline-disabled* timeline-disabled?])
       (define start-time (current-inexact-milliseconds))
       (reset!)
       (*context* (test-context test))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -75,7 +75,7 @@
      (define p3 (midpoint p1 p2 repr))
      (define cmp
        ;; Sampling error: don't know who's better
-       (with-handlers ([exn:fail:user:herbie? (const 'fail)])
+       (with-handlers ([exn:fail:user:herbie:sampling? (const 'fail)])
          (pred p3)))
 
      (cond

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -352,7 +352,7 @@
     [(flag-set? 'generate 'simplify)
      (timeline-event! 'simplify)
 
-     ; egg schedule (only mathematical rewrites)
+     ; egg schedule (only FP rewrites plus simplify rewrites for if statements)
      (define rules (append (*fp-safe-simplify-rules*) (*simplify-rules*)))
      (define schedule `((,rules . ((node . ,(*node-limit*)) (const-fold? . #f)))))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -341,8 +341,7 @@
           (> (length alts) 1)
           (equal? (representation-type repr) 'real)
           (not (null? (context-vars ctx)))
-          (with-handlers ([exn:fail:user:herbie:missing? (const #f)])
-            (get-fpcore-impl '<= '() (list repr repr))))
+          (get-fpcore-impl '<= '() (list repr repr)))
      (define opts (pareto-regimes (sort alts < #:key (curryr alt-cost repr)) ctx))
      (for/list ([opt (in-list opts)])
        (combine-alts opt ctx))]

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -148,7 +148,7 @@
   (define reprs (map (curryr repr-of (*context*)) exprs))
   (timeline-push! 'inputs (map ~a exprs))
 
-  (define runner (make-egg-runner global-batch roots reprs schedule #:context (*context*)))
+  (define runner (make-egg-runner global-batch roots reprs schedule))
   ; batchrefss is a (listof (listof batchref))
   (define batchrefss (run-egg runner `(multi . ,extractor)))
 

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -20,16 +20,12 @@
          preprocess-pcontext
          remove-unnecessary-preprocessing)
 
-(define (has-fabs-neg-impls? repr)
-  (with-handlers ([exn:fail:user:herbie? (const #f)])
-    (get-fpcore-impl '- (repr->prop repr) (list repr))
-    (get-fpcore-impl 'fabs (repr->prop repr) (list repr))
-    #t))
+(define (has-negabs-impls? repr)
+  (and (get-fpcore-impl '- (repr->prop repr) (list repr))
+       (get-fpcore-impl 'fabs (repr->prop repr) (list repr))))
 
 (define (has-copysign-impl? repr)
-  (with-handlers ([exn:fail:user:herbie? (const #f)])
-    (get-fpcore-impl 'copysign (repr->prop repr) (list repr repr))
-    #t))
+  (get-fpcore-impl 'copysign (repr->prop repr) (list repr repr)))
 
 ;; The even identities: f(x) = f(-x)
 ;; Requires `neg` and `fabs` operator implementations.

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -20,7 +20,7 @@
          preprocess-pcontext
          remove-unnecessary-preprocessing)
 
-(define (has-negabs-impls? repr)
+(define (has-fabs-neg-impls? repr)
   (and (get-fpcore-impl '- (repr->prop repr) (list repr))
        (get-fpcore-impl 'fabs (repr->prop repr) (list repr))))
 

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -27,7 +27,7 @@
 ;; Fast version does not recurse into functions applications
 (define (repr-of expr ctx)
   (match expr
-    [(? literal?) (get-representation (literal-precision expr))]
+    [(literal val precision) (get-representation precision)]
     [(? variable?) (context-lookup ctx expr)]
     [(approx _ impl) (repr-of impl ctx)]
     [(list 'if cond ift iff) (repr-of ift ctx)]
@@ -37,7 +37,7 @@
 (define (repr-of-node batch idx ctx)
   (define node (vector-ref (batch-nodes batch) idx))
   (match node
-    [(? literal?) (get-representation (literal-precision node))]
+    [(literal val precision) (get-representation precision)]
     [(? variable?) (context-lookup ctx node)]
     [(approx _ impl) (repr-of-node batch impl ctx)]
     [(list 'if cond ift iff) (repr-of-node batch ift ctx)]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -103,21 +103,16 @@
   (define crit-vars (free-variables subexpr))
   (define replaced-expr (replace-expression expr subexpr 1))
   (define non-crit-vars (free-variables replaced-expr))
-  (set-disjoint? crit-vars non-crit-vars))
+  (and (not (null? crit-vars)) (set-disjoint? crit-vars non-crit-vars)))
 
 ;; Requires that prog is a λ expression
 (define (all-critical-subexpressions expr ctx)
-  (define (subexprs-in-expr expr)
-    (cons expr
-          (if (list? expr)
-              (append-map subexprs-in-expr (cdr expr))
-              '())))
   ;; We append all variables here in case of (λ (x y) 0) or similar,
   ;; where the variables do not appear in the body but are still worth
   ;; splitting on
-  (for/list ([subexpr (remove-duplicates (append (context-vars ctx) (subexprs-in-expr expr)))]
-             #:when (and (not (null? (free-variables subexpr)))
-                         (critical-subexpression? expr subexpr)))
+  (define all-subexprs )
+  (for/list ([subexpr (set-union (context-vars ctx) (all-subexpressions expr))]
+             #:when (critical-subexpression? expr subexpr))
     subexpr))
 
 (define (option-on-expr alts err-lsts expr ctx)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -134,7 +134,7 @@
           (for/list ([val (cdr splitvals*)]
                      [prev splitvals*])
             (</total prev val repr))))
-  (define split-indices (err-lsts->split-indices bit-err-lsts* can-split?))
+  (define split-indices (infer-split-indices bit-err-lsts* can-split?))
   (define out (option split-indices alts pts* expr (pick-errors split-indices pts* err-lsts* repr)))
   (timeline-stop!)
   (timeline-push! 'branch
@@ -190,7 +190,7 @@
 
 (module core typed/racket
   (provide (struct-out si)
-           err-lsts->split-indices)
+           infer-split-indices)
   (require math/flonum)
 
   ;; Struct representing a splitindex
@@ -205,8 +205,8 @@
   ;; Returns a list of split indices saying which alt to use for which
   ;; range of points. Starting at 1 going up to num-points.
   ;; Alts are indexed 0 and points are index 1.
-  (: err-lsts->split-indices (-> (Listof (Listof Flonum)) (Listof Boolean) (Listof si)))
-  (define (err-lsts->split-indices err-lsts can-split)
+  (: infer-split-indices (-> (Listof (Listof Flonum)) (Listof Boolean) (Listof si)))
+  (define (infer-split-indices err-lsts can-split)
     ;; Coverts the list to vector form for faster processing
     (define can-split-vec (list->vector can-split))
     ;; Converting list of list to list of flvectors

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -215,7 +215,6 @@
     (define flvec-psums (vector-map make-vec-psum (list->vector err-lsts)))
 
     ;; Set up data needed for algorithm
-    (define number-of-alts (vector-length flvec-psums))
     (define number-of-points (vector-length can-split-vec))
     ;; min-weight is used as penalty to favor not adding split points
     (define min-weight (fl number-of-points))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -306,19 +306,10 @@
       (vector-set! result-alt-idxs point-idx current-alt-idx)
       (vector-set! result-prev-idxs point-idx current-prev-idx))
 
-    ;; Loop over results vectors in reverse and build the output split index list
-    (define next number-of-points)
-    (: split-idexs (Listof si))
-    (define split-idexs '())
-    (for ([i (in-range (- number-of-points 1) -1 -1)]
-          #:when (= (+ i 1) next))
+    ;; Build the output split index list
+    (let loop ([i (- number-of-points 1)])
       (define alt-idx (vector-ref result-alt-idxs i))
-      (define split-idx (vector-ref result-prev-idxs i))
-      (set! next (+ split-idx 1))
-      (set! split-idexs
-            (cond
-              [(null? split-idexs) (cons (si alt-idx number-of-points) '())]
-              [else (cons (si alt-idx (+ i 1)) split-idexs)])))
-    split-idexs))
+      (define next (vector-ref result-prev-idxs i))
+      (cons (si alt-idx (+ i 1)) (loop next)))))
 
 (require (submod "." core))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -304,13 +304,13 @@
       (vector-set! result-alt-idxs point-idx current-alt-idx)
       (vector-set! result-prev-idxs point-idx current-prev-idx))
 
-    ;; Build the output split index list
-    (let loop ([i (- number-of-points 1)])
+    ;; Loop over results vectors in reverse and build the output split index list
+    (let loop ([i (- number-of-points 1)] [rest : (Listof si) '()])
       (define alt-idx (vector-ref result-alt-idxs i))
       (define next (vector-ref result-prev-idxs i))
-      (cons (si alt-idx (+ i 1))
-            (if (= next number-of-points)
-                '()
-                (loop next))))))
+      (define sis (cons (si alt-idx (+ i 1)) rest))
+      (if (< next i)
+          (loop next sis)
+          sis))))
 
 (require (submod "." core))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -305,7 +305,8 @@
       (vector-set! result-prev-idxs point-idx current-prev-idx))
 
     ;; Loop over results vectors in reverse and build the output split index list
-    (let loop ([i (- number-of-points 1)] [rest : (Listof si) '()])
+    (let loop ([i (- number-of-points 1)]
+               [rest (cast null (Listof si))])
       (define alt-idx (vector-ref result-alt-idxs i))
       (define next (vector-ref result-prev-idxs i))
       (define sis (cons (si alt-idx (+ i 1)) rest))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -110,7 +110,6 @@
   ;; We append all variables here in case of (λ (x y) 0) or similar,
   ;; where the variables do not appear in the body but are still worth
   ;; splitting on
-  (define all-subexprs )
   (for/list ([subexpr (set-union (context-vars ctx) (all-subexpressions expr))]
              #:when (critical-subexpression? expr subexpr))
     subexpr))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -24,9 +24,7 @@
   #:transparent
   #:methods gen:custom-write
   [(define (write-proc opt port mode)
-     (display "#<option " port)
-     (write (option-split-indices opt) port)
-     (display ">" port))])
+     (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
 (define (pareto-regimes sorted ctx)
   (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -184,8 +184,7 @@
 ;; Given error-lsts, returns a list of sp objects representing where the optimal splitpoints are.
 (define (valid-splitindices? can-split? split-indices)
   (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])
-         (and (> pidx 0)
-              (list-ref can-split? pidx)))
+         (and (> pidx 0) (list-ref can-split? pidx)))
        (= (si-pidx (last split-indices)) (length can-split?))))
 
 (module core typed/racket

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -125,13 +125,7 @@
   (define timeline-stop! (timeline-start! 'times (~a expr)))
 
   (define vars (context-vars ctx))
-  (define pts
-    (for/list ([(pt ex) (in-pcontext (*pcontext*))])
-      pt))
   (define fn (compile-prog expr ctx))
-  (define splitvals
-    (for/list ([pt pts])
-      (apply fn pt)))
   (define big-table ; val and errors for each alt, per point
     (for/list ([(pt ex) (in-pcontext (*pcontext*))]
                [err-lst err-lsts])

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -308,6 +308,9 @@
     (let loop ([i (- number-of-points 1)])
       (define alt-idx (vector-ref result-alt-idxs i))
       (define next (vector-ref result-prev-idxs i))
-      (cons (si alt-idx (+ i 1)) (loop next)))))
+      (cons (si alt-idx (+ i 1))
+            (if (= next number-of-points)
+                '()
+                (loop next))))))
 
 (require (submod "." core))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -184,8 +184,8 @@
 ;; Given error-lsts, returns a list of sp objects representing where the optimal splitpoints are.
 (define (valid-splitindices? can-split? split-indices)
   (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])
-         (and (> pidx 0))
-         (list-ref can-split? pidx))
+         (and (> pidx 0)
+              (list-ref can-split? pidx)))
        (= (si-pidx (last split-indices)) (length can-split?))))
 
 (module core typed/racket

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -15,7 +15,6 @@
 
 (provide batch-prepare-points
          eval-progs-real
-         make-sampler
          sample-points)
 
 ;; Part 1: use FPBench's condition->range-table to create initial hyperrects

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -189,8 +189,8 @@
              (loop (+ 1 sampled) 0 (cons pt points) (cons exs exactss)))]
         [else
          (when (>= skipped (*max-skipped-points*))
-           (raise-herbie-error "Cannot sample enough valid points."
-                               #:url "faq.html#sample-valid-points"))
+           (raise-herbie-sampling-error "Cannot sample enough valid points."
+                                        #:url "faq.html#sample-valid-points"))
          (loop sampled (+ 1 skipped) points exactss)])))
   (cons outcomes (cons points (flip-lists exactss))))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -40,13 +40,6 @@
   ;; set parameters
   (define vars '(x a b c))
   (*context* (make-debug-context vars))
-  (define all-simplify-rules (*simplify-rules*))
-
-  ;; check that no rules in simplify match on bare variables
-  ;; this would be bad because we don't want to match type-specific operators on a value of a different type
-  (for ([rule all-simplify-rules])
-    (check-true (not (symbol? (rule-input rule)))
-                (string-append "Rule failed: " (symbol->string (rule-name rule)))))
 
   (define (test-simplify . args)
     (define batch (progs->batch args))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -104,24 +104,21 @@
   (define costs (make-hash))
   (define missing (mutable-set))
   (define impls
-    (reap [sow]
-          (for ([impl-sig (in-list pform)])
-            (match-define (list impl cost) impl-sig)
-            (define final-cost cost)
-            (unless (or cost default-cost)
-              (raise-herbie-error "Missing cost for ~a" impl))
-            (unless cost
-              (set! final-cost default-cost))
-            (cond
-              [(impl-exists? impl)
-               (hash-set! costs impl final-cost)
-               (sow impl)]
-              [optional?
-               (set-add! missing impl)]
-              [else
-               (raise-herbie-missing-error
-                "Missing implementation ~a required by platform"
-                impl)]))))
+    (reap
+     [sow]
+     (for ([impl-sig (in-list pform)])
+       (match-define (list impl cost) impl-sig)
+       (define final-cost cost)
+       (unless (or cost default-cost)
+         (raise-herbie-error "Missing cost for ~a" impl))
+       (unless cost
+         (set! final-cost default-cost))
+       (cond
+         [(impl-exists? impl)
+          (hash-set! costs impl final-cost)
+          (sow impl)]
+         [optional? (set-add! missing impl)]
+         [else (raise-herbie-missing-error "Missing implementation ~a required by platform" impl)]))))
   (define reprs
     (remove-duplicates (apply append
                               (for/list ([impl (in-list impls)])

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -147,11 +147,19 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FPCore -> LImpl
 
+(define (assert-fpcore-impl op prop-dict ireprs)
+  (or (get-fpcore-impl op prop-dict ireprs)
+      (raise-herbie-missing-error
+       "No implementation for `~a` under rounding context `~a` with types `~a`"
+       op
+       prop-dict
+       (string-join (map (λ (r) (format "<~a>" (representation-name r))) ireprs) " "))))
+
 ;; Translates an FPCore operator application into
 ;; an LImpl operator application.
 (define (fpcore->impl-app op prop-dict args ctx)
   (define ireprs (map (lambda (arg) (repr-of arg ctx)) args))
-  (define impl (get-fpcore-impl op prop-dict ireprs))
+  (define impl (assert-fpcore-impl op prop-dict ireprs))
   (define vars (impl-info impl 'vars))
   (define pattern
     (match (impl-info impl 'fpcore)
@@ -271,9 +279,9 @@
               (if (not (null? props))
                   (apply dict-set prop-dict props)
                   prop-dict))
-            (get-fpcore-impl op prop-dict* (impl-info impl 'itype))]
+            (assert-fpcore-impl op prop-dict* (impl-info impl 'itype))]
            ; rounding context inherited from parent context
-           [(list op _ ...) (get-fpcore-impl op prop-dict (impl-info impl 'itype))]))
+           [(list op _ ...) (assert-fpcore-impl op prop-dict (impl-info impl 'itype))]))
        (cond
          [(equal? impl impl*) ; inlining is safe
           (define expr* (loop expr prop-dict))

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -61,6 +61,7 @@
 
 (require "../core/programs.rkt"
          "../utils/common.rkt"
+         "../utils/errors.rkt"
          "matcher.rkt"
          "syntax.rkt"
          "types.rkt")

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -90,8 +90,6 @@
           (define arity (length (operator-info f 'itype)))
           (unless (= arity (length args))
             (error! stx "Operator ~a given ~a arguments (expects ~a)" f (length args) arity))
-          (when (operator-deprecated? f)
-            (set-add! deprecated-ops f))]
          [(hash-has-key? (*functions*) f)
           (match-define (list vars _ _) (hash-ref (*functions*) f))
           (unless (= (length vars) (length args))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -89,7 +89,7 @@
          [(operator-exists? f)
           (define arity (length (operator-info f 'itype)))
           (unless (= arity (length args))
-            (error! stx "Operator ~a given ~a arguments (expects ~a)" f (length args) arity))
+            (error! stx "Operator ~a given ~a arguments (expects ~a)" f (length args) arity))]
          [(hash-has-key? (*functions*) f)
           (match-define (list vars _ _) (hash-ref (*functions*) f))
           (unless (= (length vars) (length args))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -8,8 +8,7 @@
          "matcher.rkt"
          "types.rkt")
 
-(provide (rename-out [operator-or-impl? operator?])
-         (struct-out literal)
+(provide (struct-out literal)
          (struct-out approx)
          variable?
          constant-operator?
@@ -579,11 +578,6 @@
 
 (define (impl-exists? op)
   (hash-has-key? operator-impls op))
-
-(define (operator-or-impl? op)
-  (and (symbol? op)
-       (not (equal? op 'if))
-       (or (hash-has-key? operators op) (hash-has-key? operator-impls op))))
 
 (define (constant-operator? op)
   (and (symbol? op)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -14,7 +14,6 @@
          variable?
          constant-operator?
          operator-exists?
-         operator-deprecated?
          operator-info
          all-operators
          all-constants
@@ -54,8 +53,7 @@
 ;; A real operator requires
 ;;  - a (unique) name
 ;;  - input and output types
-;;  - optionally a deprecated? flag [#f by default]
-(struct operator (name itype otype deprecated))
+(struct operator (name itype otype))
 
 ;; All real operators
 (define operators (make-hasheq))
@@ -63,10 +61,6 @@
 ;; Checks if an operator has been registered.
 (define (operator-exists? op)
   (hash-has-key? operators op))
-
-;; Checks if an operator has been registered as deprecated.
-(define (operator-deprecated? op)
-  (operator-deprecated (hash-ref operators op)))
 
 ;; Returns all operators.
 (define (all-operators)
@@ -93,7 +87,7 @@
 ;; Registers an operator with an attribute mapping.
 ;; Panics if an operator with name `name` has already been registered.
 ;; By default, the input types are specified by `itypes`, the output type
-;; is specified by `otype`, and the operator is not deprecated; but
+;; is specified by `otype`; but
 ;; `attrib-dict` can override these properties.
 (define (register-operator! name itypes otype attrib-dict)
   (when (hash-has-key? operators name)
@@ -101,8 +95,7 @@
   ; extract relevant fields and update tables
   (define itypes* (dict-ref attrib-dict 'itype itypes))
   (define otype* (dict-ref attrib-dict 'otype otype))
-  (define deprecated? (dict-ref attrib-dict 'deprecated #f))
-  (define info (operator name itypes* otype* deprecated?))
+  (define info (operator name itypes* otype*))
   (hash-set! operators name info))
 
 ;; Syntactic form for `register-operator!`

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -26,8 +26,6 @@
          *functions*
          register-function!
          get-fpcore-impl
-         get-cast-impl
-         generate-cast-impl
          cast-impl?)
 
 (module+ internals
@@ -582,9 +580,6 @@
           #t]
          [_ #f])))
 
-(define (get-cast-impl irepr orepr #:impls [impls (all-active-operator-impls)])
-  (get-fpcore-impl 'cast (repr->prop orepr) (list irepr) #:impls impls))
-
 ; Similar to representation generators, conversion generators
 ; allow Herbie to query plugins for optimized implementations
 ; of representation conversions, rather than the default
@@ -595,13 +590,6 @@
   (-> (-> any/c any/c boolean?) void?)
   (unless (set-member? conversion-generators proc)
     (set! conversion-generators (cons proc conversion-generators))))
-
-(define (generate-cast-impl irepr orepr)
-  (match (get-cast-impl irepr orepr)
-    [#f
-     (for/first ([gen (in-list conversion-generators)])
-       (gen (representation-name irepr) (representation-name orepr)))]
-    [impl impl]))
 
 ;; Expression predicates ;;
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -529,13 +529,11 @@
                 #:when (equal? ireprs (impl-info impl 'itype)))
             (define-values (prop-dict* expr) (impl->fpcore impl))
             (define pattern (cons op (map (lambda (_) (gensym)) ireprs)))
-            (when (and (subset? prop-dict* prop-dict)
-                       (pattern-match pattern expr))
+            (when (and (subset? prop-dict* prop-dict) (pattern-match pattern expr))
               (sow impl)))))
   ; check that we have any matching impls
   (cond
-    [(null? impls)
-     #f]
+    [(null? impls) #f]
     [else
      ; we rank implementations and select the highest scoring one
      (define scores
@@ -559,9 +557,7 @@
 ;; Casts and precision changes
 
 (define (cast-impl? x)
-  (and (symbol? x)
-       (impl-exists? x)
-       (equal? (list (impl-info x 'spec)) (impl-info x 'vars))))
+  (and (symbol? x) (impl-exists? x) (equal? (list (impl-info x 'spec)) (impl-info x 'vars))))
 
 ; Similar to representation generators, conversion generators
 ; allow Herbie to query plugins for optimized implementations

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -525,13 +525,13 @@
   ; and its FPCore translation has properties that are found in `prop-dict`
   (define impls
     (reap [sow]
-          (for ([impl (in-list all-impls)])
-            (when (equal? ireprs (impl-info impl 'itype))
-              (define-values (prop-dict* expr) (impl->fpcore impl))
-              (define pattern (cons op (map (lambda (_) (gensym)) ireprs)))
-              (when (and (andmap (lambda (prop) (member prop prop-dict)) prop-dict*)
-                         (pattern-match pattern expr))
-                (sow impl))))))
+          (for ([impl (in-list all-impls)]
+                #:when (equal? ireprs (impl-info impl 'itype)))
+            (define-values (prop-dict* expr) (impl->fpcore impl))
+            (define pattern (cons op (map (lambda (_) (gensym)) ireprs)))
+            (when (and (subset? prop-dict* prop-dict)
+                       (pattern-match pattern expr))
+              (sow impl)))))
   ; check that we have any matching impls
   (cond
     [(null? impls)

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -65,14 +65,11 @@
       [#`,(? number?) (get-representation (dict-ref prop-dict ':precision))]
       [#`,(? variable? x) (context-lookup ctx x)]
       [#`,(? constant-operator? op)
-       (define impl
-         (with-handlers ([exn:fail:user:herbie:missing? (const #f)])
-           (get-fpcore-impl op prop-dict '())))
-       (match impl
+       (match (get-fpcore-impl op prop-dict '())
          [#f ; no implementation found
           (error! stx "No implementation of `~a` in platform for context `~a`" op prop-dict)
           (get-representation (dict-ref prop-dict ':precision))]
-         [_ (impl-info impl 'otype)])]
+         [impl (impl-info impl 'otype)])]
       [#`(let ([,ids #,exprs] ...) #,body)
        (define ctx*
          (for/fold ([ctx* ctx])
@@ -118,30 +115,24 @@
        (cond
          [(equal? irepr repr) repr]
          [else
-          (define impl
-            (with-handlers ([exn:fail:user:herbie:missing? (const #f)])
-              (get-fpcore-impl 'cast prop-dict (list irepr))))
-          (match impl
+          (match (get-fpcore-impl 'cast prop-dict (list irepr))
             [#f ; no implementation found
              (error! stx
                      "No implementation of `~a` in platform for context `~a`"
                      (application->string 'cast (list irepr))
                      prop-dict)
              (get-representation (dict-ref prop-dict ':precision))]
-            [_ (impl-info impl 'otype)])])]
+            [impl (impl-info impl 'otype)])])]
       [#`(,(? symbol? op) #,args ...)
        (define ireprs (map (lambda (arg) (loop arg prop-dict ctx)) args))
-       (define impl
-         (with-handlers ([exn:fail:user:herbie:missing? (const #f)])
-           (get-fpcore-impl op prop-dict ireprs)))
-       (match impl
+       (match (get-fpcore-impl op prop-dict ireprs)
          [#f ; no implementation found
           (error! stx
                   "No implementation of `~a` in platform for context `~a`"
                   (application->string op ireprs)
                   prop-dict)
           (get-representation (dict-ref prop-dict ':precision))]
-         [_ (impl-info impl 'otype)])])))
+         [impl (impl-info impl 'otype)])])))
 
 (module+ test
   (require rackunit)

--- a/src/utils/errors.rkt
+++ b/src/utils/errors.rkt
@@ -7,12 +7,10 @@
          exception->datum
          herbie-error->string
          (struct-out exn:fail:user:herbie)
-         (struct-out exn:fail:user:herbie:syntax)
          (struct-out exn:fail:user:herbie:sampling)
          (struct-out exn:fail:user:herbie:missing)
          warn
-         warning-log
-         *warnings-disabled*)
+         warning-log)
 
 (struct exn:fail:user:herbie exn:fail:user (url) #:extra-constructor-name make-exn:fail:user:herbie)
 
@@ -117,13 +115,11 @@
               *herbie-version*)]
      [else (old-error-display-handler message err)])))
 
-(define *warnings-disabled* (make-parameter false))
-
 (define/reset warnings (mutable-set))
 (define/reset warning-log '())
 
 (define (warn type message #:url [url #f] #:extra [extra '()] . args)
-  (unless (or (*warnings-disabled*) (set-member? (warnings) type))
+  (unless (set-member? (warnings) type)
     (eprintf "Warning: ~a\n" (apply format message args))
     (for ([line extra])
       (eprintf "  ~a\n" line))

--- a/src/utils/errors.rkt
+++ b/src/utils/errors.rkt
@@ -4,10 +4,8 @@
          raise-herbie-syntax-error
          raise-herbie-sampling-error
          raise-herbie-missing-error
-         syntax->error-format-string
          exception->datum
          herbie-error->string
-         herbie-error-url
          (struct-out exn:fail:user:herbie)
          (struct-out exn:fail:user:herbie:syntax)
          (struct-out exn:fail:user:herbie:sampling)


### PR DESCRIPTION
This PR includes:

- Replace `string-join` to `string-append` with constant inputs.
- Bump nightly to six-way parallelism (tried 12, didn't help, confusing)
- Delete dead code in `regimes.rkt`; also remove duplicate of `all-subexpressions`
- Simplify the reconstruction step in `err-lsts->split-indices`; also rename to `infer-split-indices`
- Remove `operator-deprecated?` on account of no operators are actually deprecated
- Remove dead / unused code in `syntax.rkt`
- Remove the ability to disable warnings (never used)