### PR TITLE
Clean up `datafile.rkt`

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -9,20 +9,12 @@
 
 (provide add-derivations)
 
-(define (canonicalize-rewrite proof)
-  (match proof
-    [`(Rewrite=> ,rule ,something) (list 'Rewrite=> (get-canon-rule-name rule rule) something)]
-    [`(Rewrite<= ,rule ,something) (list 'Rewrite<= (get-canon-rule-name rule rule) something)]
-    [(list _ ...) (map canonicalize-rewrite proof)]
-    [_ proof]))
-
 (define (canonicalize-proof prog proof loc pcontext ctx)
-  (and
-   proof
-   ;; Proofs are actually on subexpressions,
-   ;; we need to construct the proof for the full expression
-   (for/list ([step (in-list proof)])
-     (location-do loc prog (const (canonicalize-rewrite step))))))
+  (and proof
+       ;; Proofs are actually on subexpressions,
+       ;; we need to construct the proof for the full expression
+       (for/list ([step (in-list proof)])
+         (location-do loc prog (const step)))))
 
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -17,15 +17,12 @@
     [_ proof]))
 
 (define (canonicalize-proof prog proof loc pcontext ctx)
-  (cond
-    [proof
-     ;; Proofs are actually on subexpressions,
-     ;; we need to construct the proof for the full expression
-     (define proof*
-       (for/list ([step (in-list proof)])
-         (location-do loc prog (const (canonicalize-rewrite step)))))
-     proof*]
-    [else #f]))
+  (and
+   proof
+   ;; Proofs are actually on subexpressions,
+   ;; we need to construct the proof for the full expression
+   (for/list ([step (in-list proof)])
+     (location-do loc prog (const (canonicalize-rewrite step))))))
 
 ;; Computes a `equal?`-based hash table key for an alternative
 (define (altn->key altn)
@@ -103,7 +100,7 @@
     ; recursive rewrite or simplify, both using egg
     [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
      #:when (or (equal? phase 'simplify) (equal? phase 'rr))
-     (match-define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
+     (define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
      (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 
     ; everything else

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -27,7 +27,6 @@
          default-egg-cost-proc
          make-egg-runner
          run-egg
-         get-canon-rule-name
          remove-rewrites)
 
 (module+ test
@@ -318,8 +317,8 @@
              type))
        (approx (loop spec spec-type) (loop impl type))]
       [`(Explanation ,body ...) `(Explanation ,@(map (lambda (e) (loop e type)) body))]
-      [(list 'Rewrite=> rule expr) (list 'Rewrite=> rule (loop expr type))]
-      [(list 'Rewrite<= rule expr) (list 'Rewrite<= rule (loop expr type))]
+      [(list 'Rewrite=> rule expr) (list 'Rewrite=> (get-canon-rule-name rule rule) (loop expr type))]
+      [(list 'Rewrite<= rule expr) (list 'Rewrite<= (get-canon-rule-name rule rule) (loop expr type))]
       [(list 'if cond ift iff)
        (if (representation? type)
            (list 'if (loop cond (get-representation 'bool)) (loop ift type) (loop iff type))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -3,15 +3,15 @@
 (require "../utils/common.rkt"
          "programs.rkt"
          "../syntax/syntax.rkt")
-(provide simplify)
+(provide reduce)
 
 ;; Cancellation's goal is to cancel (additively or multiplicatively) like terms.
 ;; It uses commutativity, identities, inverses, associativity,
 ;; distributativity, and function inverses.
 
-(define/reset simplify-cache (make-hash))
+(define/reset reduce-cache (make-hash))
 
-(define/reset simplify-node-cache (make-hash))
+(define/reset reduce-node-cache (make-hash))
 
 ;; This is a transcription of egg-herbie/src/math.rs, lines 97-149
 (define (eval-application op . args)
@@ -59,25 +59,25 @@
   (check-equal? (eval-application 'log 1) 0)
   (check-equal? (eval-application 'exp 2) #f)) ; Not exact
 
-(define (simplify expr)
-  (hash-ref! (simplify-cache) expr (λ () (simplify* expr))))
+(define (reduce expr)
+  (hash-ref! (reduce-cache) expr (λ () (reduce* expr))))
 
-(define (simplify* expr)
+(define (reduce* expr)
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
     ; conversion (e.g. posit16->f64)
-    [(list (? cast-impl? op) body) (list op (simplify body))]
+    [(list (? cast-impl? op) body) (list op (reduce body))]
     [`(,(and (or '+ '- '*) op) ,args ...) ; v-ary
-     (define args* (map simplify args))
+     (define args* (map reduce args))
      (define val (apply eval-application op args*))
-     (or val (simplify-node (list* op args*)))]
+     (or val (reduce-node (list* op args*)))]
     [`(,op ,args ...)
-     (define args* (map simplify args))
+     (define args* (map reduce args))
      (define val (apply eval-application op args*))
-     (or val (simplify-node (list* op args*)))]))
+     (or val (reduce-node (list* op args*)))]))
 
-(define (simplify-evaluation expr)
+(define (reduce-evaluation expr)
   (match expr
     ['(sin 0) 0]
     ['(cos 0) 1]
@@ -103,7 +103,7 @@
     ['(cos (/ (PI) 4)) '(/ (sqrt 2) 2)]
     [_ expr]))
 
-(define (simplify-inverses expr)
+(define (reduce-inverses expr)
   (match expr
     [`(tanh (atanh ,x)) x]
     [`(cosh (acosh ,x)) x]
@@ -121,19 +121,19 @@
     [`(pow (cbrt ,x) 3) x]
     [_ expr]))
 
-(define (simplify-node expr)
-  (hash-ref! (simplify-node-cache) expr (λ () (simplify-node* expr))))
+(define (reduce-node expr)
+  (hash-ref! (reduce-node-cache) expr (λ () (reduce-node* expr))))
 
-(define (simplify-node* expr)
-  (match (simplify-evaluation expr)
+(define (reduce-node* expr)
+  (match (reduce-evaluation expr)
     [(? number?) expr]
     [(? variable?) expr]
     [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))
      (make-addition-node (combine-aterms (gather-additive-terms expr)))]
     [(or `(* ,_ ...) `(/ ,_ ...) `(sqrt ,_) `(cbrt ,_) `(pow ,_ ,_))
      (make-multiplication-node (combine-mterms (gather-multiplicative-terms expr)))]
-    [`(exp (* ,c (log ,x))) (simplify-node* `(pow ,x ,c))]
-    [else (simplify-inverses expr)]))
+    [`(exp (* ,c (log ,x))) (reduce-node* `(pow ,x ,c))]
+    [else (reduce-inverses expr)]))
 
 (define (negate-term term)
   (cons (- (car term)) (cdr term)))
@@ -154,7 +154,7 @@
       [`(/ ,arg) `((1 ,expr))]
       [`(/ ,arg ,args ...)
        (for/list ([term (recurse arg)])
-         (list* (car term) (simplify-node (list* '/ (cadr term) args)) (cons label (cddr term))))]
+         (list* (car term) (reduce-node (list* '/ (cadr term) args)) (cons label (cddr term))))]
 
       [`(pow ,arg 1) `((1 1))]
       [else `((1 ,expr))])))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -475,8 +475,6 @@
 (define (logstep table)
   (lognormalize (loggenerate table)))
 
-(define logbiggest 1)
-
 (define (logcompute i)
   (hash-ref! (log-cache) i (λ () (logstep (logcompute (- i 1))))))
 


### PR DESCRIPTION
This PR was laying around in the branches folder and I'm rescuing it. It seems to do two things:

- Move `get-canon-rule-name` into `egg-herbie.rkt`, which I though happened in #1106 but who knows
- Rename `simplify` to `reduce` when it refers to `reduce.rkt`