### PR TITLE
Only sound rules in simplify phases

### DIFF
--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -31,7 +31,7 @@
   (filter rule-enabled? *all-rules*))
 
 (define (*simplify-rules*)
-  (filter (conjoin rule-enabled? (has-tag? 'simplify)) *all-rules*))
+  (filter (conjoin rule-enabled? (has-tag? 'simplify) (has-tag? 'sound)) *all-rules*))
 
 ;;
 ;;  Rule loading


### PR DESCRIPTION
This PR is an experiment; do not merge without a careful examination of the nightly results. This PR just makes `*simplify-rules*` only include sound rules. This is a more coherent "simplify" / "all" distinction and it's not obvious that the unsound rules are useful for simplification anyway, since they generally make stuff more complex.