### PR TITLE
Fix derivation speed broken by #1130

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -28,7 +28,7 @@
     [_ altn]))
 
 (define (add-derivations alts)
-  (define cache (make-hasheq))
+  (define cache (make-hash))
   (for/list ([altn (in-list alts)])
     ;; We need to cache this because we'll see the same alt several times
     (alt-map (lambda (altn) (hash-ref! cache altn (lambda () (add-derivations-to altn)))) altn)))


### PR DESCRIPTION
PR #1130 was good but made derivations slower; I just set up the cache wrong, using `eq?` instead of `equal?`, which meant we were computing the same proof many times. This PR changes the cache, making derivations fast again.