### PR TITLE
Dump Rival commands from Herbie

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -20,7 +20,7 @@
                        special
                        bools
                        branches)]
-        [dump . (egg)]))
+        [dump . (egg rival)]))
 
 (define default-flags
   #hash([precision . ()]

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -75,10 +75,12 @@
                      #:unless (file-exists? (build-path dump-dir (format "~a.rival" i))))
            (build-path dump-dir (format "~a.rival" i))))
        (define dump-file (open-output-file name #:exists 'replace))
-       (pretty-print `(define (f ,@vars) ,@specs) dump-file 1)
+       (pretty-print `(define (f ,@vars)
+                        ,@specs)
+                     dump-file
+                     1)
        dump-file]
-      [else
-       #f]))
+      [else #f]))
 
   ; wrap it with useful information for Herbie
   (real-compiler pre vars var-reprs specs reprs machine dump-file))

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -7,7 +7,8 @@
 
 #lang racket
 
-(require rival)
+(require math/bigfloat
+         rival)
 
 (require "../config.rkt"
          "../syntax/types.rkt"
@@ -45,7 +46,7 @@
                   (lambda (x y) (- (ulp-difference x y repr) 1))))
 
 ;; Herbie's wrapper around the Rival machine abstraction.
-(struct real-compiler (pre vars var-reprs exprs reprs machine))
+(struct real-compiler (pre vars var-reprs exprs reprs machine dump-file))
 
 ;; Creates a Rival machine.
 ;; Takes a context to encode input variables and their representations,
@@ -62,18 +63,39 @@
   (timeline-push! 'compiler
                   (apply + 1 (expr-size pre) (map expr-size specs))
                   (+ (length vars) (rival-profile machine 'instructions)))
+
+  (define dump-file
+    (cond
+      [(flag-set? 'dump 'rival)
+       (define dump-dir "dump-rival")
+       (unless (directory-exists? dump-dir)
+         (make-directory dump-dir))
+       (define name
+         (for/first ([i (in-naturals)]
+                     #:unless (file-exists? (build-path dump-dir (format "~a.rival" i))))
+           (build-path dump-dir (format "~a.rival" i))))
+       (define dump-file (open-output-file name #:exists 'replace))
+       (pretty-print `(define (f ,@vars) ,@specs) dump-file 1)
+       dump-file]
+      [else
+       #f]))
+
   ; wrap it with useful information for Herbie
-  (real-compiler pre vars var-reprs specs reprs machine))
+  (real-compiler pre vars var-reprs specs reprs machine dump-file))
 
 ;; Runs a Rival machine on an input point.
 (define (real-apply compiler pt)
-  (match-define (real-compiler _ vars var-reprs _ _ machine) compiler)
+  (match-define (real-compiler _ vars var-reprs _ _ machine dump-file) compiler)
   (define start (current-inexact-milliseconds))
   (define pt*
     (for/vector #:length (length vars)
                 ([val (in-list pt)]
                  [repr (in-list var-reprs)])
       ((representation-repr->bf repr) val)))
+  (when dump-file
+    (define args (map bigfloat->rational (vector->list pt*)))
+    ;; convert to rational, because Rival reads as exact
+    (pretty-print `(eval f ,@args) dump-file 1))
   (define-values (status value)
     (with-handlers ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
                     [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -115,7 +115,7 @@
                         ((make-hyperrect-sampler two-point-hyperrects (list repr repr))))))
 
 (define (make-sampler compiler)
-  (match-define (real-compiler pre vars var-reprs _ reprs _) compiler)
+  (match-define (real-compiler pre vars var-reprs _ reprs _ _) compiler)
   (cond
     [(and (flag-set? 'setup 'search)
           (not (empty? var-reprs))


### PR DESCRIPTION
This PR adds a `dump:rival` Herbie flag (analogous to the existing `dump:rival` flag) that dumps every Rival machine to its own file, in Rival format, with every invocation. This might contribute to efforts to make Rival a standalone program.

I've taken some care to ensure that it's *exactly* the same inputs, which is a little annoying to read since it means we have to convert all inputs to rationals. @AYadrov possibly this can replace the existing giant JSON file we use in the Rival nightly.