### PR TITLE
Report page tweaks

### DIFF
--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -192,14 +192,9 @@ function on(mark, listeners = {}) {
 }
 
 function plotXY(testsData, filterFunction) {
-    var filteredTests = []
-    testsData.tests.forEach((test) => {
-        // Ugh global scope 
-        let other = diffAgainstFields[test.name]
-        if (filterFunction(test, other)) {
-            filteredTests.push(test)
-        }
-    })
+    var filteredTests = testsData.tests.filter((test) => {
+        return filterFunction(test, diffAgainstFields[test.name]);
+    });
     const out = Plot.plot({
         marks: [
             Plot.line([[0, 0], [1, 1]], { stroke: '#ddd' }),
@@ -331,10 +326,6 @@ function buildCompareForm(jsonData) {
 function buildBody(jsonData, otherJsonData) {
     let filterFunction = makeFilterFunction();
 
-    function hasNote(note) {
-        return (note ? toTitleCase(note) + " " : "") + "Results"
-    }
-
     var total_start = 0
     var total_result = 0
     var maximum_accuracy = 0
@@ -376,7 +367,7 @@ function buildBody(jsonData, otherJsonData) {
     ])
 
     const header = Element("header", {}, [
-        Element("h1", {}, hasNote(jsonData.note)),
+        Element("h1", {}, toTitleCase(jsonData.note ?? "") + " Results",
         Element("img", { src: "logo-car.png" }, []),
         Element("nav", {}, [
             Element("ul", {}, [Element("li", {}, [Element("a", { href: "timeline.html" }, ["Metrics"])])])

--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -222,14 +222,27 @@ function plotXY(testsData, filterFunction) {
     return out;
 }
 
-function plotPareto(jsonData) {
+function plotPareto(jsonData, otherJsonData) {
     const [initial, frontier] = jsonData["merged-cost-accuracy"];
+    const [initial2, frontier2] = 
+          otherJsonData ? otherJsonData["merged-cost-accuracy"] : [null, null];
     const out = Plot.plot({
-        marks: [
-            Plot.dot([initial], {
-                stroke: "#d00",
+        marks: 
+        (otherJsonData ? [
+            Plot.dot([initial2], {
+                stroke: "#900",
                 symbol: "square",
-                strokeWidth: 2
+                strokeWidth: 2,
+            }),
+            Plot.line(frontier2, {
+                stroke: "#900",
+                strokeWidth: 2,
+            }),
+        ] : []) + [
+            Plot.dot([initial], {
+                stroke: "#00a",
+                symbol: "square",
+                strokeWidth: 2,
             }),
             Plot.line(frontier, {
                 stroke: "#00a",
@@ -257,7 +270,8 @@ function buildCheckboxLabel(classes, text, boolState) {
 function buildDiffLine(jsonData, show) {
     const urlInput = Element("input", {
         id: "compare-input", value: compareAgainstURL,
-        placeholder: "URL to other json file"
+        placeholder: "URL to report or JSON file",
+        size: 60,
     }, []);
 
     var unitText = radioStates[radioState]?.tolerance;
@@ -307,8 +321,8 @@ function buildCompareForm(jsonData) {
 
     const hideEqual = buildCheckboxLabel("hide-equal", "Hide equal", hideDirtyEqual)
     hideEqual.addEventListener("click", (e) => {
-        hideDirtyEqual = !hideDirtyEqual
-        update()
+        hideDirtyEqual = hideEqual.checked;
+        update();
     })
 
     return Element("form", {}, [radioButtons, " ", hideEqual]);
@@ -377,7 +391,7 @@ function buildBody(jsonData, otherJsonData) {
         ]),
         Element("figure", { id: "pareto" }, [
             Element("h2", {}, [tempPareto_A]),
-            plotPareto(jsonData),
+            plotPareto(jsonData, otherJsonData),
             Element("figcaption", {}, [tempPareto_B])
         ])
     ])
@@ -385,6 +399,7 @@ function buildBody(jsonData, otherJsonData) {
     function buildTableHeader(stringName, help) {
         const textElement = Element("th", {}, [
             toTitleCase(stringName),
+            " ",
             (stringName != sortState.key ? "–" : sortState.dir ?  "⏶" : "⏷"),
             help && Element("span", { classList: "help-button", title: help }, ["?"]),
         ]);

--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -219,11 +219,21 @@ function plotXY(testsData, filterFunction) {
 
 function plotPareto(jsonData, otherJsonData) {
     const [initial, frontier] = jsonData["merged-cost-accuracy"];
-    const [initial2, frontier2] = 
-          otherJsonData ? otherJsonData["merged-cost-accuracy"] : [null, null];
-    const out = Plot.plot({
-        marks: 
-        (otherJsonData ? [
+    let marks = [
+        Plot.dot([initial], {
+            stroke: "#00a",
+            symbol: "square",
+            strokeWidth: 2,
+        }),
+        Plot.line(frontier, {
+            stroke: "#00a",
+            strokeWidth: 2,
+        }),
+    ];
+
+    if (otherJsonData) {
+        const [initial2, frontier2] = otherJsonData["merged-cost-accuracy"];
+        marks = [
             Plot.dot([initial2], {
                 stroke: "#900",
                 symbol: "square",
@@ -232,18 +242,12 @@ function plotPareto(jsonData, otherJsonData) {
             Plot.line(frontier2, {
                 stroke: "#900",
                 strokeWidth: 2,
-            }),
-        ] : []) + [
-            Plot.dot([initial], {
-                stroke: "#00a",
-                symbol: "square",
-                strokeWidth: 2,
-            }),
-            Plot.line(frontier, {
-                stroke: "#00a",
-                strokeWidth: 2,
-            }),
-        ],
+            })
+        ].concat(marks);
+    }
+
+    const out = Plot.plot({
+        marks: marks,
         width: '400',
         height: '400',
         x: { line: true, nice: true, tickFormat: c => c + "×" },
@@ -367,7 +371,7 @@ function buildBody(jsonData, otherJsonData) {
     ])
 
     const header = Element("header", {}, [
-        Element("h1", {}, toTitleCase(jsonData.note ?? "") + " Results",
+        Element("h1", {}, toTitleCase(jsonData.note || "") + " Results"),
         Element("img", { src: "logo-car.png" }, []),
         Element("nav", {}, [
             Element("ul", {}, [Element("li", {}, [Element("a", { href: "timeline.html" }, ["Metrics"])])])


### PR DESCRIPTION
This PR adds a new report page feature: mutli-pareto plots when in diff mode. Here's an example with the current and baseline `hamming` results:

<img width="373" alt="image" src="https://github.com/user-attachments/assets/78186db8-72fd-4e72-a64c-ef7cad6437c7">

The XY plot has a similar (though uglier) feature. There are also some minor code tweaks.