### PR TITLE
Possibly speed up `explain`

### DIFF
--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -118,10 +118,11 @@
       (define subexpr-val (exacts-ref subexpr))
 
       (define (update-flow-hash flow-hash pred? . children)
-        (define child-set
-          (foldl (lambda (a b) (hash-union a b #:combine +))
-                 (make-immutable-hash)
-                 (map (lambda (a) (hash-ref flow-hash a (make-immutable-hash))) children)))
+        (define child-set (make-hash))
+        (for ([child (in-list children)])
+          (when (hash-has-key? flow-hash child)
+            (for ([(k v) (in-hash (hash-ref flow-hash child))])
+              (hash-update! child-set k (curry + v) 0))))
         (define parent-set (hash-ref flow-hash subexpr (make-immutable-hash)))
         (define parent+child-set (hash-union parent-set child-set #:combine (lambda (_ v) v)))
         (define new-parent-set


### PR DESCRIPTION
This PR uses a mutable hash in `update-flow-hash` in `explain` to hopefully speed it up. The truth is that `explain` is fairly slow (7% of runtime) and seems to spend most of its time (44%) in `update-flow-hash`, which seems low-value. I don't understand that code well, but it should be possible to speed it up significantly. The actually-slow part of that method, computing ground-truth values, is only about 10% of total `explain` time. Most of the rest is wasted in timelines and `update-flow-hash`.

I'd like to see `explain` reduced from ~7% of runtime to ~1%, which would save us about 4 minutes of total time and justify keeping it on by default.