### PR TITLE
Refactor the `egg-herbie` interface a bit

### DIFF
--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -20,7 +20,7 @@
     [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) _)
      (define start-expr (location-get loc (alt-expr prev)))
      (define end-expr (location-get loc expr))
-     (define proof (first (run-egg runner `(proofs ,(cons start-expr end-expr)))))
+     (define proof (egraph-prove runner start-expr end-expr))
      (define proof* (canonicalize-proof (alt-expr altn) proof loc))
      (alt expr `(rr ,loc ,runner ,proof*) `(,prev) '())]
 

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -205,7 +205,7 @@
   ; need to fix up any constant operators
   (for ([enode (in-vector eclass)]
         [i (in-naturals)])
-    (when (and (symbol? enode) (not (string-prefix? (symbol->string expr) "$var")))
+    (when (and (symbol? enode) (not (string-prefix? (symbol->string enode) "$var")))
       (vector-set! eclass i (cons enode empty-u32vec))))
   eclass)
 
@@ -1056,7 +1056,7 @@
                  (literal enode (representation-name type))
                  enode)]
             [(? symbol?)
-             (if (string-prefix? (symbol->string expr) "$var")
+             (if (string-prefix? (symbol->string enode) "$var")
                  (egg-var->var enode ctx)
                  enode)]
             [(list '$approx spec (app eggref impl))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -130,16 +130,20 @@
         [(? symbol?) (insert-node! (var->egg-var node ctx) root?)]
         [(hole prec spec) (remap spec)] ; "hole" terms currently disappear
         [(approx spec impl)
-         (hash-ref! id->spec
-                    (remap spec)
-                    (lambda ()
-                      (define spec* (normalize-spec (batch-ref insert-batch spec)))
-                      (define type (representation-type (repr-of-node insert-batch impl ctx)))
-                      (cons spec* type))) ; preserved spec and type for extraction
          (insert-node! (list '$approx (remap spec) (remap impl)) root?)]
         [(list op (app remap args) ...) (insert-node! (cons op args) root?)]))
 
     (vector-set! mappings n idx))
+
+  (for ([node (in-vector (batch-nodes insert-batch))]
+        #:when (approx? node))
+    (match-define (approx spec impl) node)
+    (hash-ref! id->spec
+               (remap spec)
+               (lambda ()
+                 (define spec* (normalize-spec (batch-ref insert-batch spec)))
+                 (define type (representation-type (repr-of-node insert-batch impl ctx)))
+                 (cons spec* type))))
 
   (for/list ([root (in-vector (batch-roots insert-batch))])
     (remap root)))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1275,10 +1275,7 @@
   (define egg-graph (egg-runner-egg-graph runner))
 
   (unless (egraph-expr-equal? egg-graph start end ctx)
-    (error 'egraph-prove
-           "cannot prove ~a is equal to ~a; not equal"
-           start
-           end))
+    (error 'egraph-prove "cannot prove ~a is equal to ~a; not equal" start end))
   (define proof (egraph-get-proof egg-graph start end ctx))
   (when (null? proof)
     (error 'egraph-prove "proof extraction failed between`~a` and `~a`" start end))
@@ -1315,10 +1312,10 @@
   (define reprs (egg-runner-reprs runner))
   (when (flag-set? 'dump 'egg)
     (regraph-dump regraph root-ids reprs))
-  
+
   (define extract-id ((typed-egg-batch-extractor batch) regraph))
   (define finalize-batch (last extract-id))
-  
+
   ; (Listof (Listof batchref))
   (define out
     (for/list ([id (in-list root-ids)]

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -205,7 +205,7 @@
   ; need to fix up any constant operators
   (for ([enode (in-vector eclass)]
         [i (in-naturals)])
-    (when (and (symbol? enode) (not (equal? (substring (symbol->string enode) 0 4) "$var")))
+    (when (and (symbol? enode) (not (string-prefix? (symbol->string expr) "$var")))
       (vector-set! eclass i (cons enode empty-u32vec))))
   eclass)
 
@@ -1026,7 +1026,7 @@
              (literal expr (representation-name type))
              expr)]
         [(? symbol?)
-         (if (equal? (substring (symbol->string expr) 0 4) "$var")
+         (if (string-prefix? (symbol->string expr) "$var")
              (egg-var->var expr ctx)
              (list expr))]
         [(list '$approx spec impl)
@@ -1056,7 +1056,7 @@
                  (literal enode (representation-name type))
                  enode)]
             [(? symbol?)
-             (if (equal? (substring (symbol->string enode) 0 4) "$var")
+             (if (string-prefix? (symbol->string expr) "$var")
                  (egg-var->var enode ctx)
                  enode)]
             [(list '$approx spec (app eggref impl))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -129,8 +129,7 @@
         [(? number?) (insert-node! node root?)]
         [(? symbol?) (insert-node! (var->egg-var node ctx) root?)]
         [(hole prec spec) (remap spec)] ; "hole" terms currently disappear
-        [(approx spec impl)
-         (insert-node! (list '$approx (remap spec) (remap impl)) root?)]
+        [(approx spec impl) (insert-node! (list '$approx (remap spec) (remap impl)) root?)]
         [(list op (app remap args) ...) (insert-node! (cons op args) root?)]))
 
     (vector-set! mappings n idx))
@@ -297,10 +296,8 @@
        (if (representation? type)
            (literal expr (representation-name type))
            expr)]
-      [(? symbol? (regexp #rx"^\\$var"))
-       (egg-var->var expr)]
-      [(? symbol?)
-       (list expr)] ; constant function
+      [(? symbol? (regexp #rx"^\\$var")) (egg-var->var expr)]
+      [(? symbol?) (list expr)] ; constant function
       [(list '$approx spec impl) ; approx
        (define spec-type
          (if (representation? type)
@@ -1101,7 +1098,6 @@
     (batch-copy-mutable-nodes! input-batch out))
 
   (values add-id add-enode finalize-batch))
-
 
 ;; Is fractional with odd denominator.
 (define (fraction-with-odd-denominator? frac)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -296,8 +296,10 @@
        (if (representation? type)
            (literal expr (representation-name type))
            expr)]
-      [(? symbol? (regexp #rx"^\\$var")) (egg-var->var expr)]
-      [(? symbol?) (list expr)] ; constant function
+      [(? symbol?)
+       (if (string-prefix? (symbol->string expr) "$var")
+           (egg-var->var expr ctx)
+           (list expr))]
       [(list '$approx spec impl) ; approx
        (define spec-type
          (if (representation? type)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -83,12 +83,12 @@
   ; egg runner (2-phases for real rewrites and implementation selection)
   (define batch (progs->batch progs))
   (define runner
-    (make-egg-runner batch
-                     (batch-roots batch)
-                     reprs
-                     `((,lifting-rules . ((iteration . 1) (scheduler . simple)))
-                       (,rules . ((node . ,(*node-limit*))))
-                       (,lowering-rules . ((iteration . 1) (scheduler . simple))))))
+    (make-egraph batch
+                 (batch-roots batch)
+                 reprs
+                 `((,lifting-rules . ((iteration . 1) (scheduler . simple)))
+                   (,rules . ((node . ,(*node-limit*))))
+                   (,lowering-rules . ((iteration . 1) (scheduler . simple))))))
 
   ; run egg
   (define simplified (map (compose debatchref last) (simplify-batch runner batch)))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -360,7 +360,7 @@
      (define exprs (map alt-expr alts))
      (define reprs (map (lambda (expr) (repr-of expr (*context*))) exprs))
      (define batch (progs->batch exprs))
-     (define runner (make-egg-runner batch (batch-roots batch) reprs schedule))
+     (define runner (make-egraph batch (batch-roots batch) reprs schedule))
 
      ; run egg
      (define simplified (map (compose debatchref last) (simplify-batch runner batch)))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -137,7 +137,7 @@
 
   (define runner (make-egraph global-batch roots reprs schedule))
   ; batchrefss is a (listof (listof batchref))
-  (define batchrefss (run-egg runner (cons 'multi global-batch)))
+  (define batchrefss (egraph-variations runner global-batch))
 
   ; apply changelists
   (define rewritten

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -44,7 +44,7 @@
       (batchref-idx (alt-expr approx))))
 
   ; run egg
-  (define runner (make-egg-runner global-batch roots reprs schedule))
+  (define runner (make-egraph global-batch roots reprs schedule))
   (define simplification-options (simplify-batch runner global-batch))
 
   ; convert to altns
@@ -135,7 +135,7 @@
   (define reprs (map (curryr repr-of (*context*)) exprs))
   (timeline-push! 'inputs (map ~a exprs))
 
-  (define runner (make-egg-runner global-batch roots reprs schedule))
+  (define runner (make-egraph global-batch roots reprs schedule))
   ; batchrefss is a (listof (listof batchref))
   (define batchrefss (run-egg runner (cons 'multi global-batch)))
 

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -64,7 +64,7 @@
 
   ; egg query
   (define batch (progs->batch (list expr)))
-  (define runner (make-egg-runner batch (batch-roots batch) (list (context-repr ctx)) schedule))
+  (define runner (make-egraph batch (batch-roots batch) (list (context-repr ctx)) schedule))
 
   ; run egg
   (define simplified (simplify-batch runner batch))
@@ -99,10 +99,10 @@
 
   (define batch (progs->batch specs))
   (define runner
-    (make-egg-runner batch
-                     (batch-roots batch)
-                     (map (lambda (_) (context-repr ctx)) specs)
-                     `((,rules . ((node . ,(*node-limit*)))))))
+    (make-egraph batch
+                 (batch-roots batch)
+                 (map (lambda (_) (context-repr ctx)) specs)
+                 `((,rules . ((node . ,(*node-limit*)))))))
 
   ;; run egg to check for identities
   (define expr-pairs (map (curry cons spec) specs))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -106,7 +106,9 @@
 
   ;; run egg to check for identities
   (define expr-pairs (map (curry cons spec) specs))
-  (define equal?-lst (run-egg runner `(equal? . ,expr-pairs)))
+  (define equal?-lst
+    (for/list ([(start end) (in-dict expr-pairs)])
+      (egraph-equal? runner start end)))
 
   ;; collect equalities
   (define abs-instrs '())

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -40,10 +40,10 @@
   (define (test-simplify . args)
     (define batch (progs->batch args))
     (define runner
-      (make-egg-runner batch
-                       (batch-roots batch)
-                       (map (lambda (_) 'real) args)
-                       `((,(*simplify-rules*) . ((node . ,(*node-limit*)))))))
+      (make-egraph batch
+                   (batch-roots batch)
+                   (map (lambda (_) 'real) args)
+                   `((,(*simplify-rules*) . ((node . ,(*node-limit*)))))))
     (parameterize ([*egraph-platform-cost* #f])
       (map (compose debatchref last) (simplify-batch runner batch))))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -19,7 +19,7 @@
 (define (simplify-batch runner batch)
   (timeline-push! 'inputs (map ~a (batch->progs (egg-runner-batch runner) (egg-runner-roots runner))))
 
-  (define simplifieds (run-egg runner (cons 'single batch)))
+  (define simplifieds (egraph-best runner batch))
   (define out
     (for/list ([simplified (in-list simplifieds)]
                [root (egg-runner-roots runner)])


### PR DESCRIPTION
In this PR `make-egg-runner` becomes `make-egraph` and `run-egg` becomes four functions, `egraph-equal?`, `egraph-prove`, `egraph-best`, and `egraph-variations`. This allows me to simplify `preprocessing` somewhat, analogous to the recent simplification of `derivations`.

I also leverage that fact that `egg->herbie-dict` and `herbie->egg-dict` are _only_ used to rename variables, which means we don't need the dictionaries at all, just a normal Herbie context. One less thing to think about.