### PR TITLE
Re-enable profiles on nightly runs, and redo profiles in general

### DIFF
--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -44,7 +44,7 @@
           (override-test-precision the-test (*precision*))
           the-test))
     (define result (run-herbie 'improve the-test* #:seed seed))
-    (match-define (job-result _ test status time timeline warnings backend) result)
+    (match-define (job-result _ test status time timeline profile warnings backend) result)
     (match status
       ['success
        (match-define (improve-result preprocess pctxs start targets end bogosity) backend)

--- a/infra/testApi.mjs
+++ b/infra/testApi.mjs
@@ -304,7 +304,7 @@ assert.equal(mathjs.mathjs, "sqrt(x + 1.0) - sqrt(x)")
 const expectedExpressions = {
   "python": 'def expr(x):\n\treturn math.sqrt((x + 1.0)) - math.sqrt(x)\n',
   "c": 'double expr(double x) {\n\treturn sqrt((x + 1.0)) - sqrt(x);\n}\n',
-  "fortran": 'real(8) function expr(x)\n    real(8), intent (in) :: x\n    expr = sqrt((x + 1.0d0)) - sqrt(x)\nend function\n',
+  "fortran": 'real(8) function expr(x)\nuse fmin_fmax_functions\n    real(8), intent (in) :: x\n    expr = sqrt((x + 1.0d0)) - sqrt(x)\nend function\n',
   "java": 'public static double expr(double x) {\n\treturn Math.sqrt((x + 1.0)) - Math.sqrt(x);\n}\n',
   "julia": 'function expr(x)\n\treturn Float64(sqrt(Float64(x + 1.0)) - sqrt(x))\nend\n',
   "matlab": 'function tmp = expr(x)\n\ttmp = sqrt((x + 1.0)) - sqrt(x);\nend\n',

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -95,7 +95,7 @@
      ([test (in-list tests)])
      (values
       (start-job
-       (create-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f))
+       (create-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f))
       (test-name test))))
 
   (define info

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -306,8 +306,7 @@
                         #:delay 0.01
                         #:render (λ (p order) (set! profile (profile->json p)))))
        (struct-copy job-result result [profile profile])]
-      [else
-       (compute-result)]))
+      [else (compute-result)]))
 
   ;; Branch on whether or not we should run inside an engine
   (define eng (engine in-engine))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -142,7 +142,7 @@
 
 (define (herbie-do-server-job command job-id)
   (define herbie-result (wrapper-run-herbie command job-id))
-  (match-define (job-result kind test status time _ _ backend) herbie-result)
+  (match-define (job-result kind test status time _ _ _ backend) herbie-result)
   (match kind
     ['alternatives (make-alternatives-result herbie-result test job-id)]
     ['evaluate (make-calculate-result herbie-result job-id)]
@@ -457,6 +457,7 @@
   (define job-time (job-result-time herbie-result))
   (define warnings (job-result-warnings herbie-result))
   (define timeline (job-result-timeline herbie-result))
+  (define profile (job-result-profile herbie-result))
 
   (define repr (test-output-repr test))
   (define backend-hash
@@ -479,6 +480,8 @@
           warnings
           'timeline
           timeline
+          'profile
+          profile
           'backend
           backend-hash
           'job

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -15,7 +15,7 @@
 (define (all-pages result-hash)
   (define good? (eq? (hash-ref result-hash 'status) 'success))
   (define default-pages '("graph.html" "timeline.html" "timeline.json"))
-  (define success-pages '("points.json"))
+  (define success-pages '("points.json" "profile.json"))
   (append default-pages (if good? success-pages empty)))
 
 (define ((page-error-handler result-hash page out) e)
@@ -40,6 +40,7 @@
                                 #:path "..")
                  out)]
     ["timeline.json" (write-json (hash-ref result-hash 'timeline) out)]
+    ["profile.json" (write-json (hash-ref result-hash 'profile) out)]
     ["points.json" (write-json (make-points-json result-hash) out)]))
 
 (define (make-graph-html result-hash output? profile?)


### PR DESCRIPTION
Previous PR #1064 inadvertently disabled profiling, as noted in #1078. Worse, the way profiles worked _before_ that PR was pretty weird and wouldn't be compatible with the `server.rkt` approach. This PR fixes everything by making profiles yet another entry in the `job-result` struct and re-enabling them for nightlies.