### PR TITLE
Fix TeXification of named constants like PI

### DIFF
--- a/src/platforms/bool.rkt
+++ b/src/platforms/bool.rkt
@@ -20,7 +20,9 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-constants bool [TRUE TRUE true] [FALSE FALSE false])
+;; Don't use define-constants because don't want to require :precision bool annotation
+(define-operator-impl (TRUE) bool #:spec (TRUE) #:fl (const true) #:fpcore (! TRUE))
+(define-operator-impl (FALSE) bool #:spec (FALSE) #:fl (const false) #:fpcore (! FALSE))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/platforms/runtime/utils.rkt
+++ b/src/platforms/runtime/utils.rkt
@@ -20,7 +20,11 @@
 
 (define-syntax-rule (define-constants repr [name impl-name value] ...)
   (begin
-    (define-operator-impl (impl-name) repr #:spec (name) #:fl (const value)) ...))
+    (define-operator-impl (impl-name)
+                          repr
+                          #:spec (name)
+                          #:fl (const value)
+                          #:fpcore (! :precision binary64 name)) ...))
 
 (define-syntax-rule (define-comparator-impls repr [name impl-name impl-fn attrib ...] ...)
   (begin

--- a/src/platforms/runtime/utils.rkt
+++ b/src/platforms/runtime/utils.rkt
@@ -24,7 +24,7 @@
                           repr
                           #:spec (name)
                           #:fl (const value)
-                          #:fpcore (! :precision binary64 name)) ...))
+                          #:fpcore (! :precision repr name)) ...))
 
 (define-syntax-rule (define-comparator-impls repr [name impl-name impl-fn attrib ...] ...)
   (begin

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -505,8 +505,12 @@
           (for ([impl (in-list (platform-impls (*active-platform*)))]
                 #:when (equal? ireprs (impl-info impl 'itype)))
             (define-values (prop-dict* expr) (impl->fpcore impl))
+            (define expr*
+              (if (symbol? expr)
+                  (list expr)
+                  expr*)) ; Handle named constants
             (define pattern (cons op (map (lambda (_) (gensym)) ireprs)))
-            (when (and (subset? prop-dict* prop-dict) (pattern-match pattern expr))
+            (when (and (subset? prop-dict* prop-dict) (pattern-match pattern expr*))
               (sow impl)))))
   ; check that we have any matching impls
   (cond

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -508,7 +508,7 @@
             (define expr*
               (if (symbol? expr)
                   (list expr)
-                  expr*)) ; Handle named constants
+                  expr)) ; Handle named constants
             (define pattern (cons op (map (lambda (_) (gensym)) ireprs)))
             (when (and (subset? prop-dict* prop-dict) (pattern-match pattern expr*))
               (sow impl)))))

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -150,8 +150,7 @@
 
 (define (assert-fpcore-impl op prop-dict ireprs)
   (or (get-fpcore-impl op prop-dict ireprs)
-      (error
-       'assert-fpcore-impl
+      (raise-herbie-missing-error
        "No implementation for `~a` under rounding context `~a` with types `~a`"
        op
        prop-dict

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -150,7 +150,8 @@
 
 (define (assert-fpcore-impl op prop-dict ireprs)
   (or (get-fpcore-impl op prop-dict ireprs)
-      (raise-herbie-missing-error
+      (error
+       'assert-fpcore-impl
        "No implementation for `~a` under rounding context `~a` with types `~a`"
        op
        prop-dict
@@ -274,7 +275,7 @@
        (match-define (cons expr impl) (vector-ref ivec idx))
        (define impl*
          (match expr
-           [(list '! props ... (list op _ ...))
+           [(list '! props ... (or (? symbol? op) (list op _ ...)))
             ; rounding context updated parent context
             (define prop-dict*
               (if (not (null? props))


### PR DESCRIPTION
These got broken by the transition to the new platforms definition, but now they're fixed.