### PR TITLE
Rename `simplify` to `reduce` in `reduce.rkt`

### DIFF
--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -3,15 +3,15 @@
 (require "../utils/common.rkt"
          "programs.rkt"
          "../syntax/syntax.rkt")
-(provide simplify)
+(provide reduce)
 
 ;; Cancellation's goal is to cancel (additively or multiplicatively) like terms.
 ;; It uses commutativity, identities, inverses, associativity,
 ;; distributativity, and function inverses.
 
-(define/reset simplify-cache (make-hash))
+(define/reset reduce-cache (make-hash))
 
-(define/reset simplify-node-cache (make-hash))
+(define/reset reduce-node-cache (make-hash))
 
 ;; This is a transcription of egg-herbie/src/math.rs, lines 97-149
 (define (eval-application op . args)
@@ -59,25 +59,25 @@
   (check-equal? (eval-application 'log 1) 0)
   (check-equal? (eval-application 'exp 2) #f)) ; Not exact
 
-(define (simplify expr)
-  (hash-ref! (simplify-cache) expr (λ () (simplify* expr))))
+(define (reduce expr)
+  (hash-ref! (reduce-cache) expr (λ () (reduce* expr))))
 
-(define (simplify* expr)
+(define (reduce* expr)
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
     ; conversion (e.g. posit16->f64)
-    [(list (? cast-impl? op) body) (list op (simplify body))]
+    [(list (? cast-impl? op) body) (list op (reduce body))]
     [`(,(and (or '+ '- '*) op) ,args ...) ; v-ary
-     (define args* (map simplify args))
+     (define args* (map reduce args))
      (define val (apply eval-application op args*))
-     (or val (simplify-node (list* op args*)))]
+     (or val (reduce-node (list* op args*)))]
     [`(,op ,args ...)
-     (define args* (map simplify args))
+     (define args* (map reduce args))
      (define val (apply eval-application op args*))
-     (or val (simplify-node (list* op args*)))]))
+     (or val (reduce-node (list* op args*)))]))
 
-(define (simplify-evaluation expr)
+(define (reduce-evaluation expr)
   (match expr
     ['(sin 0) 0]
     ['(cos 0) 1]
@@ -103,7 +103,7 @@
     ['(cos (/ (PI) 4)) '(/ (sqrt 2) 2)]
     [_ expr]))
 
-(define (simplify-inverses expr)
+(define (reduce-inverses expr)
   (match expr
     [`(tanh (atanh ,x)) x]
     [`(cosh (acosh ,x)) x]
@@ -121,19 +121,19 @@
     [`(pow (cbrt ,x) 3) x]
     [_ expr]))
 
-(define (simplify-node expr)
-  (hash-ref! (simplify-node-cache) expr (λ () (simplify-node* expr))))
+(define (reduce-node expr)
+  (hash-ref! (reduce-node-cache) expr (λ () (reduce-node* expr))))
 
-(define (simplify-node* expr)
-  (match (simplify-evaluation expr)
+(define (reduce-node* expr)
+  (match (reduce-evaluation expr)
     [(? number?) expr]
     [(? variable?) expr]
     [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))
      (make-addition-node (combine-aterms (gather-additive-terms expr)))]
     [(or `(* ,_ ...) `(/ ,_ ...) `(sqrt ,_) `(cbrt ,_) `(pow ,_ ,_))
      (make-multiplication-node (combine-mterms (gather-multiplicative-terms expr)))]
-    [`(exp (* ,c (log ,x))) (simplify-node* `(pow ,x ,c))]
-    [else (simplify-inverses expr)]))
+    [`(exp (* ,c (log ,x))) (reduce-node* `(pow ,x ,c))]
+    [else (reduce-inverses expr)]))
 
 (define (negate-term term)
   (cons (- (car term)) (cdr term)))
@@ -154,7 +154,7 @@
       [`(/ ,arg) `((1 ,expr))]
       [`(/ ,arg ,args ...)
        (for/list ([term (recurse arg)])
-         (list* (car term) (simplify-node (list* '/ (cadr term) args)) (cons label (cddr term))))]
+         (list* (car term) (reduce-node (list* '/ (cadr term) args)) (cons label (cddr term))))]
 
       [`(pow ,arg 1) `((1 1))]
       [else `((1 ,expr))])))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -475,8 +475,6 @@
 (define (logstep table)
   (lognormalize (loggenerate table)))
 
-(define logbiggest 1)
-
 (define (logcompute i)
   (hash-ref! (log-cache) i (λ () (logstep (logcompute (- i 1))))))
 


### PR DESCRIPTION
It's always been confusing that there are two things called `simplify`, now there aren't.