### PR TITLE
Make the `simplify-batch` call return a single batchref, not a list of them

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1100,13 +1100,10 @@
   (match-define (list extract-id _ _) extract)
   ; extract expr
   (define key (cons id type))
-  (cond
-    ; at least one extractable expression
-    [(hash-has-key? canon key)
-     (define id* (hash-ref canon key))
-     (list (extract-id id* type))]
-    ; no extractable expressions
-    [else (list)]))
+  ; TODO: this can actually fail if no extractable expressions
+  ; Most of Herbie doesn't actually check for / handle this
+  (define id* (hash-ref canon key))
+  (extract-id id* type))
 
 ;; Extracts multiple expressions according to the extractor
 (define (regraph-extract-variants regraph extract id type)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -91,7 +91,7 @@
                        (,lowering-rules . ((iteration . 1) (scheduler . simple))))))
 
   ; run egg
-  (define simplified (map (compose debatchref last) (simplify-batch runner batch)))
+  (define simplified (map debatchref (simplify-batch runner batch)))
 
   ; run egg
   (define simplifiedss (regroup-nested subexprss simplified))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -363,7 +363,7 @@
      (define runner (make-egg-runner batch (batch-roots batch) reprs schedule))
 
      ; run egg
-     (define simplified (map (compose debatchref last) (simplify-batch runner batch)))
+     (define simplified (map debatchref (simplify-batch runner batch)))
 
      ; de-duplication
      (remove-duplicates (for/list ([altn (in-list alts)]

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -53,7 +53,6 @@
           (define global-batch-mutable (batch->mutable-batch global-batch)) ; Create mutable batch
           (for ([altn (in-list approxs)]
                 [simplified (in-list simplifieds)])
-            (define prev (car (alt-prevs altn)))
             (sow (alt simplified `(simplify ,runner #f) (list altn) '())))
           (batch-copy-mutable-nodes! global-batch global-batch-mutable))) ; Update global-batch
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -45,18 +45,16 @@
 
   ; run egg
   (define runner (make-egg-runner global-batch roots reprs schedule))
-  (define simplification-options (simplify-batch runner global-batch))
+  (define simplifieds (simplify-batch runner global-batch))
 
   ; convert to altns
   (define simplified
     (reap [sow]
           (define global-batch-mutable (batch->mutable-batch global-batch)) ; Create mutable batch
           (for ([altn (in-list approxs)]
-                [outputs (in-list simplification-options)])
-            (match-define (cons _ simplified) outputs)
+                [simplified (in-list simplifieds)])
             (define prev (car (alt-prevs altn)))
-            (for ([bref (in-list simplified)])
-              (sow (alt bref `(simplify ,runner #f) (list altn) '()))))
+            (sow (alt simplified `(simplify ,runner #f) (list altn) '())))
           (batch-copy-mutable-nodes! global-batch global-batch-mutable))) ; Update global-batch
 
   (timeline-push! 'count (length approxs) (length simplified))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -67,15 +67,11 @@
   (define runner (make-egg-runner batch (batch-roots batch) (list (context-repr ctx)) schedule))
 
   ; run egg
-  (define simplified (simplify-batch runner batch))
+  (define simplified (first (simplify-batch runner batch)))
 
   ; alternatives
   (define start-alt (make-alt expr))
-  (cons start-alt
-        (remove-duplicates
-         (for/list ([batchreff (rest simplified)])
-           (alt (debatchref batchreff) `(simplify () ,runner #f) (list start-alt) '()))
-         alt-equal?)))
+  (list start-alt (alt (debatchref simplified) `(simplify () ,runner #f) (list start-alt) '())))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
 (define (find-preprocessing init expr ctx)


### PR DESCRIPTION
This raises the possibility of a crash if a term is unimplementable, but I'm not sure that using a list as a sort-of "option" is the right way to handle that, especially since we're not doing that consistently.