### PR TITLE
Fix bugs in parsing of :alt expressions

### DIFF
--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -135,12 +135,9 @@
 
 (define (parse-platform-name ann)
   (match ann
-    [(list '! props ...)
-     (let loop ([props props])
-       (match props
-         [(list ':herbie-platform name _ ...) name]
-         [(list _ _ rest ...) (loop rest)]
-         [(list) #f]))]
+    [(list '! props ... body)
+     (define dict (props->dict props))
+     (dict-ref dict ':herbie-platform #f)]
     [_ #f]))
 
 (define (parse-test stx)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -189,7 +189,7 @@
       [(list '! props ... body)
        (loop body
              (if (not (null? props))
-                 (apply dict-set prop-dict props)
+                 (apply dict-set* prop-dict props)
                  prop-dict))]
       [(list 'neg arg) ; non-standard but useful [TODO: remove]
        (define arg* (loop arg prop-dict))


### PR DESCRIPTION
This PR fixes how we parse `:herbie-target` fields to allow them to have more than one property and to have those properties in any order.