### PR TITLE
Add `(hole repr spec)` terms to simplify Taylor expansion

### DIFF
--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -26,6 +26,7 @@
 (define (expr-recurse expr f)
   (match expr
     [(approx spec impl) (approx (f spec) (f impl))]
+    [(hole precision spec) (hole precision (f spec))]
     [(list op args ...) (cons op (map f args))]
     [_ expr]))
 

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -46,21 +46,9 @@
       ;  usually: impl -> impl
       ;  taylor: spec -> approx (_, impl)
       [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f) `(,prev) _)
-       (define rewrite
-         (match (alt-event prev)
-           [(list 'taylor _ ...)
-            ; simplify after taylor: spec -> approx (_, impl)
-            (define start-expr (location-get loc (alt-expr prev)))
-            (define end-expr (location-get loc expr))
-            (unless (approx? end-expr)
-              (error 'make-proof-tables "expected approx node, got ~a" end-expr))
-            (cons start-expr end-expr)]
-           [_
-            ; simplify after other: impl -> impl
-            (define start-expr (location-get loc (alt-expr prev)))
-            (define end-expr (location-get loc expr))
-            (cons start-expr end-expr)]))
-
+       (define start-expr (location-get loc (alt-expr prev)))
+       (define end-expr (location-get loc expr))
+       (define rewrite (cons start-expr end-expr))
        (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
        (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
 

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -54,7 +54,7 @@
             (define end-expr (location-get loc expr))
             (unless (approx? end-expr)
               (error 'make-proof-tables "expected approx node, got ~a" end-expr))
-            (cons start-expr (approx-impl end-expr))]
+            (cons start-expr end-expr)]
            [_
             ; simplify after other: impl -> impl
             (define start-expr (location-get loc (alt-expr prev)))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -35,17 +35,7 @@
   (define (build! altn)
     (match altn
       ; recursive rewrite using egg (impl -> impl)
-      [(alt expr `(rr ,loc ,(? egg-runner? runner) #f) `(,prev) _)
-       (define start-expr (location-get loc (alt-expr prev)))
-       (define end-expr (location-get loc expr))
-       (define rewrite (cons start-expr end-expr))
-       (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
-       (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
-
-      ; simplify using egg
-      ;  usually: impl -> impl
-      ;  taylor: spec -> approx (_, impl)
-      [(alt expr `(simplify ,loc ,(? egg-runner? runner) #f) `(,prev) _)
+      [(alt expr `(,(or 'rr 'simplify) ,loc ,(? egg-runner? runner) #f) `(,prev) _)
        (define start-expr (location-get loc (alt-expr prev)))
        (define end-expr (location-get loc expr))
        (define rewrite (cons start-expr end-expr))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -137,8 +137,7 @@
         [(literal v _) (insert-node! v root?)]
         [(? number?) (insert-node! node root?)]
         [(? symbol?) (insert-node! (normalize-var node) root?)]
-        [(hole prec spec)
-         (remap spec)] ; "hole" terms currently disappear
+        [(hole prec spec) (remap spec)] ; "hole" terms currently disappear
         [(approx spec impl)
          (hash-ref! id->spec
                     (remap spec)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -132,11 +132,13 @@
   (for ([node (in-vector (batch-nodes insert-batch))]
         [root? (in-vector root-mask)]
         [n (in-naturals)])
-    (define node*
+    (define idx
       (match node
-        [(literal v _) v]
-        [(? number?) node]
-        [(? symbol?) (normalize-var node)]
+        [(literal v _) (insert-node! v root?)]
+        [(? number?) (insert-node! node root?)]
+        [(? symbol?) (insert-node! (normalize-var node) root?)]
+        [(hole prec spec)
+         (remap spec)] ; "hole" terms currently disappear
         [(approx spec impl)
          (hash-ref! id->spec
                     (remap spec)
@@ -144,10 +146,10 @@
                       (define spec* (normalize-spec (batch-ref insert-batch spec)))
                       (define type (representation-type (repr-of-node insert-batch impl ctx)))
                       (cons spec* type))) ; preserved spec and type for extraction
-         (list '$approx (remap spec) (remap impl))]
-        [(list op (app remap args) ...) (cons op args)]))
+         (insert-node! (list '$approx (remap spec) (remap impl)) root?)]
+        [(list op (app remap args) ...) (insert-node! (cons op args) root?)]))
 
-    (vector-set! mappings n (insert-node! node* root?)))
+    (vector-set! mappings n idx))
 
   (for/list ([root (in-vector (batch-roots insert-batch))])
     (remap root)))
@@ -276,6 +278,7 @@
                     (hash-set! egg->herbie-dict replacement (cons expr (context-lookup ctx expr)))
                     replacement))]
       [(approx spec impl) (list '$approx (loop spec) (loop impl))]
+      [(hole precision spec) (loop spec)]
       [(list op args ...) (cons op (map loop args))])))
 
 (define (flatten-let expr)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -55,13 +55,8 @@
                 [outputs (in-list simplification-options)])
             (match-define (cons _ simplified) outputs)
             (define prev (car (alt-prevs altn)))
-            (for ([batchreff (in-list simplified)])
-              (define spec (prog->spec (debatchref (alt-expr prev))))
-              (define idx ; Munge
-                (mutable-batch-push! global-batch-mutable
-                                     (approx (mutable-batch-munge! global-batch-mutable spec)
-                                             (batchref-idx batchreff))))
-              (sow (alt (batchref global-batch idx) `(simplify ,runner #f) (list altn) '()))))
+            (for ([bref (in-list simplified)])
+              (sow (alt bref `(simplify ,runner #f) (list altn) '()))))
           (batch-copy-mutable-nodes! global-batch global-batch-mutable))) ; Update global-batch
 
   (timeline-push! 'count (length approxs) (length simplified))
@@ -80,10 +75,8 @@
                               #;(log ,log-x ,exp-x))))
 
 (define (taylor-alts starting-exprs altns global-batch)
-  (define exprs
-    (for/list ([expr (in-list starting-exprs)])
-      (prog->spec expr)))
-  (define free-vars (map free-variables exprs))
+  (define specs (map prog->spec starting-exprs))
+  (define free-vars (map free-variables specs))
   (define vars (context-vars (*context*)))
 
   (reap [sow]
@@ -91,14 +84,15 @@
         (for* ([var (in-list vars)]
                [transform-type transforms-to-try])
           (match-define (list name f finv) transform-type)
-          (define timeline-stop! (timeline-start! 'series (~a exprs) (~a var) (~a name)))
-          (define genexprs (approximate exprs var #:transform (cons f finv)))
+          (define timeline-stop! (timeline-start! 'series (~a specs) (~a var) (~a name)))
+          (define genexprs (approximate specs var #:transform (cons f finv)))
           (for ([genexpr (in-list genexprs)]
+                [spec (in-list specs)]
                 [altn (in-list altns)]
                 [fv (in-list free-vars)]
-                #:when (member var fv)) ; check whether var exists in expr at all
+                #:when (set-member? fv var)) ; check whether var exists in expr at all
             (for ([i (in-range (*taylor-order-limit*))])
-              (define gen (genexpr))
+              (define gen (approx spec (genexpr)))
               (define idx (mutable-batch-munge! global-batch-mutable gen)) ; Munge gen
               (sow (alt (batchref global-batch idx) `(taylor ,name ,var) (list altn) '()))))
           (timeline-stop!))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -88,11 +88,13 @@
           (define genexprs (approximate specs var #:transform (cons f finv)))
           (for ([genexpr (in-list genexprs)]
                 [spec (in-list specs)]
+                [expr (in-list starting-exprs)]
                 [altn (in-list altns)]
                 [fv (in-list free-vars)]
                 #:when (set-member? fv var)) ; check whether var exists in expr at all
             (for ([i (in-range (*taylor-order-limit*))])
-              (define gen (approx spec (genexpr)))
+              (define repr (repr-of expr (*context*)))
+              (define gen (approx spec (hole (representation-name repr) (genexpr))))
               (define idx (mutable-batch-munge! global-batch-mutable gen)) ; Munge gen
               (sow (alt (batchref global-batch idx) `(taylor ,name ,var) (list altn) '()))))
           (timeline-stop!))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -40,6 +40,7 @@
     [(literal val precision) (get-representation precision)]
     [(? variable?) (context-lookup ctx node)]
     [(approx _ impl) (repr-of-node batch impl ctx)]
+    [(hole precision spec) (get-representation precision)]
     [(list 'if cond ift iff) (repr-of-node batch ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))
 

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -73,16 +73,16 @@
   (values (format-accuracy err repr-bits #:unit "%")
           (format "~a on training set" (format-accuracy err2 repr-bits #:unit "%"))))
 
-(define (remove-literals expr)
-  (match expr
-    [(? symbol?) expr]
-    [(? number?) expr]
-    [(? literal?) (literal-value expr)]
-    [(approx spec impl) (approx (remove-literals spec) (remove-literals impl))]
-    [(list op args ...) (cons op (map remove-literals args))]))
-
 (define (expr->fpcore expr ctx #:ident [ident #f])
-  (list 'FPCore (context-vars ctx) (remove-literals expr)))
+  (list 'FPCore (context-vars ctx)
+        (let loop ([expr expr])
+          (match expr
+            [(? symbol?) expr]
+            [(? number?) expr]
+            [(? literal?) (literal-value expr)]
+            [(approx spec impl) (loop impl)]
+            [(hole precision spec) (loop spec)]
+            [(list op args ...) (cons op (map loop args))]))))
 
 (define (mixed->fpcore expr ctx)
   (define expr*

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -74,7 +74,8 @@
           (format "~a on training set" (format-accuracy err2 repr-bits #:unit "%"))))
 
 (define (expr->fpcore expr ctx #:ident [ident #f])
-  (list 'FPCore (context-vars ctx)
+  (list 'FPCore
+        (context-vars ctx)
         (let loop ([expr expr])
           (match expr
             [(? symbol?) expr]

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -92,6 +92,7 @@
         [(? number?) expr]
         [(? literal?) (literal-value expr)]
         [(approx _ impl) (loop impl)]
+        [(hole precision spec) (loop spec)]
         [`(if ,cond ,ift ,iff)
          `(if ,(loop cond)
               ,(loop ift)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -10,6 +10,7 @@
 
 (provide (struct-out literal)
          (struct-out approx)
+         (struct-out hole)
          variable?
          constant-operator?
          operator-exists?
@@ -493,8 +494,11 @@
 (struct literal (value precision) #:prefab)
 
 ;; An approximation of a specification by
-;; an arbitrary floating-point expression.
+;; a floating-point expression.
 (struct approx (spec impl) #:prefab)
+
+;; An unknown floating-point expression that implements a given spec
+(struct hole (precision spec) #:prefab)
 
 ;; name -> (vars repr body)	;; name -> (vars prec body)
 (define *functions* (make-parameter (make-hasheq)))


### PR DESCRIPTION
This PR breaks out one component of #1124 to test it better and also merge it early. Basically, before this PR, Taylor converted an impl like `(sin.f64 x)` to a spec like `(- x (/ (pow x 3) 6))`. This was just weird (why do we go from impl to spec) and had a bunch of downsides and needed special handling in various places. I fix it by instead adding a term `(hole prec spec)`, which represents an _unknown_ impl of `spec` at the given precision. Inside egg, we totally elide the `spec` term (this is unlike #1124) so when we extract we get a term of the right term.

This `hole` term also makes everything type-correct which allows us to make Taylor go from impl to impl, with the result impl being something like `(approx original-spec (impl original-precision taylored-spec))`.