### PR TITLE
Removing multiple phases for the derivations phase

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -28,5 +28,7 @@
     [_ altn]))
 
 (define (add-derivations alts)
+  (define cache (make-hasheq))
   (for/list ([altn (in-list alts)])
-    (alt-map add-derivations-to altn)))
+    ;; We need to cache this because we'll see the same alt several times
+    (alt-map (lambda (altn) (hash-ref! cache altn (lambda () (add-derivations-to altn)))) altn)))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -1,11 +1,8 @@
 #lang racket
 
 (require "../utils/alternative.rkt"
-         "points.rkt"
          "programs.rkt"
-         "egg-herbie.rkt"
-         "../syntax/sugar.rkt"
-         "../syntax/syntax.rkt")
+         "egg-herbie.rkt")
 
 (provide add-derivations)
 

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -22,7 +22,7 @@
      (define end-expr (location-get loc expr))
      (define proof (run-egg runner `(proofs ,(cons start-expr end-expr))))
      (define proof* (canonicalize-proof (alt-expr altn) proof loc))
-     (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
+     (alt expr `(rr ,loc ,runner ,proof*) `(,prev) '())]
 
     ; everything else
     [_ altn]))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -9,76 +9,27 @@
 
 (provide add-derivations)
 
-(define (canonicalize-proof prog proof loc pcontext ctx)
+(define (canonicalize-proof prog proof loc)
   (and proof
        ;; Proofs are actually on subexpressions,
        ;; we need to construct the proof for the full expression
        (for/list ([step (in-list proof)])
          (location-do loc prog (const step)))))
 
-;; Computes a `equal?`-based hash table key for an alternative
-(define (altn->key altn)
-  (match altn
-    [(alt expr `(rr ,loc ,method ,_) prevs _) (list expr (list 'rr loc method) (map alt-expr prevs))]
-    [(alt expr `(simplify ,loc ,method ,_) prevs _)
-     (list expr (list 'simplify loc method) (map alt-expr prevs))]
-    [_ (error 'altn->key "unimplemented ~a" altn)]))
-
-;; Creates two tables:
-;;  - map from alternative to a pair (e, l ~> r) where `e` is an `egg-runner`
-;;      and `l ~> r` is the rewrite we want a proof for.
-;;  - map from egg query to list of proofs
-(define (make-proof-tables altns)
-  (define alt->query&rws (make-hash))
-  (define query->rws (make-hash))
-
-  (define (build! altn)
-    (match altn
-      ; recursive rewrite using egg (impl -> impl)
-      [(alt expr `(,(or 'rr 'simplify) ,loc ,(? egg-runner? runner) #f) `(,prev) _)
-       (define start-expr (location-get loc (alt-expr prev)))
-       (define end-expr (location-get loc expr))
-       (define rewrite (cons start-expr end-expr))
-       (hash-set! alt->query&rws (altn->key altn) (cons runner rewrite))
-       (hash-update! query->rws runner (lambda (rws) (set-add rws rewrite)) '())]
-
-      ; everything else
-      [_ (void)])
-
-    altn)
-
-  ; build the table
-  (for ([altn (in-list altns)])
-    (alt-for-each build! altn))
-  (values alt->query&rws query->rws))
-
-;; Runs proof extraction.
-;; Result is a map from egg query to rewrites.
-(define (compute-proofs query->rws)
-  (for/hash ([(runner rws) (in-hash query->rws)])
-    (define proofs (run-egg runner `(proofs . ,rws)))
-    (values runner (map cons rws proofs))))
-
-;; Lookups a proof based on an alternative
-(define ((lookup-proof alt->query&rws query->proofs) altn)
-  (match-define (cons runner rw) (hash-ref alt->query&rws (altn->key altn)))
-  (cdr (assoc rw (hash-ref query->proofs runner))))
-
 ;; Adds proof information to alternatives.
-(define (add-derivations-to altn pcontext ctx alt->proof)
+(define (add-derivations-to altn)
   (match altn
     ; recursive rewrite or simplify, both using egg
-    [(alt expr (list phase loc (? egg-runner? runner) #f) `(,prev) _)
-     #:when (or (equal? phase 'simplify) (equal? phase 'rr))
-     (define proof (canonicalize-proof (alt-expr altn) (alt->proof altn) loc pcontext ctx))
+    [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) _)
+     (define start-expr (location-get loc (alt-expr prev)))
+     (define end-expr (location-get loc expr))
+     (define proof (run-egg runner `(proofs . ,(cons start-expr end-expr))))
+     (define proof* (canonicalize-proof (alt-expr altn) proof loc))
      (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 
     ; everything else
     [_ altn]))
 
-(define (add-derivations alts pcontext ctx)
-  (define-values (alt->query&rws query->rws) (make-proof-tables alts))
-  (define query->proofs (compute-proofs query->rws))
-  (define lookup-proc (lookup-proof alt->query&rws query->proofs))
+(define (add-derivations alts)
   (for/list ([altn (in-list alts)])
-    (alt-map (curryr add-derivations-to pcontext ctx lookup-proc) altn)))
+    (alt-map add-derivations-to altn)))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -23,7 +23,7 @@
     [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) _)
      (define start-expr (location-get loc (alt-expr prev)))
      (define end-expr (location-get loc expr))
-     (define proof (run-egg runner `(proofs . ,(cons start-expr end-expr))))
+     (define proof (run-egg runner `(proofs ,(cons start-expr end-expr))))
      (define proof* (canonicalize-proof (alt-expr altn) proof loc))
      (alt expr `(rr ,loc ,runner ,proof) `(,prev) '())]
 

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -20,7 +20,7 @@
     [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) _)
      (define start-expr (location-get loc (alt-expr prev)))
      (define end-expr (location-get loc expr))
-     (define proof (run-egg runner `(proofs ,(cons start-expr end-expr))))
+     (define proof (first (run-egg runner `(proofs ,(cons start-expr end-expr)))))
      (define proof* (canonicalize-proof (alt-expr altn) proof loc))
      (alt expr `(rr ,loc ,runner ,proof*) `(,prev) '())]
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -378,7 +378,7 @@
   (cond
     [(flag-set? 'generate 'proofs)
      (timeline-event! 'derivations)
-     (add-derivations alts (*pcontext*) (*context*))]
+     (add-derivations alts)]
     [else alts]))
 
 (define (sort-alts alts)


### PR DESCRIPTION
Once upon a time, the derivations phase had to regenerate the egraph from scratch before computing derivations. Because of that, we wanted to recompute the egraph the minimal number of times, so the derivations phase first found all derivations needed, partitioned them by egraph, and then ran each egraph once (computing all proofs). This was implemented in #736. Recently, #1119 allows us to reuse the original egraph instead of regenerating it, so this batching no longer makes sense or does anything, so this PR gets us back to the easy one-phase code.