### PR TITLE
Remove `diff-report` and friends

### DIFF
--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -11,8 +11,7 @@
          make-report-info
          read-datafile
          write-datafile
-         merge-datafiles
-         diff-datafiles)
+         merge-datafiles)
 
 (struct table-row
         (name identifier
@@ -296,30 +295,3 @@
                ;; Easiest to just recompute everything based off the combined tests
                (merged-cost-accuracy tests)))
 
-(define (diff-datafiles old new)
-  (define old-tests
-    (for/hash ([ot (in-list (report-info-tests old))])
-      (values (table-row-name ot) ot)))
-  (define tests*
-    (for/list ([nt (in-list (report-info-tests new))])
-      (if (hash-has-key? old-tests (table-row-name nt))
-          (let ([ot (hash-ref old-tests (table-row-name nt))])
-            (define end-score (table-row-result nt))
-            (define target-score (table-row-result ot))
-            (define start-score (table-row-start nt))
-
-            (struct-copy table-row
-                         nt
-                         [status
-                          (if (and end-score target-score start-score)
-                              (cond
-                                [(< end-score (- target-score 1)) "gt-target"]
-                                [(< end-score (+ target-score 1)) "eq-target"]
-                                [(> end-score (+ start-score 1)) "lt-start"]
-                                [(> end-score (- start-score 1)) "eq-start"]
-                                [(> end-score (+ target-score 1)) "lt-target"])
-                              (table-row-status nt))]
-                         [target-prog (table-row-output ot)]
-                         [target (table-row-result ot)]))
-          nt)))
-  (struct-copy report-info new [tests tests*]))

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -294,4 +294,3 @@
                tests
                ;; Easiest to just recompute everything based off the combined tests
                (merged-cost-accuracy tests)))
-

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -15,8 +15,7 @@
          "server.rkt")
 
 (provide make-report
-         rerun-report
-         diff-report)
+         rerun-report)
 
 (define (extract-test row)
   (define vars (table-row-vars row))
@@ -140,12 +139,6 @@
     [(and (not (test-output t1)) (not (test-output t2))) (string<? (test-name t1) (test-name t2))]
     ; Put things with an output first
     [else (test-output t1)]))
-
-(define (diff-report old new)
-  (define df
-    (diff-datafiles (call-with-input-file (build-path old "results.json") read-datafile)
-                    (call-with-input-file (build-path new "results.json") read-datafile)))
-  (copy-file (web-resource "report.html") (build-path new "index.html") #t))
 
 ;; Generate a path for a given benchmark name
 (define (bench-folder-path bench-name index)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -12,7 +12,7 @@
 (load-herbie-plugins)
 
 (lazy-require ["api/demo.rkt" (run-demo)]
-              ["api/run.rkt" (make-report rerun-report diff-report)]
+              ["api/run.rkt" (make-report rerun-report)]
               ["api/shell.rkt" (run-shell)]
               ["api/improve.rkt" (run-improve)])
 
@@ -197,7 +197,6 @@
     [("--profile") "Whether to profile each run" (void)]
     #:args (input output)
     (rerun-report input #:dir output #:note report-note #:threads threads)]
-   [diff "Diff two HTML reports" #:args (old new) (diff-report old new)]
    #:args files
    (match files
      ['()


### PR DESCRIPTION
This PR removes `herbie diff` and its supporting code. Back in the day this was a command-line way to diff reports, but these days that's built in to the JS of the report page and this code is no longer needed.