### PR TITLE
Remove the "soundiness" step

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -7,7 +7,7 @@
          "../syntax/sugar.rkt"
          "../syntax/syntax.rkt")
 
-(provide add-soundiness)
+(provide add-derivations)
 
 (define (canonicalize-rewrite proof)
   (match proof
@@ -99,7 +99,7 @@
   (cdr (assoc rw (hash-ref query->proofs runner))))
 
 ;; Adds proof information to alternatives.
-(define (add-soundiness-to altn pcontext ctx alt->proof)
+(define (add-derivations-to altn pcontext ctx alt->proof)
   (match altn
     ; recursive rewrite or simplify, both using egg
     [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
@@ -111,9 +111,9 @@
     ; everything else
     [_ altn]))
 
-(define (add-soundiness alts pcontext ctx)
+(define (add-derivations alts pcontext ctx)
   (define-values (alt->query&rws query->rws) (make-proof-tables alts))
   (define query->proofs (compute-proofs query->rws))
   (define lookup-proc (lookup-proof alt->query&rws query->proofs))
   (for/list ([altn (in-list alts)])
-    (alt-map (curryr add-soundiness-to pcontext ctx lookup-proc) altn)))
+    (alt-map (curryr add-derivations-to pcontext ctx lookup-proc) altn)))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -30,8 +30,7 @@
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)
   (match altn
-    [(alt expr `(rr ,loc ,method ,_) prevs _)
-     (list expr (list 'rr loc method) (map alt-expr prevs))]
+    [(alt expr `(rr ,loc ,method ,_) prevs _) (list expr (list 'rr loc method) (map alt-expr prevs))]
     [(alt expr `(simplify ,loc ,method ,_) prevs _)
      (list expr (list 'simplify loc method) (map alt-expr prevs))]
     [_ (error 'altn->key "unimplemented ~a" altn)]))
@@ -104,8 +103,7 @@
     ; recursive rewrite or simplify, both using egg
     [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
      #:when (or (equal? phase 'simplify) (equal? phase 'rr))
-     (match-define proof
-       (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
+     (match-define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
      (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 
     ; everything else

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -226,8 +226,8 @@
          (define event*
            (match event
              [(list 'taylor name var) (list 'taylor loc0 name var)]
-             [(list 'rr input proof soundiness) (list 'rr loc0 input proof soundiness)]
-             [(list 'simplify input proof soundiness) (list 'simplify loc0 input proof soundiness)]))
+             [(list 'rr input proof) (list 'rr loc0 input proof)]
+             [(list 'simplify input proof) (list 'simplify loc0 input proof)]))
          (define expr* (location-do loc0 (alt-expr orig) (const (debatchref (alt-expr altn)))))
          (alt expr* event* (list (loop (first prevs))) (alt-preprocessing orig))])))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -19,7 +19,7 @@
          "preprocess.rkt"
          "programs.rkt"
          "../utils/timeline.rkt"
-         "soundiness.rkt"
+         "derivations.rkt"
          "batch.rkt")
 (provide run-improve!)
 
@@ -40,7 +40,7 @@
 ;; These high-level functions give the high-level workflow of Herbie:
 ;; - Initial steps: explain, preprocessing, initialize the alt table
 ;; - the loop: choose some alts, localize, run the patch table, and finalize
-;; - Final steps: regimes, final simplify, add soundiness, and remove preprocessing
+;; - Final steps: regimes, final simplify, derivations, and remove preprocessing
 
 (define (run-improve! initial specification context pcontext)
   (explain! initial context pcontext)
@@ -82,7 +82,7 @@
   (define all-alts (atab-all-alts (^table^)))
   (define joined-alts (make-regime! all-alts))
   (define cleaned-alts (final-simplify! joined-alts))
-  (define annotated-alts (add-soundness! cleaned-alts))
+  (define annotated-alts (add-derivations! cleaned-alts))
 
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
   (sort-alts annotated-alts))
@@ -380,11 +380,11 @@
                         alt-equal?)]
     [else alts]))
 
-(define (add-soundness! alts)
+(define (add-derivations! alts)
   (cond
     [(flag-set? 'generate 'proofs)
-     (timeline-event! 'soundness)
-     (add-soundiness alts (*pcontext*) (*context*))]
+     (timeline-event! 'derivations)
+     (add-derivations alts (*pcontext*) (*context*))]
     [else alts]))
 
 (define (sort-alts alts)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -65,7 +65,7 @@
                 (mutable-batch-push! global-batch-mutable
                                      (approx (mutable-batch-munge! global-batch-mutable spec)
                                              (batchref-idx batchreff))))
-              (sow (alt (batchref global-batch idx) `(simplify ,runner #f #f) (list altn) '()))))
+              (sow (alt (batchref global-batch idx) `(simplify ,runner #f) (list altn) '()))))
           (batch-copy-mutable-nodes! global-batch global-batch-mutable))) ; Update global-batch
 
   (timeline-push! 'count (length approxs) (length simplified))
@@ -158,7 +158,7 @@
           (for ([batchrefs (in-list batchrefss)]
                 [altn (in-list altns)])
             (for ([batchref* (in-list batchrefs)])
-              (sow (alt batchref* (list 'rr runner #f #f) (list altn) '()))))))
+              (sow (alt batchref* (list 'rr runner #f) (list altn) '()))))))
 
   (timeline-push! 'outputs (map (compose ~a debatchref alt-expr) rewritten))
   (timeline-push! 'count (length altns) (length rewritten))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -78,7 +78,7 @@
   (cons start-alt
         (remove-duplicates
          (for/list ([batchreff (rest simplified)])
-           (alt (debatchref batchreff) `(simplify () ,runner #f #f) (list start-alt) '()))
+           (alt (debatchref batchreff) `(simplify () ,runner #f) (list start-alt) '()))
          alt-equal?)))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html

--- a/src/core/soundiness.rkt
+++ b/src/core/soundiness.rkt
@@ -16,31 +16,6 @@
     [(list _ ...) (map canonicalize-rewrite proof)]
     [_ proof]))
 
-(define (get-proof-errors proof pcontext ctx)
-  (define proof-exprs (map remove-rewrites proof))
-  (define proof-progs (filter impl-prog? proof-exprs))
-  (define errss (batch-errors proof-progs pcontext ctx))
-
-  (define prog->errs
-    (for/hash ([prog (in-list proof-progs)]
-               [errs (in-list errss)])
-      (values prog errs)))
-
-  (define proof-errors
-    (for/list ([expr (in-list proof-exprs)])
-      (hash-ref prog->errs expr #f)))
-
-  (define proof-diffs
-    (cons (list 0 0)
-          (for/list ([prev proof-errors]
-                     [current (rest proof-errors)])
-            (and prev
-                 current
-                 (list (count > current prev) ; num points where error increased
-                       (count < current prev)))))) ; num points where error decreased
-
-  proof-diffs)
-
 (define (canonicalize-proof prog proof loc pcontext ctx)
   (cond
     [proof
@@ -49,16 +24,15 @@
      (define proof*
        (for/list ([step (in-list proof)])
          (location-do loc prog (const (canonicalize-rewrite step)))))
-     (define errors (get-proof-errors proof* pcontext ctx))
-     (cons proof* errors)]
-    [else (cons #f #f)]))
+     proof*]
+    [else #f]))
 
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)
   (match altn
-    [(alt expr `(rr ,loc ,method ,_ ,_) prevs _)
+    [(alt expr `(rr ,loc ,method ,_) prevs _)
      (list expr (list 'rr loc method) (map alt-expr prevs))]
-    [(alt expr `(simplify ,loc ,method ,_ ,_) prevs _)
+    [(alt expr `(simplify ,loc ,method ,_) prevs _)
      (list expr (list 'simplify loc method) (map alt-expr prevs))]
     [_ (error 'altn->key "unimplemented ~a" altn)]))
 
@@ -73,7 +47,7 @@
   (define (build! altn)
     (match altn
       ; recursive rewrite using egg (impl -> impl)
-      [(alt expr `(rr ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
+      [(alt expr `(rr ,loc ,(? egg-runner? runner) #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define end-expr (location-get loc expr))
        (define rewrite (cons start-expr end-expr))
@@ -83,7 +57,7 @@
       ; simplify using egg
       ;  usually: impl -> impl
       ;  taylor: spec -> approx (_, impl)
-      [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f #f) `(,prev) _)
+      [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f) `(,prev) _)
        (define rewrite
          (match (alt-event prev)
            [(list 'taylor _ ...)
@@ -128,11 +102,11 @@
 (define (add-soundiness-to altn pcontext ctx alt->proof)
   (match altn
     ; recursive rewrite or simplify, both using egg
-    [(alt expr (list phase loc (? egg-runner? runner) #f #f) `(,prev) _)
+    [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
      #:when (or (equal? phase 'simplify) (equal? phase 'rr))
-     (match-define (cons proof* errs)
+     (match-define proof
        (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
-     (alt expr `(rr ,loc ,runner ,proof* ,errs) `(,prev) '())]
+     (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 
     ; everything else
     [_ altn]))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -151,11 +151,11 @@
                 ,(core->tex core #:loc (and loc (cons 2 loc)) #:color "blue")
                 "\\]")))]
 
-    [(alt prog `(simplify ,loc ,input ,proof ,soundiness) `(,prev) _)
+    [(alt prog `(simplify ,loc ,input ,proof) `(,prev) _)
      (define-values (err err2) (altn-errors altn pcontext pcontext2 ctx))
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li ,(if proof
-                (render-proof proof soundiness pcontext ctx)
+                (render-proof proof pcontext ctx)
                 ""))
        (li (p "Simplified" (span ((class "error") [title ,err2]) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]
@@ -172,20 +172,19 @@
        (li (p "Final simplification" (span ((class "error") [title ,err2]) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(program->tex prog ctx) "\\]")))]
 
-    [(alt prog `(rr ,loc ,input ,proof ,soundiness) `(,prev) _)
+    [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
      (define-values (err err2) (altn-errors altn pcontext pcontext2 ctx))
      `(,@(render-history prev pcontext pcontext2 ctx)
        (li ,(if proof
-                (render-proof proof soundiness pcontext ctx)
+                (render-proof proof pcontext ctx)
                 ""))
        (li (p "Applied rewrites" (span ((class "error") [title ,err2]) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]))
 
-(define (render-proof proof soundiness pcontext ctx)
+(define (render-proof proof pcontext ctx)
   `(div ((class "proof"))
         (details (summary "Step-by-step derivation")
-                 (ol ,@(for/list ([step proof]
-                                  [sound soundiness])
+                 (ol ,@(for/list ([step proof])
                          (define-values (dir rule loc expr) (splice-proof-step step))
                          ;; need to handle mixed real/float expressions
                          (define-values (err prog)
@@ -195,25 +194,14 @@
                                                        (representation-total-bits (context-repr ctx)))
                                       (program->fpcore expr ctx))]
                              [else (values "N/A" (mixed->fpcore expr ctx))]))
-                         ;; soundiness
-                         (define num-increase
-                           (if sound
-                               (first sound)
-                               "N/A"))
-                         (define num-decrease
-                           (if sound
-                               (second sound)
-                               "N/A"))
                          ; the proof
                          (if (equal? dir 'Goal)
                              ""
                              `(li ,(let ([dir (match dir
                                                 ['Rewrite<= "right to left"]
-                                                ['Rewrite=> "left to right"])]
-                                         [tag (string-append (format " ↑ ~a" num-increase)
-                                                             (format " ↓ ~a" num-decrease))])
+                                                ['Rewrite=> "left to right"])])
                                      `(p (code ([title ,dir]) ,(~a rule))
-                                         (span ((class "error") [title ,tag]) ,err)))
+                                         (span ([class "error"]) ,err)))
                                   (div ((class "math"))
                                        "\\[\\leadsto "
                                        ,(core->tex prog #:loc (and loc (cons 2 loc)) #:color "blue")
@@ -262,12 +250,12 @@
             (error . ,err)
             (training-error . ,err2))]
 
-    [(alt prog `(simplify ,loc ,input ,proof ,soundiness) `(,prev) _)
+    [(alt prog `(simplify ,loc ,input ,proof) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "simplify")
             (prev . ,(render-json prev pcontext pcontext2 ctx))
             (proof . ,(if proof
-                          (render-proof-json proof soundiness pcontext ctx)
+                          (render-proof-json proof pcontext ctx)
                           (json-null)))
             (loc . ,loc)
             (error . ,err)
@@ -287,12 +275,12 @@
             (error . ,err)
             (training-error . ,err2))]
 
-    [(alt prog `(rr ,loc ,input ,proof ,soundiness) `(,prev) _)
+    [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "rr")
             (prev . ,(render-json prev pcontext pcontext2 ctx))
             (proof . ,(if proof
-                          (render-proof-json proof soundiness pcontext ctx)
+                          (render-proof-json proof pcontext ctx)
                           (json-null)))
             (loc . ,loc)
             (error . ,err)
@@ -306,22 +294,12 @@
             (training-error . ,err2)
             (preprocessing . ,(map (curry map symbol->string) preprocessing)))]))
 
-(define (render-proof-json proof soundiness pcontext ctx)
-  (for/list ([step proof]
-             [sound soundiness])
+(define (render-proof-json proof pcontext ctx)
+  (for/list ([step proof])
     (define-values (dir rule loc expr) (splice-proof-step step))
     (define err
       (if (impl-prog? expr)
           (errors-score (errors expr pcontext ctx))
-          "N/A"))
-
-    (define num-increase
-      (if sound
-          (first sound)
-          "N/A"))
-    (define num-decrease
-      (if sound
-          (second sound)
           "N/A"))
 
     `#hash((error . ,err)
@@ -331,5 +309,4 @@
                            ['Rewrite=> "ltr"]
                            ['Goal "goal"]))
            (rule . ,(~a rule))
-           (loc . ,loc)
-           (tag . ,(string-append (format " ↑ ~a" num-increase) (format " ↓ ~a" num-decrease))))))
+           (loc . ,loc))))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -201,7 +201,7 @@
                                                 ['Rewrite<= "right to left"]
                                                 ['Rewrite=> "left to right"])])
                                      `(p (code ([title ,dir]) ,(~a rule))
-                                         (span ([class "error"]) ,err)))
+                                         (span ((class "error")) ,err)))
                                   (div ((class "math"))
                                        "\\[\\leadsto "
                                        ,(core->tex prog #:loc (and loc (cons 2 loc)) #:color "blue")

--- a/src/reports/resources/report.css
+++ b/src/reports/resources/report.css
@@ -319,7 +319,7 @@ table pre { padding: 0; margin: 0; text-align: left; font-size: 110%; }
 
 .timeline-rewrite  { --phase-color: #4e9a06; }
 .timeline-simplify { --phase-color: #73d216; }
-.timeline-soundness{ --phase-color: #8ae234; }
+.timeline-derivations{ --phase-color: #8ae234; }
 
 .timeline-preprocess { --phase-color: #5c3566; }
 .timeline-series   { --phase-color: #ad7fa8; }


### PR DESCRIPTION
This PR removes the part of Herbie that evaluates each intermediate rewrite step in a derivation. This data isn't really used anywhere by anyone, it costs time (not a lot in regular Herbie, but possibly a lot in custom platforms), and it's code we carry around for no reason.