### PR TITLE
Cleanup various parts of the sandbox/server API

### DIFF
--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -47,7 +47,7 @@
     (match-define (job-result _ test status time timeline profile warnings backend) result)
     (match status
       ['success
-       (match-define (improve-result preprocess pctxs start targets end bogosity) backend)
+       (match-define (improve-result preprocess pctxs start targets end) backend)
        (match-define (alt-analysis start-alt _ start-error) start)
        (match-define (alt-analysis end-alt _ end-error) (first end))
 

--- a/infra/test-api.mjs
+++ b/infra/test-api.mjs
@@ -61,7 +61,7 @@ function makeURL(endpoint) {
 /* Step 2: Test the formal API */
 
 // Reusable testing data
-const SAMPLE_SIZE = 8000
+const SAMPLE_SIZE = 8256
 
 const FPCoreFormula = '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))'
 const FPCoreFormula2 = '(FPCore (x) (- (sqrt (+ x 1))))'

--- a/infra/test-api.mjs
+++ b/infra/test-api.mjs
@@ -137,23 +137,6 @@ await testAPI("/api/analyze", {
   assert.deepEqual(body.points, [[[14.97651307489794], "2.3"]]);
 });
 
-// Exacts endpoint
-await testAPI("/api/exacts", {
-  formula: FPCoreFormula2,
-  sample: eval_sample
-}, (body) => {
-  assert.deepEqual(body.points, [[[1], -1.4142135623730951]]);
-});
-
-// Calculate endpoint
-await testAPI("/api/calculate", {
-  formula: FPCoreFormula2,
-  sample: eval_sample
-}, (body) => {
-  assert.deepEqual(body.points, [[[1], -1.4142135623730951]]);
-});
-
-
 // Local error endpoint
 await testAPI("/api/localerror", {
   formula: FPCoreFormula,

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -62,8 +62,6 @@
                   [("api" "sample") #:method "post" sample-endpoint]
                   [("api" "explanations") #:method "post" explanations-endpoint]
                   [("api" "analyze") #:method "post" analyze-endpoint]
-                  [("api" "exacts") #:method "post" exacts-endpoint]
-                  [("api" "calculate") #:method "post" calculate-endpoint]
                   [("api" "localerror") #:method "post" local-error-endpoint]
                   [("api" "alternatives") #:method "post" alternatives-endpoint]
                   [("api" "cost") #:method "post" cost-endpoint]
@@ -73,8 +71,6 @@
                   [("api" "start" "sample") #:method "post" start-sample-endpoint]
                   [("api" "start" "explanations") #:method "post" start-explanations-endpoint]
                   [("api" "start" "analyze") #:method "post" start-analyze-endpoint]
-                  [("api" "start" "exacts") #:method "post" start-exacts-endpoint]
-                  [("api" "start" "calculate") #:method "post" start-calculate-endpoint]
                   [("api" "start" "localerror") #:method "post" start-local-error-endpoint]
                   [("api" "start" "alternatives") #:method "post" start-alternatives-endpoint]
                   [("api" "start" "cost") #:method "post" start-cost-endpoint]))
@@ -453,23 +449,6 @@
 
 (define-endpoint ([analyze-endpoint start-analyze-endpoint] post-data)
                  (start-job 'errors
-                            (get-test post-data)
-                            #:seed (parse-seed post-data)
-                            #:pcontext (get-pcontext post-data)
-                            #:profile? #f
-                            #:timeline-disabled? #t))
-
-;; (await fetch('/api/exacts', {method: 'POST', body: JSON.stringify({formula: "(FPCore (x) (- (sqrt (+ x 1))))", points: [[1, 1]]})})).json()
-(define-endpoint ([exacts-endpoint start-exacts-endpoint] post-data)
-                 (start-job 'exacts
-                            (get-test post-data)
-                            #:seed (parse-seed post-data)
-                            #:pcontext (get-pcontext post-data)
-                            #:profile? #f
-                            #:timeline-disabled? #t))
-
-(define-endpoint ([calculate-endpoint start-calculate-endpoint] post-data)
-                 (start-job 'evaluate
                             (get-test post-data)
                             #:seed (parse-seed post-data)
                             #:pcontext (get-pcontext post-data)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -38,6 +38,7 @@
 (struct alt-analysis (alt train-errors test-errors) #:prefab)
 
 (define (sample-pcontext test)
+  (random) ;; Tick the random number generator, for backwards compatibility
   (define specification (prog->spec (or (test-spec test) (test-input test))))
   (define precondition (prog->spec (test-pre test)))
   (define sample
@@ -168,9 +169,6 @@
 ;; Improvement backend for generating reports
 ;; A more heavyweight version of `get-alternatives`
 (define (get-alternatives/report test)
-  (define seed (get-seed))
-  (random) ;; Child process uses deterministic but different seed from evaluator
-
   (define joint-pcontext (sample-pcontext test))
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext joint-pcontext))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -107,7 +107,7 @@
 
 ;; Given a test and a sample of points,
 ;; the floating-point result at each point
-(define (get-calculation test pcontext)
+(define (get-evaluate test pcontext)
   (unless pcontext
     (error 'get-calculation "cannnot run without a pcontext"))
 
@@ -168,7 +168,7 @@
 
 ;; Improvement backend for generating reports
 ;; A more heavyweight version of `get-alternatives`
-(define (get-alternatives/report test)
+(define (get-improve test)
   (define joint-pcontext (sample-pcontext test))
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext joint-pcontext))
@@ -252,13 +252,13 @@
         (define result
           (match command
             ['alternatives (get-alternatives test pcontext seed)]
-            ['evaluate (get-calculation test pcontext)]
             ['cost (get-cost test)]
             ['errors (get-errors test pcontext)]
+            ['evaluate (get-evaluate test pcontext)]
             ['exacts (get-exacts test pcontext)]
-            ['improve (get-alternatives/report test)]
-            ['local-error (get-local-error test pcontext)]
             ['explanations (get-explanations test pcontext)]
+            ['improve (get-improve test)]
+            ['local-error (get-local-error test pcontext)]
             ['sample (get-sample test)]
             [_ (error 'compute-result "unknown command ~a" command)]))
         (timeline-event! 'end)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -90,32 +90,6 @@
              [err (in-list errs)])
     (list pt err)))
 
-;; Given a test and a sample of points, the ground truth of each point
-;; If the sample contains the expected number of points, i.e., `(*num-points*) + (*reeval-pts*)`,
-;; then the first `*num-points*` will be discarded and the rest will be used for evaluation,
-;; otherwise the entire set is used.
-(define (get-exacts test pcontext)
-  (unless pcontext
-    (error 'get-exacts "cannnot run without a pcontext"))
-  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
-  (define pts (pcontext-points test-pcontext))
-  (define fn (eval-progs-real (list (prog->spec (test-input test))) (list (*context*))))
-  (for/list ([pt pts])
-    (list pt (car (apply fn pt)))))
-
-;; Given a test and a sample of points,
-;; the floating-point result at each point
-(define (get-evaluate test pcontext)
-  (unless pcontext
-    (error 'get-calculation "cannnot run without a pcontext"))
-
-  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
-  (define pts (pcontext-points test-pcontext))
-
-  (define fn (compile-prog (test-input test) (test-context test)))
-  (for/list ([pt pts])
-    (list pt (apply fn pt))))
-
 ;; Given a test and a sample of points, computes the local error at every node in the expression
 ;; returning a tree of errors that mirrors the structure of the expression.
 ;; If the sample contains the expected number of points, i.e., `(*num-points*) + (*reeval-pts*)`,
@@ -252,8 +226,6 @@
             ['alternatives (get-alternatives test pcontext seed)]
             ['cost (get-cost test)]
             ['errors (get-errors test pcontext)]
-            ['evaluate (get-evaluate test pcontext)]
-            ['exacts (get-exacts test pcontext)]
             ['explanations (get-explanations test pcontext)]
             ['improve (get-improve test)]
             ['local-error (get-local-error test pcontext)]

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -34,7 +34,7 @@
          (struct-out alt-analysis))
 
 (struct job-result (command test status time timeline profile warnings backend))
-(struct improve-result (preprocess pctxs start target end bogosity))
+(struct improve-result (preprocess pctxs start target end))
 (struct alt-analysis (alt train-errors test-errors) #:prefab)
 
 (define (sample-pcontext vars specification precondition)
@@ -216,7 +216,7 @@
   (timeline-adjust! 'regimes 'link ".")
 
   (define pctxs (list train-pcontext test-pcontext*))
-  (improve-result preprocessing pctxs start-alt-data target-alt-data end-data domain-stats))
+  (improve-result preprocessing pctxs start-alt-data target-alt-data end-data))
 
 ;;
 ;;  Public interface

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -74,9 +74,7 @@
 
 ;; Given a test and a sample of points, returns the test points.
 (define (get-sample test)
-  (define joint-pcontext (sample-pcontext test))
-  (define-values (_ test-pcontext) (partition-pcontext joint-pcontext))
-  test-pcontext)
+  (sample-pcontext test))
 
 ;; Given a test and a sample of points, computes the error at each point.
 ;; If the sample contains the expected number of points, i.e., `(*num-points*) + (*reeval-pts*)`,

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -99,16 +99,14 @@
   (unless pcontext
     (error 'get-local-error "cannnot run without a pcontext"))
 
-  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
-  (*pcontext* test-pcontext)
+  (*pcontext* pcontext)
   (local-error-as-tree (test-input test) (*context*)))
 
 (define (get-explanations test pcontext)
   (unless pcontext
     (error 'explain "cannot run without a pcontext"))
 
-  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
-  (*pcontext* test-pcontext)
+  (*pcontext* pcontext)
   (define-values (fperrors
                   sorted-explanations-table
                   confusion-matrix

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -160,8 +160,8 @@
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
   ;; TODO: Ignoring all user-provided preprocessing right now
-  (define-values (alternatives preprocessing)
-    (run-improve! (test-input test) (test-spec test) (*context*) train-pcontext))
+  (define alternatives (run-improve! (test-input test) (test-spec test) (*context*) train-pcontext))
+  (define preprocessing (alt-preprocessing (first alternatives)))
   (define test-pcontext* (preprocess-pcontext (*context*) test-pcontext preprocessing))
 
   (list alternatives test-pcontext test-pcontext*))
@@ -173,13 +173,13 @@
 
   (define-values (train-pcontext test-pcontext) (partition-pcontext joint-pcontext))
   ;; TODO: Ignoring all user-provided preprocessing right now
-  (define-values (alternatives preprocessing)
-    (run-improve! (test-input test) (test-spec test) (*context*) train-pcontext))
+  (define alternatives (run-improve! (test-input test) (test-spec test) (*context*) train-pcontext))
+  (define preprocessing (alt-preprocessing (first alternatives)))
   (define test-pcontext* (preprocess-pcontext (*context*) test-pcontext preprocessing))
 
   ;; compute error/cost for input expression
   (define start-expr (test-input test))
-  (define start-alt (make-alt start-expr))
+  (define start-alt (make-alt-preprocessing start-expr (test-preprocess test)))
   (define start-train-errs (errors start-expr train-pcontext (*context*)))
   (define start-test-errs (errors start-expr test-pcontext* (*context*)))
   (define start-alt-data (alt-analysis start-alt start-train-errs start-test-errs))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -477,18 +477,7 @@
 (define (make-alternatives-result herbie-result job-id)
 
   (define test (job-result-test herbie-result))
-  (define vars (test-vars test))
-  (define repr (test-output-repr test))
-
   (match-define (list altns test-pcontext processed-pcontext) (job-result-backend herbie-result))
-  (define splitpoints
-    (for/list ([alt altns])
-      (for/list ([var vars])
-        (define split-var? (equal? var (regime-var alt)))
-        (if split-var?
-            (for/list ([val (regime-splitpoints alt)])
-              (real->ordinal (repr->real val repr) repr))
-            '()))))
 
   (define fpcores
     (for/list ([altn altns])
@@ -507,9 +496,7 @@
       (render-json altn processed-pcontext test-pcontext (test-context test))))
   (hasheq 'alternatives
           fpcores
-          'histories
+          'histories ; FIXME: currently used by Odyssey but should switch to 'derivations below
           histories
           'derivations
-          derivations
-          'splitpoints
-          splitpoints))
+          derivations))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -440,9 +440,7 @@
           'target
           (improve-result-target backend)
           'end
-          end-hash-table
-          'bogosity
-          (improve-result-bogosity backend)))
+          end-hash-table))
 
 (define (end-hash end repr pcontexts test)
 

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -142,8 +142,6 @@
     ['alternatives make-alternatives-result]
     ['cost make-cost-result]
     ['errors make-error-result]
-    ['evaluate make-calculate-result]
-    ['exacts make-exacts-result]
     ['explanations make-explanation-result]
     ['improve make-improve-result]
     ['local-error make-local-error-result]
@@ -375,9 +373,6 @@
   (define repr (context-repr (test-context test)))
   (hasheq 'points (pcontext->json pctx repr)))
 
-(define (make-calculate-result herbie-result job-id)
-  (hasheq 'points (job-result-backend herbie-result)))
-
 (define (make-cost-result herbie-result job-id)
   (hasheq 'cost (job-result-backend herbie-result)))
 
@@ -388,9 +383,6 @@
       (define err (second pt&err))
       (list pt (format-bits (ulps->bits err)))))
   (hasheq 'points errs))
-
-(define (make-exacts-result herbie-result job-id)
-  (hasheq 'points (job-result-backend herbie-result)))
 
 (define (make-improve-result herbie-result job-id)
   (define test (job-result-test herbie-result))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -53,7 +53,8 @@
 
      ;; We don't want unused alts in our history!
      (define-values (alts* splitpoints*) (remove-unused-alts alts splitpoints))
-     (alt expr* (list 'regimes splitpoints*) alts* '())]))
+     (define preprocessing (alt-preprocessing (first alts*)))
+     (alt expr* (list 'regimes splitpoints*) alts* preprocessing)]))
 
 (define (remove-unused-alts alts splitpoints)
   (for/fold ([alts* '()]

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -17,12 +17,12 @@
 (define (add-derivations-to altn)
   (match altn
     ; recursive rewrite or simplify, both using egg
-    [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) _)
+    [(alt expr (list (or 'simplify 'rr) loc (? egg-runner? runner) #f) `(,prev) preprocessing)
      (define start-expr (location-get loc (alt-expr prev)))
      (define end-expr (location-get loc expr))
      (define proof (egraph-prove runner start-expr end-expr))
      (define proof* (canonicalize-proof (alt-expr altn) proof loc))
-     (alt expr `(rr ,loc ,runner ,proof*) `(,prev) '())]
+     (alt expr `(rr ,loc ,runner ,proof*) `(,prev) preprocessing)]
 
     ; everything else
     [_ altn]))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -59,7 +59,8 @@
     (for/list ([altn alternatives])
       (define expr (alt-expr altn))
       (define preprocessing (alt-preprocessing altn))
-      (alt-add-preprocessing altn (remove-unnecessary-preprocessing expr context pcontext preprocessing))))
+      (alt-add-preprocessing altn
+                             (remove-unnecessary-preprocessing expr context pcontext preprocessing))))
   final-alts)
 
 (define (extract!)

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -55,13 +55,12 @@
   (define alternatives (extract!))
 
   (timeline-event! 'preprocess)
-  (define best (alt-expr (first alternatives)))
   (define final-alts
-    (for/list ([altern alternatives])
-      (alt-add-preprocessing
-       altern
-       (remove-unnecessary-preprocessing best context pcontext (alt-preprocessing altern)))))
-  (values final-alts (remove-unnecessary-preprocessing best context pcontext preprocessing)))
+    (for/list ([altn alternatives])
+      (define expr (alt-expr altn))
+      (define preprocessing (alt-preprocessing altn))
+      (alt-add-preprocessing altn (remove-unnecessary-preprocessing expr context pcontext preprocessing))))
+  final-alts)
 
 (define (extract!)
   (timeline-push-alts! '())

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -220,4 +220,5 @@
           #:url "faq.html#inf-points"
           "~a of points produce a very large (infinite) output. You may want to add a precondition."
           (format-accuracy (- total (hash-ref table2 'infinite)) total #:unit "%")))
-  (cons (combine-tables table table2) results))
+  (timeline-push! 'bogosity (combine-tables table table2))
+  results)

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -46,7 +46,7 @@
   (match-define (list pts exs)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (cdr (sample-points '(TRUE) (list p1) (list ctx)))))
+      (sample-points '(TRUE) (list p1) (list ctx))))
 
   (define compiler (make-real-compiler (list p2) (list ctx)))
   (for ([pt (in-list pts)]
@@ -68,7 +68,7 @@
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (cdr (sample-points pre (list p1 p2) (list ctx ctx)))))
+      (sample-points pre (list p1 p2) (list ctx ctx))))
 
   (for ([pt (in-list pts)]
         [v1 (in-list exs1)]

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -125,7 +125,7 @@
 (define (render-comparison #:title [title #f] name a b)
   (render-large #:title title name a `(span ((class "unit")) " → ") b))
 
-(define (render-specification test #:bogosity [bogosity #f])
+(define (render-specification test)
   (define-values (dropdown body)
     (render-program (test-spec test)
                     (test-context test)
@@ -137,14 +137,7 @@
                               (a ((class "help-button float") [href ,(doc-url "report.html#spec")]
                                                               [target "_blank"])
                                  "?"))
-                     ,body
-                     ,@(cond
-                         [bogosity
-                          `((p "Sampling outcomes in "
-                               (kbd ,(~a (representation-name (test-output-repr test))))
-                               " precision:")
-                            ,(render-bogosity bogosity))]
-                         [else '()]))))
+                     ,body)))
 
 (define languages
   `(("FPCore" "fpcore" ,(λ (c i) (fpcore->string c))) ("C" "c" ,core->c)

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -41,7 +41,6 @@
   (match-define (alt-analysis start-alt _ start-error) (hash-ref backend 'start))
   (define targets (hash-ref backend 'target))
   (define end (hash-ref backend 'end))
-  (define bogosity (hash-ref backend 'bogosity))
 
   (define start-cost (alt-cost start-alt repr))
 
@@ -101,7 +100,7 @@
                              #:title "Relative speed of fastest alternative that improves accuracy.")
                ""))
      ,(render-warnings warnings)
-     ,(render-specification test #:bogosity bogosity)
+     ,(render-specification test)
      (figure ([id "graphs"])
              (h2 "Local Percentage Accuracy vs "
                  (span ([id "variables"]))


### PR DESCRIPTION
This PR is a kind of grab-bag of cleanups, including:

- [x] Removing bogosity from the reports (still present in timeline)
- [x] Simplify the `sandbox.rkt` code by deduplicating data and moving around common APIs
- [x] Clean up preprocessing somewhat (still a mess)
- [x] Delete some APIs, remove some steps from other APIs
- [-] Make `get-alternatives` and `get-improve` more similar, gearing up for eventual merge

The long-term vision here is to make `get-alternatives` and `get-improve` use the same exact code path and the same exact output formats, thereby ultimately fixing #1058.