### PR TITLE
Add "e.g." to placeholder text

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -167,8 +167,8 @@
        `(form
          ([action ,(url improve)] [method "post"] [id "formula"] [data-progress ,(url improve-start)])
          (textarea ([name "formula"] [autofocus "true"]
-                                     [placeholder "(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
-         (input ([name "formula-math"] [placeholder "sqrt(x + 1) - sqrt(x)"]))
+                                     [placeholder "e.g. (FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))"]))
+         (input ([name "formula-math"] [placeholder "e.g. sqrt(x + 1) - sqrt(x)"]))
          (table ([id "input-ranges"]))
          (ul ([id "errors"]))
          (ul ([id "warnings"]))


### PR DESCRIPTION
This very small change adds "e.g." to the front of the spec input placeholder to solve the issue noted by Ganesh:

![image](https://github.com/user-attachments/assets/40ac4c87-030b-42b1-ba75-232bd1b4a021)

This change matches the behavior of the Odyssey demo. The placeholder lightness there seems to match the current Herbie demo and this doesn't seem to be an issue there.