### PR TITLE
Prune once before extraction instead of every eqsat iteration

### DIFF
--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -198,12 +198,11 @@ pub unsafe extern "C" fn egraph_run(
             .run(&context.rules);
     }
 
-    // Prune e-nodes with children if its e-class contains `ConstantFold` analysis data. Pruning
-    // occurs once, right before extraction. Improves performance without affecting correctness:
-    // E.g. if an e-class represents the number 2, it's safe to keep the `(2)` e-node but remove the
-    // `(+ 1 1)` e-node.
+    // Prune all e-nodes with children where its e-class has a leaf node (with no children). Pruning
+    // safely improves performance because pruning occurs right before extraction and leaf e-nodes
+    // always have a lower cost.
     context.runner.egraph.classes_mut().for_each(|eclass| {
-        if eclass.data.is_some() {
+        if eclass.nodes.iter().any(|n| n.is_leaf()) {
             eclass.nodes.retain(|n| n.is_leaf());
         }
     });

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -268,10 +268,6 @@ impl Analysis<Math> for ConstantFold {
                 &subst,
                 "metadata-eval".to_string(),
             );
-
-            if egraph.analysis.prune {
-                egraph[class_id].nodes.retain(|n| n.is_leaf())
-            }
         }
     }
 }


### PR DESCRIPTION
- Prune once before extraction instead of every eqsat iteration
- Restrict exponent in `pow` constant folding

Runtime performance is improved by 6-8%, from ~70 minutes for a full benchmark run on `main` to ~65 minutes with this PR. Accuracy changes are a tossup (some worse, some better).

In this context, "pruning" means removing e-nodes with children if its e-class contains at least one leaf e-node.
