### PR TITLE
Bump enode count to 20k

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -116,7 +116,7 @@
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph
-(define *node-limit* (make-parameter 8000))
+(define *node-limit* (make-parameter 20000))
 (define *proof-max-length* (make-parameter 200))
 (define *proof-max-string-length* (make-parameter 10000))
 


### PR DESCRIPTION
This is a draft PR looking to see if it's possible to bump the number of enodes in our egraphs to 20k and, in doing so, maybe allow `no-localize` to merge. It's not really clear why we need to bump the number of enodes, but `no-localize` is such a big speedup that maybe this would still be a pareto improvement? Right now, bumping enode count carries a huge cost because our very slow extraction procedure then needs to extract from this bigger egraph, but in the long term, maybe the new encoding can fix that.