### PR TITLE
Cleanup derivations

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -9,20 +9,12 @@
 
 (provide add-derivations)
 
-(define (canonicalize-rewrite proof)
-  (match proof
-    [`(Rewrite=> ,rule ,something) (list 'Rewrite=> (get-canon-rule-name rule rule) something)]
-    [`(Rewrite<= ,rule ,something) (list 'Rewrite<= (get-canon-rule-name rule rule) something)]
-    [(list _ ...) (map canonicalize-rewrite proof)]
-    [_ proof]))
-
 (define (canonicalize-proof prog proof loc pcontext ctx)
-  (and
-   proof
-   ;; Proofs are actually on subexpressions,
-   ;; we need to construct the proof for the full expression
-   (for/list ([step (in-list proof)])
-     (location-do loc prog (const (canonicalize-rewrite step))))))
+  (and proof
+       ;; Proofs are actually on subexpressions,
+       ;; we need to construct the proof for the full expression
+       (for/list ([step (in-list proof)])
+         (location-do loc prog (const step)))))
 
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -17,15 +17,12 @@
     [_ proof]))
 
 (define (canonicalize-proof prog proof loc pcontext ctx)
-  (cond
-    [proof
-     ;; Proofs are actually on subexpressions,
-     ;; we need to construct the proof for the full expression
-     (define proof*
-       (for/list ([step (in-list proof)])
-         (location-do loc prog (const (canonicalize-rewrite step)))))
-     proof*]
-    [else #f]))
+  (and
+   proof
+   ;; Proofs are actually on subexpressions,
+   ;; we need to construct the proof for the full expression
+   (for/list ([step (in-list proof)])
+     (location-do loc prog (const (canonicalize-rewrite step))))))
 
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)
@@ -103,7 +100,7 @@
     ; recursive rewrite or simplify, both using egg
     [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
      #:when (or (equal? phase 'simplify) (equal? phase 'rr))
-     (match-define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
+     (define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
      (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 
     ; everything else

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -27,7 +27,6 @@
          default-egg-cost-proc
          make-egg-runner
          run-egg
-         get-canon-rule-name
          remove-rewrites)
 
 (module+ test
@@ -318,8 +317,8 @@
              type))
        (approx (loop spec spec-type) (loop impl type))]
       [`(Explanation ,body ...) `(Explanation ,@(map (lambda (e) (loop e type)) body))]
-      [(list 'Rewrite=> rule expr) (list 'Rewrite=> rule (loop expr type))]
-      [(list 'Rewrite<= rule expr) (list 'Rewrite<= rule (loop expr type))]
+      [(list 'Rewrite=> rule expr) (list 'Rewrite=> (get-canon-rule-name rule rule) (loop expr type))]
+      [(list 'Rewrite<= rule expr) (list 'Rewrite<= (get-canon-rule-name rule rule) (loop expr type))]
       [(list 'if cond ift iff)
        (if (representation? type)
            (list 'if (loop cond (get-representation 'bool)) (loop ift type) (loop iff type))


### PR DESCRIPTION
This PR moves `get-canon-rule-name` to happen entirely inside `egg-parsed->expr`, which has two advantages:

- This ugly part of the egg-herbie library is hidden from callers
- The derivations package skips making a whole unnecessary copy of the proof