### PR TITLE
Store the e-graph instead of recomputing it

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1232,8 +1232,7 @@
            [_ (oops! "in instruction `~a`, unknown parameter `~a`" instr param)]))]
       [_ (oops! "expected `(<rules> . <params>)`, got `~a`" instr)]))
 
-  (define-values (root-ids egg-graph)
-    (egraph-run-schedule batch roots schedule ctx))
+  (define-values (root-ids egg-graph) (egraph-run-schedule batch roots schedule ctx))
 
   ; make the runner
   (egg-runner batch roots reprs schedule ctx root-ids egg-graph))


### PR DESCRIPTION
This PR runs the egraph eagerly in the `egg-runner` struct instead of rebuilding it from scratch. This might have some advantages:

- It makes the `derivations` phase faster since it can use the stored egraph instead of rebuilding it
- It also might make the API simpler since you now just manipulate an egraph

I think the reason we didn't do this originally is that originally we didn't have a good memory management story for the FFI, but as we've learned more about it it's become doable to just store the e-graph in memory and allow it to be garbage collected.

This PR is still experimental, and if it gives good results I expect to do significant simplifications to the egg-herbie code.