### PR TITLE
Remove the `hostname` global in Herbie

### DIFF
--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -40,7 +40,7 @@
 
 (define key-contracts
   (hash string?
-        '(date-full date-short folder commit branch hostname)
+        '(date-full date-short folder commit branch)
         exact-nonnegative-integer?
         '(date-unix tests-passed tests-available tests-crashed)
         (listof string?)
@@ -77,7 +77,6 @@
   (match-define (report-info date
                              commit
                              branch
-                             hostname
                              seed
                              flags
                              points
@@ -114,8 +113,6 @@
         speed
         'folder
         (path->string folder)
-        'hostname
-        hostname
         'commit
         commit
         'branch
@@ -175,9 +172,8 @@
                                      (round* (field 'bits-available)))
                              ""))
                     (td ([title
-                          ,(format "At ~a\nOn ~a\nFlags ~a"
+                          ,(format "At ~a\nFlags ~a"
                                    (field 'date-full)
-                                   (field 'hostname)
                                    (string-join (field 'options) " "))])
                         (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
 

--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -153,29 +153,27 @@
            (th "Collection")
            (th "Tests")
            (th "Bits"))
-    (tbody ,@(for/list ([info infos])
-               (define field (curry dict-ref info))
+    (tbody
+     ,@
+     (for/list ([info infos])
+       (define field (curry dict-ref info))
 
-               `(tr ((class ,(if (bad-result? info) "crash" "")))
-                    ;; TODO: Best to output a datetime field in RFC3338 format,
-                    ;; but Racket doesn't make that easy.
-                    (td ([title ,(field 'date-full)])
-                        (time ([data-unix ,(~a (field 'date-unix))]) ,(field 'date-short)))
-                    (td (time ([data-ms ,(~a (field 'speed))]) ,(format-time (field 'speed))))
-                    (td ([title ,(field 'commit)]) ,(field 'branch))
-                    (td ,(if (> (field 'tests-available) 0)
-                             (format "~a/~a" (field 'tests-passed) (field 'tests-available))
-                             ""))
-                    (td ,(if (field 'bits-improved)
-                             (format "~a/~a"
-                                     (round* (field 'bits-improved))
-                                     (round* (field 'bits-available)))
-                             ""))
-                    (td ([title
-                          ,(format "At ~a\nFlags ~a"
-                                   (field 'date-full)
-                                   (string-join (field 'options) " "))])
-                        (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
+       `(tr ((class ,(if (bad-result? info) "crash" "")))
+            ;; TODO: Best to output a datetime field in RFC3338 format,
+            ;; but Racket doesn't make that easy.
+            (td ([title ,(field 'date-full)])
+                (time ([data-unix ,(~a (field 'date-unix))]) ,(field 'date-short)))
+            (td (time ([data-ms ,(~a (field 'speed))]) ,(format-time (field 'speed))))
+            (td ([title ,(field 'commit)]) ,(field 'branch))
+            (td ,(if (> (field 'tests-available) 0)
+                     (format "~a/~a" (field 'tests-passed) (field 'tests-available))
+                     ""))
+            (td ,(if (field 'bits-improved)
+                     (format "~a/~a" (round* (field 'bits-improved)) (round* (field 'bits-available)))
+                     ""))
+            (td ([title
+                  ,(format "At ~a\nFlags ~a" (field 'date-full) (string-join (field 'options) " "))])
+                (a ([href ,(format "./~a/index.html" (field 'folder))]) "»")))))))
 
 (define (make-index-page folders out)
   (define branch-infos

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -36,8 +36,7 @@
               cost-accuracy)
   #:prefab)
 
-(struct report-info
-        (date commit branch seed flags points iterations tests merged-cost-accuracy)
+(struct report-info (date commit branch seed flags points iterations tests merged-cost-accuracy)
   #:prefab
   #:mutable)
 
@@ -153,15 +152,7 @@
 
   (define data
     (match info
-      [(report-info date
-                    commit
-                    branch
-                    seed
-                    flags
-                    points
-                    iterations
-                    tests
-                    merged-cost-accuracy)
+      [(report-info date commit branch seed flags points iterations tests merged-cost-accuracy)
        (make-hash `((date . ,(date->seconds date)) (commit . ,commit)
                                                    (branch . ,branch)
                                                    (seed . ,(~a seed))

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -37,7 +37,7 @@
   #:prefab)
 
 (struct report-info
-        (date commit branch hostname seed flags points iterations tests merged-cost-accuracy)
+        (date commit branch seed flags points iterations tests merged-cost-accuracy)
   #:prefab
   #:mutable)
 
@@ -45,7 +45,6 @@
   (report-info (current-date)
                *herbie-commit*
                *herbie-branch*
-               *hostname*
                (or seed (get-seed))
                (*flags*)
                (*num-points*)
@@ -157,7 +156,6 @@
       [(report-info date
                     commit
                     branch
-                    hostname
                     seed
                     flags
                     points
@@ -166,7 +164,6 @@
                     merged-cost-accuracy)
        (make-hash `((date . ,(date->seconds date)) (commit . ,commit)
                                                    (branch . ,branch)
-                                                   (hostname . ,hostname)
                                                    (seed . ,(~a seed))
                                                    (flags . ,(flags->list flags))
                                                    (points . ,points)
@@ -201,7 +198,6 @@
     (report-info (seconds->date (get 'date))
                  (get 'commit)
                  (get 'branch)
-                 (hash-ref json 'hostname "")
                  (parse-string (get 'seed))
                  (list->flags (get 'flags))
                  (get 'points)
@@ -256,7 +252,6 @@
   (when (null? dfs)
     (error 'merge-datafiles "Cannot merge no datafiles"))
   (for ([f (in-list (list report-info-commit
-                          report-info-hostname
                           report-info-seed
                           report-info-flags
                           report-info-points
@@ -279,7 +274,6 @@
   (report-info (last (sort (map report-info-date dfs) < #:key date->seconds))
                (report-info-commit (first dfs))
                (first (filter values (map report-info-branch dfs)))
-               (report-info-hostname (first dfs))
                (report-info-seed (first dfs))
                (report-info-flags (first dfs))
                (report-info-points (first dfs))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -167,8 +167,6 @@
 
 (define *herbie-version* "2.2")
 
-(define *hostname* (run-command "hostname"))
-
 (define *herbie-commit* (git-command "rev-parse" "HEAD" #:default *herbie-version*))
 
 (define *herbie-branch* (git-command "rev-parse" "--abbrev-ref" "HEAD" #:default "release"))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -134,9 +134,6 @@
 (define *pareto-mode* (make-parameter #t))
 (define *pareto-pick-limit* (make-parameter 5))
 
-;; In mainloop, cache improvements between iterations
-(define *use-improve-cache* (make-parameter #t))
-
 ;; If `:precision` is unspecified, which representation should we use?
 (define *default-precision* (make-parameter 'binary64))
 

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -542,7 +542,6 @@
   (match-define (report-info date
                              commit
                              branch
-                             hostname
                              seed
                              flags
                              points
@@ -559,7 +558,6 @@
                            (substring commit 0 8)))
                   " on "
                   ,branch))
-          (tr (th "Hostname:") (td ,hostname " with Racket " ,(version)))
           (tr (th "Seed:") (td ,(~a seed)))
           (tr (th "Parameters:")
               (td ,(~a (*num-points*)) " points for " ,(~a (*num-iterations*)) " iterations"))


### PR DESCRIPTION
It turns out that Herbie, on startup, always ran the `hostname` command, which it then inserted into reports but otherwise never used. I think this is low-value, and very hypothetically a privacy issue, and it slows down boot, basically no reason to deal with this.