### PR TITLE
Fix non-determinism

### DIFF
--- a/src/platforms/binary32.rkt
+++ b/src/platforms/binary32.rkt
@@ -210,11 +210,11 @@
                             [(binary32 binary32 binary32)
                              (atan2 copysign fdim fmax fmin fmod pow remainder)])
 
-(define-libm c_erfcf (erfc float float))
-(define-libm c_expm1f (expm1 float float))
-(define-libm c_log1pf (log1p float float))
-(define-libm c_hypotf (hypot float float float))
-(define-libm c_fmaf (fma float float float float))
+(define-libm c_erfcf (erfcf float float))
+(define-libm c_expm1f (expm1f float float))
+(define-libm c_log1pf (log1pf float float))
+(define-libm c_hypotf (hypotf float float float))
+(define-libm c_fmaf (fmaf float float float float))
 
 (when c_erfcf
   (define-operator-impl (erfc.f32 [x : binary32])


### PR DESCRIPTION
This PR fixes a tiny oversight in Herbie that actually lead to non-determinism. Basically, when we load `fma.f32` over FFI we load `fma` instead of `fmaf`, but we still give it the correct type signature. I'm not even 100% sure what this actually leads to specifically (reading junk out of unused vector lanes?) but here we are.

This is somehow the root cause of the non-determinism. FML.