### PR TITLE
Flip `batch-errors` output

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -211,8 +211,8 @@
 
   ;; compute error/cost for output expression
   (define end-exprs (map alt-expr end-alts))
-  (define end-train-errs (flip-lists (batch-errors end-exprs train-pcontext ctx)))
-  (define end-test-errs (flip-lists (batch-errors end-exprs test-pcontext* ctx)))
+  (define end-train-errs (batch-errors end-exprs train-pcontext ctx))
+  (define end-test-errs (batch-errors end-exprs test-pcontext* ctx))
   (define end-alts-data (map alt-analysis end-alts end-train-errs end-test-errs))
 
   ;; bundle up the result

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -168,7 +168,7 @@
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (atab-eval-altns atab altns ctx)
-  (define errss (flip-lists (batch-errors (map alt-expr altns) (alt-table-pcontext atab) ctx)))
+  (define errss (batch-errors (map alt-expr altns) (alt-table-pcontext atab) ctx))
   (define costs (map (curryr alt-cost* (context-repr ctx)) altns))
   (values errss costs))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -391,5 +391,5 @@
   (define repr (context-repr (*context*)))
   ;; find the best, sort the rest by cost
   (define errss (batch-errors (map alt-expr alts) (*pcontext*) (*context*)))
-  (define best (car (argmin (compose errors-score cdr) (map cons alts (flip-lists errss)))))
+  (define best (car (argmin (compose errors-score cdr) (map cons alts errss))))
   (cons best (sort (set-remove alts best) > #:key (curryr alt-cost repr))))

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -74,14 +74,13 @@
   ;; This generates the errors array in reverse because that's how lists work
   (define num-points (pcontext-length pcontext))
   (for/fold ([result (make-list (length exprs) '())])
-            ([pt (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)])
+            ([point (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)])
     (for/list ([out (in-vector (apply fn point))]
                [rest (in-list result)])
-      (cons
-       (if (special? out)
-           max-error
-           (ulp-difference out exact repr))
-       rest))))
+      (cons (if (special? out)
+                max-error
+                (ulp-difference out exact repr))
+            rest))))
 
 ;; Herbie <=> JSON conversion for pcontext
 ;; A JSON pcontext is just a list of lists

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -74,7 +74,8 @@
   ;; This generates the errors array in reverse because that's how lists work
   (define num-points (pcontext-length pcontext))
   (for/fold ([result (make-list (length exprs) '())])
-            ([point (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)])
+            ([point (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)]
+             [exact (in-vector (pcontext-exacts pcontext) (- num-points 1) -1 -1)])
     (for/list ([out (in-vector (apply fn point))]
                [rest (in-list result)])
       (cons (if (special? out)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -27,7 +27,7 @@
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
 (define (pareto-regimes sorted ctx)
-  (define err-lsts (flip-lists (batch-errors (map alt-expr sorted) (*pcontext*) ctx)))
+  (define err-lsts (batch-errors (map alt-expr sorted) (*pcontext*) ctx))
   (define branches
     (if (null? sorted)
         '()


### PR DESCRIPTION
Right now `batch-errors` outputs a list (per point) of lists (per alt) of errors. This is dumb and every single caller actually applies `flip-lists` to transpose the lists. So this PR rewrites `batch-errors` to generate the lists in the transposed orientation. It's a little uglier, but it's less "paperwork" and it might be faster / less allocation too.

Longer term I think the goal should be to make it a list (per alt) of vectors (per point), which would mean even less allocation.