### PR TITLE
Move some common arguments to `simplify-batch`

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -91,9 +91,7 @@
                        (,lowering-rules . ((iteration . 1) (scheduler . simple))))))
 
   ; run egg
-  (define simplified
-    (map (compose debatchref last)
-         (simplify-batch runner batch)))
+  (define simplified (map (compose debatchref last) (simplify-batch runner batch)))
 
   ; run egg
   (define simplifiedss (regroup-nested subexprss simplified))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -93,10 +93,7 @@
   ; run egg
   (define simplified
     (map (compose debatchref last)
-         (simplify-batch runner
-                         (typed-egg-batch-extractor
-                          (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc)
-                          batch))))
+         (simplify-batch runner batch)))
 
   ; run egg
   (define simplifiedss (regroup-nested subexprss simplified))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -365,11 +365,7 @@
      ; run egg
      (define simplified
        (map (compose debatchref last)
-            (simplify-batch runner
-                            (typed-egg-batch-extractor (if (*egraph-platform-cost*)
-                                                           platform-egg-cost-proc
-                                                           default-egg-cost-proc)
-                                                       batch))))
+            (simplify-batch runner batch)))
 
      ; de-duplication
      (remove-duplicates (for/list ([altn (in-list alts)]

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -363,9 +363,7 @@
      (define runner (make-egg-runner batch (batch-roots batch) reprs schedule))
 
      ; run egg
-     (define simplified
-       (map (compose debatchref last)
-            (simplify-batch runner batch)))
+     (define simplified (map (compose debatchref last) (simplify-batch runner batch)))
 
      ; de-duplication
      (remove-duplicates (for/list ([altn (in-list alts)]

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -46,10 +46,7 @@
   ; run egg
   (define runner (make-egg-runner global-batch roots reprs schedule))
   (define simplification-options
-    (simplify-batch runner
-                    (typed-egg-batch-extractor
-                     (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc)
-                     global-batch)))
+    (simplify-batch runner global-batch))
 
   ; convert to altns
   (define simplified

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -45,8 +45,7 @@
 
   ; run egg
   (define runner (make-egg-runner global-batch roots reprs schedule))
-  (define simplification-options
-    (simplify-batch runner global-batch))
+  (define simplification-options (simplify-batch runner global-batch))
 
   ; convert to altns
   (define simplified

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -67,11 +67,7 @@
   (define runner (make-egg-runner batch (batch-roots batch) (list (context-repr ctx)) schedule))
 
   ; run egg
-  (define simplified
-    (simplify-batch runner
-                    (typed-egg-batch-extractor
-                     (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc)
-                     batch)))
+  (define simplified (simplify-batch runner batch))
 
   ; alternatives
   (define start-alt (make-alt expr))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -9,8 +9,7 @@
          "egg-herbie.rkt"
          "batch.rkt")
 
-(provide
- (contract-out [simplify-batch (-> egg-runner? batch? (listof (listof batchref?)))]))
+(provide (contract-out [simplify-batch (-> egg-runner? batch? (listof (listof batchref?)))]))
 
 (module+ test
   (require rackunit

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -9,15 +9,15 @@
          "egg-herbie.rkt"
          "batch.rkt")
 
-(provide simplify-batch)
+(provide
+ (contract-out [simplify-batch (-> egg-runner? batch? (listof (listof batchref?)))]))
 
 (module+ test
   (require rackunit
            "../syntax/load-plugin.rkt")
   (load-herbie-plugins))
 
-(define/contract (simplify-batch runner batch)
-  (-> egg-runner? procedure? (listof (listof batchref?)))
+(define (simplify-batch runner batch)
   (timeline-push! 'inputs (map ~a (batch->progs (egg-runner-batch runner) (egg-runner-roots runner))))
 
   (define cost-proc (if (*egraph-platform-cost*) platform-egg-cost-proc default-egg-cost-proc))


### PR DESCRIPTION
This is a small cleanup PR. Frankly we need to redo the `egg-herbie.rkt`/`simplify.rkt` API entirely but for now this is just mopping the decks on the proverbial Titanic.