### PR TITLE
Change execution order for single-threaded server

### DIFF
--- a/infra/test-api.mjs
+++ b/infra/test-api.mjs
@@ -20,7 +20,7 @@ function getFreePort() {
 const PORT = await getFreePort();
 
 console.log("Spawning server on port " + PORT)
-const child = spawn('racket', ['-y', 'src/main.rkt', 'web', '--quiet', '--port', ""+PORT]);
+const child = spawn('racket', ['-y', 'src/main.rkt', '--threads', '2', 'web', '--quiet', '--port', ""+PORT]);
 
 child.stdout.on('data', (data) => {
     console.log(""+data);

--- a/infra/test-api.mjs
+++ b/infra/test-api.mjs
@@ -20,7 +20,7 @@ function getFreePort() {
 const PORT = await getFreePort();
 
 console.log("Spawning server on port " + PORT)
-const child = spawn('racket', ['-y', 'src/main.rkt', '--threads', '2', 'web', '--quiet', '--port', ""+PORT]);
+const child = spawn('racket', ['-y', 'src/main.rkt', 'web', '--threads', '2', '--quiet', '--port', ""+PORT]);
 
 child.stdout.on('data', (data) => {
     console.log(""+data);

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -28,6 +28,7 @@
 
 (provide run-demo)
 
+(define *demo?* (make-parameter false))
 (define *demo-prefix* (make-parameter "/"))
 (define *demo-log* (make-parameter false))
 

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -63,8 +63,7 @@
 (define (merge-profile-jsons ps)
   (profile->json (apply profile-merge (map json->profile (dict-values ps)))))
 
-(define (generate-bench-report job-id bench-name test-number dir number-of-test)
-  (define result (wait-for-job job-id))
+(define (generate-bench-report result bench-name test-number dir total-tests)
   (define report-path (bench-folder-path bench-name test-number))
   (define report-directory (build-path dir report-path))
   (unless (directory-exists? report-directory)
@@ -79,7 +78,7 @@
                                (make-page page out result #t #f)))))
 
   (define table-data (get-table-data-from-hash result report-path))
-  (print-test-result (+ test-number 1) number-of-test table-data)
+  (print-test-result (+ test-number 1) total-tests table-data)
   table-data)
 
 (define (run-tests tests #:dir dir #:threads threads)
@@ -96,7 +95,7 @@
     (for/list ([job-id (in-list job-ids)]
                [test (in-list tests)]
                [test-number (in-naturals)])
-      (generate-bench-report job-id (test-name test) test-number dir (length tests))))
+      (generate-bench-report (wait-for-job job-id) (test-name test) test-number dir (length tests))))
 
   (define info (make-report-info results #:seed seed))
   (write-datafile (build-path dir "results.json") info)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -118,8 +118,8 @@
       (place-channel-put manager (list* msg args))
       (match msg
         ['start
-         (match-define (list hash-false command job-id) args)
          (hash-set! completed-work job-id (herbie-do-server-job command job-id))])))
+         (match-define (list #f command job-id) args)
 
 (define (manager-ask msg . args)
   (log "Asking manager: ~a, ~a.\n" msg args)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -255,9 +255,7 @@
         (define reassigned (make-hash))
         (for ([(wid worker) (in-hash waiting-workers)]
               [(jid command) (in-hash queued-jobs)])
-          (log "Starting worker [~a] on [~a].\n"
-               jid
-               (test-name (herbie-command-test command)))
+          (log "Starting worker [~a] on [~a].\n" jid (test-name (herbie-command-test command)))
           ; Check if the job is already in progress.
           (unless (hash-has-key? current-jobs jid)
             (place-channel-put worker (list 'apply self command jid))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -249,7 +249,7 @@
           [(hash-has-key? completed-jobs job-id)
            (place-channel-put self (list 'send job-id (hash-ref completed-jobs job-id)))]
           [else
-           (hash-set! queued-jobs job-id command job-id)
+           (hash-set! queued-jobs job-id command)
            (place-channel-put self (list 'assign self))])]
        [(list 'assign self)
         (define reassigned (make-hash))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -245,12 +245,12 @@
      (match (place-channel-get ch)
        [(list 'start self command job-id)
         ; Check if the work has been completed already if not assign the work.
-        (if (hash-has-key? completed-jobs job-id)
-            (place-channel-put self (list 'send job-id (hash-ref completed-jobs job-id)))
-            (place-channel-put self (list 'queue self job-id command)))]
-       [(list 'queue self job-id command)
-        (hash-set! queued-jobs job-id command job-id)
-        (place-channel-put self (list 'assign self))]
+        (cond
+          [(hash-has-key? completed-jobs job-id)
+           (place-channel-put self (list 'send job-id (hash-ref completed-jobs job-id)))]
+          [else
+           (hash-set! queued-jobs job-id command job-id)
+           (place-channel-put self (list 'assign self))])]
        [(list 'assign self)
         (define reassigned (make-hash))
         (for ([(wid worker) (in-hash waiting-workers)]

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -21,7 +21,6 @@
 
 (provide make-path
          get-improve-table-data
-         make-improve-result
          server-check-on
          get-results-for
          get-timeline-for
@@ -31,10 +30,8 @@
          wait-for-job
          start-job-server
          write-results-to-disk
-         *demo?*
          *demo-output*)
 
-(define *demo?* (make-parameter false))
 (define *demo-output* (make-parameter false))
 
 (define log-level #f)


### PR DESCRIPTION
Right now, the single-threaded server runs jobs when `start-job` is called. This PR changes it to instead run jobs when `wait-for-job` is called. The reason to change things is simple; `run.rkt` has code that at a high level does:

```racket
(for ([job ...])
  (start-job job))
(for ([job ...])
  (wait-for-job job)
  (print-status job))
```

If we run things in `start-job` then we get all the status prints at the very end, once all jobs are done (useless). If we run then in `wait-for-job` then we get prints one at a time, like we're suppose to.

The PR also has some random minor improvements to the server code.