### PR TITLE
Minor cleanups to `main.rkt`

### DIFF
--- a/infra/index.css
+++ b/infra/index.css
@@ -44,8 +44,7 @@ svg .no-data { text-anchor: middle; font-size: 18px; fill: rgb(60%, 60%, 60%)}
 #reports tr.crash { color: red; }
 #reports td { text-align: right; padding: .5em; overflow: hidden; font-size: 15pt; }
 #reports tbody tr:hover {background-color: #e0f8d8; cursor: pointer;}
-#reports td:nth-child(3), #reports th:nth-child(2) { text-align: center; display: none; }
-#reports td:nth-child(4) { text-align: center; }
+#reports td:nth-child(3), #reports th:nth-child(3) { display: none; }
 #reports thead { border-bottom: 1px solid black; height: 5em; vertical-align: bottom; }
 #reports a {
     position: absolute; left: 0; right: 0; z-index: 100;

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -156,30 +156,30 @@
            (th "Collection")
            (th "Tests")
            (th "Bits"))
-    (tbody
-     ,@
-     (for/list ([info infos])
-       (define field (curry dict-ref info))
+    (tbody ,@(for/list ([info infos])
+               (define field (curry dict-ref info))
 
-       `(tr ((class ,(if (bad-result? info) "crash" "")))
-            ;; TODO: Best to output a datetime field in RFC3338 format,
-            ;; but Racket doesn't make that easy.
-            (td ([title ,(field 'date-full)])
-                (time ([data-unix ,(~a (field 'date-unix))]) ,(field 'date-short)))
-            (td (time ([data-ms ,(~a (field 'speed))]) ,(format-time (field 'speed))))
-            (td ([title ,(field 'commit)]) ,(field 'branch))
-            (td ,(if (> (field 'tests-available) 0)
-                     (format "~a/~a" (field 'tests-passed) (field 'tests-available))
-                     ""))
-            (td ,(if (field 'bits-improved)
-                     (format "~a/~a" (round* (field 'bits-improved)) (round* (field 'bits-available)))
-                     ""))
-            (td ([title
-                  ,(format "At ~a\nOn ~a\nFlags ~a"
-                           (field 'date-full)
-                           (field 'hostname)
-                           (string-join (field 'options) " "))])
-                (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
+               `(tr ((class ,(if (bad-result? info) "crash" "")))
+                    ;; TODO: Best to output a datetime field in RFC3338 format,
+                    ;; but Racket doesn't make that easy.
+                    (td ([title ,(field 'date-full)])
+                        (time ([data-unix ,(~a (field 'date-unix))]) ,(field 'date-short)))
+                    (td (time ([data-ms ,(~a (field 'speed))]) ,(format-time (field 'speed))))
+                    (td ([title ,(field 'commit)]) ,(field 'branch))
+                    (td ,(if (> (field 'tests-available) 0)
+                             (format "~a/~a" (field 'tests-passed) (field 'tests-available))
+                             ""))
+                    (td ,(if (field 'bits-improved)
+                             (format "~a/~a"
+                                     (round* (field 'bits-improved))
+                                     (round* (field 'bits-available)))
+                             ""))
+                    (td ([title
+                          ,(format "At ~a\nOn ~a\nFlags ~a"
+                                   (field 'date-full)
+                                   (field 'hostname)
+                                   (string-join (field 'options) " "))])
+                        (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
 
 (define (make-index-page folders out)
   (define branch-infos

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -41,8 +41,6 @@
 (define key-contracts
   (hash string?
         '(date-full date-short folder commit branch hostname)
-        (or/c string? false)
-        '(note)
         exact-nonnegative-integer?
         '(date-unix tests-passed tests-available tests-crashed)
         (listof string?)
@@ -84,7 +82,6 @@
                              flags
                              points
                              iterations
-                             note
                              tests
                              merged-cost-accuracy)
     info)
@@ -125,8 +122,6 @@
         branch
         'options
         (map ~a (get-options info))
-        'note
-        note
         'tests-passed
         total-passed
         'tests-available
@@ -173,8 +168,6 @@
                 (time ([data-unix ,(~a (field 'date-unix))]) ,(field 'date-short)))
             (td (time ([data-ms ,(~a (field 'speed))]) ,(format-time (field 'speed))))
             (td ([title ,(field 'commit)]) ,(field 'branch))
-            (td ([title ,(string-join (field 'options) " ")] (class ,(if (field 'note) "note" "")))
-                ,(or (field 'note) "⭐"))
             (td ,(if (> (field 'tests-available) 0)
                      (format "~a/~a" (field 'tests-passed) (field 'tests-available))
                      ""))
@@ -203,18 +196,6 @@
   (define-values (mainline-infos other-infos)
     (partition (λ (x) (set-member? '("master" "develop" "main") (dict-ref (first x) 'branch)))
                branch-infos))
-
-  (when (null? mainline-infos)
-    (set! mainline-infos
-          (list (filter (curryr dict-ref 'note)
-                        (map first
-                             (group-by (curryr dict-ref 'note)
-                                       (sort (filter (λ (x)
-                                                       (set-member? '("master" "develop" "main")
-                                                                    (dict-ref x 'branch)))
-                                                     folders)
-                                             >
-                                             #:key (curryr dict-ref 'date-unix))))))))
 
   (define crashes (filter (λ (x) (> (dict-ref x 'tests-crashed) 0)) (apply append mainline-infos)))
   (define last-crash

--- a/infra/merge.rkt
+++ b/infra/merge.rkt
@@ -36,7 +36,7 @@
                          #:exists 'replace
                          (curry write-json (profile->json joint-pf))))
 
-(define (merge-reports outdir name . dirs)
+(define (merge-reports outdir . dirs)
   (load-herbie-builtins)
   (define rss
     (filter (conjoin (negate eof-object?) identity)
@@ -48,15 +48,12 @@
                       eof
                       (cons df dir)))))))
   (define dfs (map car rss))
-  (define joint-rs (merge-datafiles dfs #:dirs dirs #:name name))
+  (define joint-rs (merge-datafiles dfs #:dirs dirs))
   (write-datafile (build-path outdir "results.json") joint-rs)
   (copy-file (web-resource "report.html") (build-path outdir "index.html") #t))
 
 (module+ main
-  (define name #f)
-  (command-line #:once-each [("--name") _name "Name for the merged report" (set! name _name)]
-                #:args (outdir . dirs)
-                (apply merge-reports outdir name dirs)
+  (command-line #:args (outdir . dirs)
                 (apply merge-timelines outdir dirs)
                 (apply merge-profiles outdir dirs)
                 (copy-file (web-resource "report.js") (build-path outdir "report.js") #t)

--- a/infra/merge.rkt
+++ b/infra/merge.rkt
@@ -54,6 +54,7 @@
 
 (module+ main
   (command-line #:args (outdir . dirs)
+                (apply merge-reports outdir dirs)
                 (apply merge-timelines outdir dirs)
                 (apply merge-profiles outdir dirs)
                 (copy-file (web-resource "report.js") (build-path outdir "report.js") #t)

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -8,23 +8,23 @@ SEED=$(date "+%Y%j")
 BENCHDIR="$1"; shift
 REPORTDIR="$1"; shift
 
-mkdir -p reports
+mkdir -p "$REPORTDIR"
 rm -rf "reports"/* || echo "nothing to delete"
 
 # run
 dirs=""
-for bench in bench/*; do
+for bench in "$BENCHDIR"/*; do
   name=$(basename "$bench" .fpcore)
-  rm -rf "reports/$name"
+  rm -rf "$REPORTDIR"/"$name"
 
   racket -y "src/main.rkt" report \
          --seed "$SEED" \
          "$@" \
-         "$bench" "reports/$name"
+         "$bench" "$REPORTDIR"/"$name"
   
   dirs="$dirs $name";
 done
 
 # merge reports
-racket -y infra/merge.rkt --name "$(basename bench .fpcore)" "reports" $dirs
+racket -y infra/merge.rkt "$REPORTDIR" $dirs
 

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -18,7 +18,6 @@ for bench in bench/*; do
   rm -rf "reports/$name"
 
   racket -y "src/main.rkt" report \
-         --note "$name" \
          --seed "$SEED" \
          "$@" \
          "$bench" "reports/$name"

--- a/infra/regression-chart.js
+++ b/infra/regression-chart.js
@@ -9,7 +9,6 @@ precision_step = 8;
 
 key = undefined;
 used_branch = {};
-used_tag = {};
 
 function get_point(tr) {
     var tests = tr.children[4].textContent.split("/");
@@ -17,11 +16,7 @@ function get_point(tr) {
     var flags = tr.children[3].getAttribute("title");
     flags = flags !== "" ? flags.split(" ") : [];
 
-    var note = tr.getElementsByClassName("note")[0];
-    var trtag = note && note.textContent;
-    
     return {
-        tag: trtag,
         tests: { got: +tests[0], total: +tests[1]},
         bits: { got: +bits[0], total: +bits[1] },
         branch: tr.children[2].textContent,
@@ -36,7 +31,6 @@ function get_data(table) {
     var data = Array.prototype.slice.call(table.querySelectorAll("tbody tr")).map(get_point);
     data.forEach(function(pt) {
         if (pt.tag && pt.branch) used_branch[pt.branch] = (used_branch[pt.branch] || 0) + 1;
-        if (pt.tag) used_tag[pt.tag] = (used_tag[pt.tag] || 0) + 1;
     });
     data.sort(function(a,b) {return a.time - b.time});
     return data;
@@ -168,27 +162,26 @@ function make_speed_graph(node, data) {
 
 }
 
-function select_data(data, options, tag) {
+function select_data(data, options) {
     return data = DATA.filter(function(x) {
         var out = true;
         for (var flag in options) {
             out = out && (x.flags.indexOf(flag) !== -1) == OPTIONS[flag];
         }
-        return out && x.tag == tag;
+        return out;
     });
 }
 
-function render(node1, node2, data, options, tag) {
+function render(node1, node2, data, options) {
     node1.selectAll("*").remove();
     node2.selectAll("*").remove();
     // Update classes
     var olds = Array.prototype.slice.call(document.getElementsByClassName("selected"));
     olds.forEach(function(old) { old.classList.remove("selected") })
-    document.getElementById("suite-" + tag).classList.add("selected");
     for (var flag in options) {
         if (options[flag]) document.getElementById("flag-" + flag).classList.add("selected");
     }
-    var data = select_data(data, options, tag);
+    var data = select_data(data, options);
     make_accuracy_graph(node1, data, "bits");
     make_speed_graph(node2, data);
 }
@@ -196,40 +189,15 @@ function render(node1, node2, data, options, tag) {
 function draw_results(node1, node2) {
     DATA = get_data(document.getElementById("reports"));
     OPTIONS = {"rules:numerics": true};
-    TAG = null;
     NODE1 = node1;
     NODE2 = node2;
-
-    function toggle_tag(tag) {
-        return function(evt) {
-            TAG = tag;
-            render(NODE1, NODE2, DATA, OPTIONS, TAG);
-        }
-    }
 
     function toggle_flag(flag) {
         return function(evt) {
             OPTIONS[flag] = !OPTIONS[flag];
-            render(NODE1, NODE2, DATA, OPTIONS, TAG);
+            render(NODE1, NODE2, DATA, OPTIONS);
         }
     }
-
-    var best_type = null;
-    var type_list = document.getElementById("suites");
-    for (var type in used_tag) {
-        if (!type) continue;
-        if ((!best_type || used_tag[type] > used_tag[best_type]) && type !== "tutorial") best_type = type;
-        var li = document.createElement("li");
-        var a = document.createElement("a");
-        a.href = "#" + type;
-        a.textContent = type;
-        a.addEventListener("click", toggle_tag(type));
-        li.id = "suite-" + type;
-        li.appendChild(a);
-        type_list.appendChild(li)
-    }
-    TAG = best_type;
-    if (!TAG) return;
 
     var flag_list = document.getElementById("classes");
     for (var flag in OPTIONS) {
@@ -251,7 +219,7 @@ function draw_results(node1, node2) {
     }
     key = d3.scale.category20().domain(branches);
 
-    render(NODE1, NODE2, DATA, OPTIONS, TAG);
+    render(NODE1, NODE2, DATA, OPTIONS);
 
     var branches = [];
     var toclinks = document.getElementById("toc").querySelectorAll("li a");

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -37,11 +37,11 @@
   #:prefab)
 
 (struct report-info
-        (date commit branch hostname seed flags points iterations note tests merged-cost-accuracy)
+        (date commit branch hostname seed flags points iterations tests merged-cost-accuracy)
   #:prefab
   #:mutable)
 
-(define (make-report-info tests #:note [note ""] #:seed [seed #f])
+(define (make-report-info tests #:seed [seed #f])
   (report-info (current-date)
                *herbie-commit*
                *herbie-branch*
@@ -50,7 +50,6 @@
                (*flags*)
                (*num-points*)
                (*num-iterations*)
-               note
                tests
                (merged-cost-accuracy tests)))
 
@@ -163,7 +162,6 @@
                     flags
                     points
                     iterations
-                    note
                     tests
                     merged-cost-accuracy)
        (make-hash `((date . ,(date->seconds date)) (commit . ,commit)
@@ -173,7 +171,6 @@
                                                    (flags . ,(flags->list flags))
                                                    (points . ,points)
                                                    (iterations . ,iterations)
-                                                   (note . ,note)
                                                    (tests . ,(map simplify-test tests))
                                                    (merged-cost-accuracy . ,merged-cost-accuracy)))]))
 
@@ -209,7 +206,6 @@
                  (list->flags (get 'flags))
                  (get 'points)
                  (get 'iterations)
-                 (hash-ref json 'note #f)
                  (for/list ([test (get 'tests)]
                             #:when (hash-has-key? test 'vars))
                    (let ([get (λ (field) (hash-ref test field))])
@@ -256,7 +252,7 @@
 (define (unique? a)
   (or (null? a) (andmap (curry equal? (car a)) (cdr a))))
 
-(define (merge-datafiles dfs #:dirs [dirs #f] #:name [name #f])
+(define (merge-datafiles dfs #:dirs [dirs #f])
   (when (null? dfs)
     (error 'merge-datafiles "Cannot merge no datafiles"))
   (for ([f (in-list (list report-info-commit
@@ -288,9 +284,6 @@
                (report-info-flags (first dfs))
                (report-info-points (first dfs))
                (report-info-iterations (first dfs))
-               (if name
-                   (~a name)
-                   (~a (cons 'merged (map report-info-note dfs))))
                tests
                ;; Easiest to just recompute everything based off the combined tests
                (merged-cost-accuracy tests)))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -106,10 +106,7 @@
     [(and (*demo-output*) (file-exists? (build-path (*demo-output*) "results.json")))
      (next-dispatcher)]
     [else
-     (define info
-       (make-report-info (get-improve-table-data)
-                         #:seed (get-seed)
-                         #:note (if (*demo?*) "Web demo results" "Herbie results")))
+     (define info (make-report-info (get-improve-table-data) #:seed (get-seed)))
      (response 200
                #"OK"
                (current-seconds)

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -88,23 +88,18 @@
     (make-directory dir))
 
   (start-job-server threads)
-  (define-values (job-ids bench-names)
-    (for/lists
-     (l1 l2)
-     ([test (in-list tests)])
-     (values
+  (define job-ids
+    (for/list ([test (in-list tests)])
       (start-job
-       (create-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f))
-      (test-name test))))
+       (create-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f))))
 
-  (define info
-    (make-report-info (for/list ([job-id job-ids]
-                                 [bench-name bench-names]
-                                 [test-number (in-naturals 0)])
-                        (generate-bench-report job-id bench-name test-number dir (length tests)))
-                      #:seed seed
-                      #:note note))
+  (define results
+    (for/list ([job-id (in-list job-ids)]
+               [test (in-list tests)]
+               [test-number (in-naturals)])
+      (generate-bench-report job-id (test-name test) test-number dir (length tests))))
 
+  (define info (make-report-info results #:seed seed #:note note))
   (write-datafile (build-path dir "results.json") info)
   (copy-file (web-resource "report-page.js") (build-path dir "report-page.js") #t)
   (copy-file (web-resource "report.js") (build-path dir "report.js") #t)

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -36,18 +36,18 @@
           (cons k (representation-name v)))
         (table-row-conversions row)))
 
-(define (make-report bench-dirs #:dir dir #:note note #:threads threads)
+(define (make-report bench-dirs #:dir dir #:threads threads)
   (define tests (reverse (sort (append-map load-tests bench-dirs) test<?)))
-  (run-tests tests #:dir dir #:note note #:threads threads))
+  (run-tests tests #:dir dir #:threads threads))
 
-(define (rerun-report json-file #:dir dir #:note note #:threads threads)
+(define (rerun-report json-file #:dir dir #:threads threads)
   (define data (call-with-input-file json-file read-datafile))
   (define tests (map extract-test (report-info-tests data)))
   (*flags* (report-info-flags data))
   (set-seed! (report-info-seed data))
   (*num-points* (report-info-points data))
   (*num-iterations* (report-info-iterations data))
-  (run-tests tests #:dir dir #:note note #:threads threads))
+  (run-tests tests #:dir dir #:threads threads))
 
 (define (read-json-files info dir name)
   (filter identity
@@ -82,7 +82,7 @@
   (print-test-result (+ test-number 1) number-of-test table-data)
   table-data)
 
-(define (run-tests tests #:dir dir #:note note #:threads threads)
+(define (run-tests tests #:dir dir #:threads threads)
   (define seed (get-seed))
   (unless (directory-exists? dir)
     (make-directory dir))
@@ -99,7 +99,7 @@
                [test-number (in-naturals)])
       (generate-bench-report job-id (test-name test) test-number dir (length tests))))
 
-  (define info (make-report-info results #:seed seed #:note note))
+  (define info (make-report-info results #:seed seed))
   (write-datafile (build-path dir "results.json") info)
   (copy-file (web-resource "report-page.js") (build-path dir "report-page.js") #t)
   (copy-file (web-resource "report.js") (build-path dir "report.js") #t)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -71,7 +71,7 @@
     (if (file-exists? data-file)
         (let ([info (call-with-input-file data-file read-datafile)])
           (struct-copy report-info info [tests (cons data (report-info-tests info))]))
-        (make-report-info (list data) #:seed (get-seed) #:note (if (*demo?*) "Web demo results" ""))))
+        (make-report-info (list data) #:seed (get-seed))))
   (define tmp-file (build-path (*demo-output*) "results.tmp"))
   (write-datafile tmp-file info)
   (rename-file-or-directory tmp-file data-file #t)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -110,6 +110,7 @@
      this feature forces Herbie to extract a single, most-accurate output expression."
      "[Default: Pareto-Herbie enabled]")
     (*pareto-mode* #f)]
+   [("--profile") "Whether to profile each run (no-op, always on)" (void)]
    #:multi [("--plugin")
             path
             ("Path to a Herbie plugin." "Allows for dynamic loading of \"loose\" plugins.")
@@ -173,7 +174,6 @@
      num
      "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
-    [("--profile") "Whether to profile each run (no-op, always on)" (void)]
     #:args (input output)
     (make-report (list input) #:dir output #:note report-note #:threads threads)]
    [reproduce
@@ -183,7 +183,6 @@
      num
      "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
-    [("--profile") "Whether to profile each run (no-op, always on)" (void)]
     #:args (input output)
     (rerun-report input #:dir output #:note report-note #:threads threads)]
    #:args files

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -84,7 +84,6 @@
     (*platform-name* (string->symbol platform))
     (*active-platform* (get-platform (*platform-name*)))
     (activate-platform! (*active-platform*))]
-
    [("--num-iters")
     num
     ("The number of iterations to use for the main loop. Herbie may find additional improvements
@@ -109,7 +108,6 @@
      during sampling. May fix \"Cannot sample enough valid points\" but will slow."
      (format "[Default: ~a iterations]" (*max-find-range-depth*)))
     (*max-find-range-depth* (string->number num))]
-
    [("--no-pareto")
     ("Disables Pareto-Herbie (Pherbie). Pareto-mode performs accuracy and expression cost
      optimization and extracts multiple output expressions that are Pareto-optimal. Disabling

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -57,7 +57,6 @@
 
   (define threads #f)
   (define report-note #f)
-  (define timeout-set? #f)
 
   (define seed (random 1 (expt 2 31)))
   (set-seed! seed)
@@ -69,7 +68,6 @@
    [("--timeout")
     s
     ("Timeout for each test (in seconds)." (format "[Default: ~a seconds]" (/ (*timeout*) 1000)))
-    (set! timeout-set? #t)
     (*timeout* (* 1000 (string->number s)))]
    [("--seed")
     int

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -29,7 +29,7 @@
      (and (dict-has-key? all-flags category)
           (set-member? (dict-ref all-flags category) flag)
           (list category flag))]
-    [_ #f]))
+    [_ (raise-herbie-error "Invalid flag `~a`" s #:url "options.html")]))
 
 (define (default-flags->table)
   (list* (format "~a | ~a | ~a"
@@ -122,10 +122,7 @@
     flag
     ("Disable a search flag (formatted category:name)."
      "See `+o/--enable` for the full list of search flags.")
-    (define tf (string->flag flag))
-    (when (not tf)
-      (raise-herbie-error "Invalid flag ~a" flag #:url "options.html"))
-    (apply disable-flag! tf)]
+    (apply disable-flag! (string->flag flag))]
    [("+o" "--enable")
     flag
     ("Enable a search flag (formatted category:name)."
@@ -134,10 +131,7 @@
      (apply string-append
             "\n" ;; 5 spaces is the padding inserted by `command-line`
             (map (curry format "     ~a\n") (default-flags->table))))
-    (define tf (string->flag flag))
-    (when (not tf)
-      (raise-herbie-error "Invalid flag ~a" flag #:url "options.html"))
-    (apply enable-flag! tf)]
+    (apply enable-flag! (string->flag flag))]
    #:subcommands [shell "Interact with Herbie from the shell" #:args () (run-shell)]
    [web
     "Interact with Herbie from your browser"

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -176,7 +176,7 @@
      num
      "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
-    [("--profile") "Whether to profile each run" (void)]
+    [("--profile") "Whether to profile each run (no-op, always on)" (void)]
     #:args (input output)
     (make-report (list input) #:dir output #:note report-note #:threads threads)]
    [reproduce
@@ -186,7 +186,7 @@
      num
      "How many tests to run in parallel: 'yes', 'no', or a number"
      (set! threads (string->thread-count num))]
-    [("--profile") "Whether to profile each run" (void)]
+    [("--profile") "Whether to profile each run (no-op, always on)" (void)]
     #:args (input output)
     (rerun-report input #:dir output #:note report-note #:threads threads)]
    #:args files

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -56,8 +56,6 @@
   (define demo-public #f)
 
   (define threads #f)
-  (define report-note #f)
-
   (set-seed! (random 1 (expt 2 31)))
 
   (multi-command-line
@@ -165,14 +163,12 @@
     (run-improve input output #:threads threads)]
    [report
     "Run Herbie on an FPCore file, producing an HTML report"
-    #:once-each [("--note") note "Add a note for this run" (set! report-note note)]
     #:args (input output)
-    (make-report (list input) #:dir output #:note report-note #:threads threads)]
+    (make-report (list input) #:dir output #:threads threads)]
    [reproduce
     "Rerun an HTML report"
-    #:once-each [("--note") note "Add a note for this run" (set! report-note note)]
     #:args (input output)
-    (rerun-report input #:dir output #:note report-note #:threads threads)]
+    (rerun-report input #:dir output #:threads threads)]
    #:args files
    (match files
      ['()

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -192,8 +192,9 @@
    #:args files
    (match files
      ['()
-      (eprintf "Please specify a Herbie tool, such as `herbie web`.\n")
-      (eprintf "See <https://herbie.uwplse.org/doc/~a/options.html> for more.\n" *herbie-version*)]
+      (raise-herbie-error "Please specify a Herbie tool like `racket -l herbie web`"
+                          #:url "options.html")]
      [(cons tool _)
-      (eprintf "Unknown Herbie tool `~a`. See a list of available tools with `herbie --help`.\n" tool)
-      (eprintf "See <https://herbie.uwplse.org/doc/~a/options.html> for more.\n" *herbie-version*)])))
+      (raise-herbie-error "Unknown tool `~a`. List available tools with `racket -l herbie -- --help`"
+                          tool
+                          #:url "options.html")])))

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -58,8 +58,7 @@
   (define threads #f)
   (define report-note #f)
 
-  (define seed (random 1 (expt 2 31)))
-  (set-seed! seed)
+  (set-seed! (random 1 (expt 2 31)))
 
   (multi-command-line
    #:program "herbie"

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -74,12 +74,17 @@
     (define given-seed (read (open-input-string int)))
     (when given-seed
       (set-seed! given-seed))]
+   [("--threads")
+    num
+    "How many jobs to run in parallel: Processor count is the default."
+    (set! threads (string->thread-count num))]
    [("--platform")
     platform
     ("The platform to use during improvement" "[Default: default]")
     (*platform-name* (string->symbol platform))
     (*active-platform* (get-platform (*platform-name*)))
     (activate-platform! (*active-platform*))]
+
    [("--num-iters")
     num
     ("The number of iterations to use for the main loop. Herbie may find additional improvements
@@ -104,6 +109,7 @@
      during sampling. May fix \"Cannot sample enough valid points\" but will slow."
      (format "[Default: ~a iterations]" (*max-find-range-depth*)))
     (*max-find-range-depth* (string->number num))]
+
    [("--no-pareto")
     ("Disables Pareto-Herbie (Pherbie). Pareto-mode performs accuracy and expression cost
      optimization and extracts multiple output expressions that are Pareto-optimal. Disabling
@@ -144,10 +150,6 @@
     [("--prefix") prefix "Prefix for proxying demo" (set! demo-prefix prefix)]
     [("--demo") "Run in Herbie web demo mode. Changes some text" (set! demo? true)]
     [("--quiet") "Print a smaller banner and don't start a browser." (set! quiet? true)]
-    [("--threads")
-     num
-     "How many jobs to run in parallel: Processor count is the default."
-     (set! threads (string->thread-count num))]
     [("--no-browser") "Run the web demo but don't start a browser." (set! browser? #f)]
     #:args ()
     (run-demo #:quiet quiet?
@@ -161,28 +163,16 @@
               #:public? demo-public)]
    [improve
     "Run Herbie on an FPCore file, producing an FPCore file"
-    #:once-each [("--threads")
-                 num
-                 "How many tests to run in parallel: 'yes', 'no', or a number"
-                 (set! threads (string->thread-count num))]
     #:args (input output)
     (run-improve input output #:threads threads)]
    [report
     "Run Herbie on an FPCore file, producing an HTML report"
     #:once-each [("--note") note "Add a note for this run" (set! report-note note)]
-    [("--threads")
-     num
-     "How many tests to run in parallel: 'yes', 'no', or a number"
-     (set! threads (string->thread-count num))]
     #:args (input output)
     (make-report (list input) #:dir output #:note report-note #:threads threads)]
    [reproduce
     "Rerun an HTML report"
     #:once-each [("--note") note "Add a note for this run" (set! report-note note)]
-    [("--threads")
-     num
-     "How many tests to run in parallel: 'yes', 'no', or a number"
-     (set! threads (string->thread-count num))]
     #:args (input output)
     (rerun-report input #:dir output #:note report-note #:threads threads)]
    #:args files

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -20,10 +20,8 @@
   (match th
     ["no" #f]
     ["yes" (max (- (processor-count) 1) 1)]
-    [else
-     (match (string->number th)
-       [(? positive-integer? x) x]
-       [else (error 'string->thread-count "invalid thread count ~a" th)])]))
+    [(app string->number (? positive-integer? x)) x]
+    [_ (raise-herbie-error "Invalid thread count `~a`" th #:url "options.html")]))
 
 (define (string->flag s)
   (match (string-split s ":")

--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -383,7 +383,7 @@ function buildBody(jsonData, otherJsonData) {
     ])
 
     const header = Element("header", {}, [
-        Element("h1", {}, toTitleCase(jsonData.note || "") + " Results"),
+        Element("h1", {}, "Herbie Results"),
         Element("img", { src: "logo-car.png" }, []),
         Element("nav", {}, [
             Element("ul", {}, [Element("li", {}, [Element("a", { href: "timeline.html" }, ["Metrics"])])])

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -547,7 +547,6 @@
                              flags
                              points
                              iterations
-                             note
                              tests
                              merged-cost-accuracy)
     info)


### PR DESCRIPTION
This PR makes a surprisingly large number of small cleanups to `main.rkt`. The most important ones move `--profile` (which is a no-op) and `--threads` (which every command except `shell` uses) into the global flags section. This means that only the `web` tool has special flags, which makes documentation a bit easier, too. Besides that there's some improvement to error handling and some general reduction in code.

Some additional improvements I'd like to do but might not do in this PR:
- [x] Remove the `--note` feature entirely; it seems to be entirely cosmetic and very very obsolete, though perhaps there's something in `infra/make-index.rkt` that uses it for something real. I've removed it from nightlies (probably its only user) to test if anything breaks.
- [ ] Make `*threads*` a global variable instead of being passed around everywhere as an argument.