### PR TITLE
Merge `create-job` and `start-job`

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -318,13 +318,12 @@
          (raise-herbie-error "no formula specified"))
        (define test (parse-test formula))
        (define job-id
-         (start-job
-          (create-job 'improve
-                      test
-                      #:seed (get-seed)
-                      #:pcontext #f
-                      #:profile? #f
-                      #:timeline-disabled? #f)))
+         (start-job 'improve
+                    test
+                    #:seed (get-seed)
+                    #:pcontext #f
+                    #:profile? #f
+                    #:timeline-disabled? #f))
        (body job-id))]
     [_
      (response/error "Demo Error"
@@ -431,10 +430,8 @@
  ([sample-endpoint start-sample-endpoint] post-data)
  (define test (get-test post-data))
  (define seed (parse-seed post-data))
-  (start-job
-   (create-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t)))
+ (start-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t))
 
-; (create-job 'explanations (get-test post-data) #:seed (get-seed post-data) #:pcontext (get-pcontext post-data) #:profile? #f #:timeline-disabled? #t)
 (define (get-test post-data)
   (define formula-str (hash-ref post-data 'formula))
   (define formula (read-syntax 'web (open-input-string formula-str)))
@@ -450,68 +447,57 @@
   (json->pcontext sample (test-context test)))
 
 (define-endpoint ([explanations-endpoint start-explanations-endpoint] post-data)
-  (start-job
-   (create-job 'explanations
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'explanations
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
 (define-endpoint ([analyze-endpoint start-analyze-endpoint] post-data)
-  (start-job
-                 (create-job 'errors
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'errors
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
 ;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
 (define-endpoint ([exacts-endpoint start-exacts-endpoint] post-data)
-  (start-job
-                 (create-job 'exacts
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'exacts
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
 (define-endpoint ([calculate-endpoint start-calculate-endpoint] post-data)
-  (start-job
-                 (create-job 'evaluate
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'evaluate
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
 (define-endpoint ([local-error-endpoint start-local-error-endpoint] post-data)
-  (start-job
-                 (create-job 'local-error
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'local-error
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
 (define-endpoint ([alternatives-endpoint start-alternatives-endpoint] post-data)
-  (start-job
-                 (create-job 'alternatives
-                             (get-test post-data)
-                             #:seed (parse-seed post-data)
-                             #:pcontext (get-pcontext post-data)
-                             #:profile? #f
-                             #:timeline-disabled? #t)))
+                 (start-job 'alternatives
+                            (get-test post-data)
+                            #:seed (parse-seed post-data)
+                            #:pcontext (get-pcontext post-data)
+                            #:profile? #f
+                            #:timeline-disabled? #t))
 
-(define-endpoint ([cost-endpoint start-cost-endpoint] post-data)
-  (start-job
-                 (create-job 'cost
-                             (get-test post-data)
-                             #:seed #f
-                             #:pcontext #f
-                             #:profile? #f
-                             #:timeline-disabled? #f)))
+(define-endpoint
+ ([cost-endpoint start-cost-endpoint] post-data)
+ (start-job 'cost (get-test post-data) #:seed #f #:pcontext #f #:profile? #f #:timeline-disabled? #f))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -317,14 +317,15 @@
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
        (define test (parse-test formula))
-       (define command
-         (create-job 'improve
-                     test
-                     #:seed (get-seed)
-                     #:pcontext #f
-                     #:profile? #f
-                     #:timeline-disabled? #f))
-       (body command))]
+       (define job-id
+         (start-job
+          (create-job 'improve
+                      test
+                      #:seed (get-seed)
+                      #:pcontext #f
+                      #:profile? #f
+                      #:timeline-disabled? #f)))
+       (body job-id))]
     [_
      (response/error "Demo Error"
                      `(p "You didn't specify a formula (or you specified several). "
@@ -335,8 +336,7 @@
 (define (improve-start req)
   (improve-common
    req
-   (λ (command)
-     (define job-id (start-job command))
+   (λ (job-id)
      (response/full 201
                     #"Job started"
                     (current-seconds)
@@ -384,8 +384,7 @@
 
 (define (improve req)
   (improve-common req
-                  (λ (command)
-                    (define job-id (start-job command))
+                  (λ (job-id)
                     (wait-for-job job-id)
                     (redirect-to (add-prefix (format "~a.~a/graph.html" job-id *herbie-commit*))
                                  see-other))
@@ -419,11 +418,11 @@
       body ...)
     (define sync-name
       (post-with-json-response (lambda (post-data)
-                                 (define job-id (start-job (function post-data)))
+                                 (define job-id (function post-data))
                                  (wait-for-job job-id))))
     (define async-name
       (post-with-json-response (lambda (post-data)
-                                 (define job-id (start-job (function post-data)))
+                                 (define job-id (function post-data))
                                  (hasheq 'job job-id 'path (make-path job-id)))))))
 
 ; /api/sample endpoint: test in console on demo page:
@@ -432,7 +431,8 @@
  ([sample-endpoint start-sample-endpoint] post-data)
  (define test (get-test post-data))
  (define seed (parse-seed post-data))
- (create-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+  (start-job
+   (create-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t)))
 
 ; (create-job 'explanations (get-test post-data) #:seed (get-seed post-data) #:pcontext (get-pcontext post-data) #:profile? #f #:timeline-disabled? #t)
 (define (get-test post-data)
@@ -450,61 +450,68 @@
   (json->pcontext sample (test-context test)))
 
 (define-endpoint ([explanations-endpoint start-explanations-endpoint] post-data)
-                 (create-job 'explanations
+  (start-job
+   (create-job 'explanations
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 (define-endpoint ([analyze-endpoint start-analyze-endpoint] post-data)
+  (start-job
                  (create-job 'errors
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 ;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
 (define-endpoint ([exacts-endpoint start-exacts-endpoint] post-data)
+  (start-job
                  (create-job 'exacts
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 (define-endpoint ([calculate-endpoint start-calculate-endpoint] post-data)
+  (start-job
                  (create-job 'evaluate
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 (define-endpoint ([local-error-endpoint start-local-error-endpoint] post-data)
+  (start-job
                  (create-job 'local-error
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 (define-endpoint ([alternatives-endpoint start-alternatives-endpoint] post-data)
+  (start-job
                  (create-job 'alternatives
                              (get-test post-data)
                              #:seed (parse-seed post-data)
                              #:pcontext (get-pcontext post-data)
                              #:profile? #f
-                             #:timeline-disabled? #t))
+                             #:timeline-disabled? #t)))
 
 (define-endpoint ([cost-endpoint start-cost-endpoint] post-data)
+  (start-job
                  (create-job 'cost
                              (get-test post-data)
                              #:seed #f
                              #:pcontext #f
                              #:profile? #f
-                             #:timeline-disabled? #f))
+                             #:timeline-disabled? #f)))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/improve.rkt
+++ b/src/api/improve.rkt
@@ -36,8 +36,7 @@
   (start-job-server threads)
   (define ids
     (for/list ([test (in-list tests)])
-      (start-job
-        (create-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f))))
+      (start-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f)))
   (define results
     (for/list ([id ids])
       (get-table-data-from-hash (wait-for-job id) "")))

--- a/src/api/improve.rkt
+++ b/src/api/improve.rkt
@@ -36,9 +36,8 @@
   (start-job-server threads)
   (define ids
     (for/list ([test (in-list tests)])
-      (define command
-        (create-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f))
-      (start-job command)))
+      (start-job
+        (create-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f))))
   (define results
     (for/list ([id ids])
       (get-table-data-from-hash (wait-for-job id) "")))

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -92,10 +92,8 @@
     (for/lists
      (l1 l2)
      ([test (in-list tests)])
-     (values
-      (start-job
-       (create-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f))
-      (test-name test))))
+     (values (start-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f)
+             (test-name test))))
 
   (define info
     (make-report-info (for/list ([job-id job-ids]


### PR DESCRIPTION
Every single call to `create-job` immediately passes the created command to `start-job`, so this PR merges the two.