### PR TITLE
Merge `/api/improve` and `/api/alternatives`, remove custom Herbie properties

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,12 +37,12 @@ jobs:
         run: |
           <bench/tutorial.fpcore racket -l herbie shell >/tmp/out.fpcore
           test `grep -c :precision /tmp/out.fpcore` -eq 3
-          test `grep -c -v ';;' /tmp/out.fpcore` -eq 3
+          test `grep -c -v ';;' /tmp/out.fpcore` -eq 0
       - name: "Test the improve command-line tool"
         run: |
           racket -l herbie improve bench/tutorial.fpcore /tmp/out.fpcore
           test `grep -c :precision /tmp/out.fpcore` -eq 3
-          test `grep -c -v '; ' /tmp/out.fpcore` -eq 3
+          test `grep -c -v '; ' /tmp/out.fpcore` -eq 0
       - name: "Run the report command-line tool"
         run: |
           racket -l herbie report bench/tutorial.fpcore /tmp/out/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -36,11 +36,13 @@ jobs:
       - name: "Test the shell command-line tool"
         run: |
           <bench/tutorial.fpcore racket -l herbie shell >/tmp/out.fpcore
-          test `grep -c :herbie-time /tmp/out.fpcore` -eq 3
+          test `grep -c :precision /tmp/out.fpcore` -eq 3
+          test `grep -c -v ';;' /tmp/out.fpcore` -eq 3
       - name: "Test the improve command-line tool"
         run: |
           racket -l herbie improve bench/tutorial.fpcore /tmp/out.fpcore
-          test `grep -c :herbie-time /tmp/out.fpcore` -eq 3
+          test `grep -c :precision /tmp/out.fpcore` -eq 3
+          test `grep -c -v '; ' /tmp/out.fpcore` -eq 3
       - name: "Run the report command-line tool"
         run: |
           racket -l herbie report bench/tutorial.fpcore /tmp/out/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,12 +37,12 @@ jobs:
         run: |
           <bench/tutorial.fpcore racket -l herbie shell >/tmp/out.fpcore
           test `grep -c :precision /tmp/out.fpcore` -eq 3
-          test `grep -c -v ';;' /tmp/out.fpcore` -eq 0
+          test `grep -c ';;' /tmp/out.fpcore` -eq 0
       - name: "Test the improve command-line tool"
         run: |
           racket -l herbie improve bench/tutorial.fpcore /tmp/out.fpcore
           test `grep -c :precision /tmp/out.fpcore` -eq 3
-          test `grep -c -v '; ' /tmp/out.fpcore` -eq 0
+          test `grep -c '; ' /tmp/out.fpcore` -eq 0
       - name: "Run the report command-line tool"
         run: |
           racket -l herbie report bench/tutorial.fpcore /tmp/out/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           racket -l herbie improve bench/tutorial.fpcore /tmp/out.fpcore
           test `grep -c :precision /tmp/out.fpcore` -eq 3
-          test `grep -c '; ' /tmp/out.fpcore` -eq 0
+          test `grep -c '^; ' /tmp/out.fpcore` -eq 0
       - name: "Run the report command-line tool"
         run: |
           racket -l herbie report bench/tutorial.fpcore /tmp/out/

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -77,11 +77,6 @@
 
 (define (generate-page req job-id page)
   (define path (first (string-split (url->string (request-uri req)) "/")))
-  (cond
-    [(check-and-send path job-id page)]
-    [else (next-dispatcher)]))
-
-(define (check-and-send path job-id page)
   (define result-hash (get-results-for job-id))
   (cond
     [(set-member? (all-pages result-hash) page)
@@ -96,7 +91,7 @@
                (λ (out)
                  (with-handlers ([exn:fail? (page-error-handler result-hash page out)])
                    (make-page page out result-hash (*demo-output*) #f))))]
-    [else #f]))
+    [else (next-dispatcher)]))
 
 (define (generate-report req)
   (cond

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -224,7 +224,7 @@
       (on-timeout)))
 
 (define (dummy-table-row-from-hash result-hash status link)
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define repr (test-output-repr test))
   (define preprocess
     (if (eq? (hash-ref result-hash 'status) 'success)
@@ -253,7 +253,7 @@
              '()))
 
 (define (get-table-data-from-hash result-hash link)
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define backend (hash-ref result-hash 'backend))
   (define status (hash-ref result-hash 'status))
   (match status

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -195,11 +195,11 @@
         (timeline-event! 'start) ; Prevents the timeline from being empty.
         (define result
           (match command
-            ['alternatives (get-improve test pcontext)]
+            ['alternatives (get-alternatives test pcontext)]
             ['cost (get-cost test)]
             ['errors (get-errors test pcontext)]
             ['explanations (get-explanations test pcontext)]
-            ['improve (get-improve test (get-sample test))]
+            ['improve (get-alternatives test (get-sample test))]
             ['local-error (get-local-error test pcontext)]
             ['sample (get-sample test)]
             [_ (error 'compute-result "unknown command ~a" command)]))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -223,7 +223,7 @@
         (timeline-event! 'start) ; Prevents the timeline from being empty.
         (define result
           (match command
-            ['alternatives (get-alternatives test pcontext)]
+            ['alternatives (get-improve test pcontext)]
             ['cost (get-cost test)]
             ['errors (get-errors test pcontext)]
             ['explanations (get-explanations test pcontext)]

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -119,23 +119,6 @@
 
 ;; TODO: What in the timeline needs fixing with these changes?
 
-;; Given a test and a sample of points, returns a list of improved alternatives
-;; and both the test set of points and processed test set of points.
-;; If the sample contains the expected number of points, i.e., `(*num-points*) + (*reeval-pts*)`,
-;; then the first `*num-points*` will be discarded and the rest will be used for evaluation,
-;; otherwise the entire set is used.
-(define (get-alternatives test pcontext)
-  (unless pcontext
-    (error 'get-alternatives "cannnot run without a pcontext"))
-
-  (define-values (train-pcontext test-pcontext) (partition-pcontext pcontext))
-  ;; TODO: Ignoring all user-provided preprocessing right now
-  (define alternatives (run-improve! (test-input test) (test-spec test) (*context*) train-pcontext))
-  (define preprocessing (alt-preprocessing (first alternatives)))
-  (define test-pcontext* (preprocess-pcontext (*context*) test-pcontext preprocessing))
-
-  (list alternatives test-pcontext test-pcontext*))
-
 ;; Improvement backend for generating reports
 ;; This is (get-alternatives) + a bunch of extra evaluation / data collection
 (define (get-improve test joint-pcontext)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -228,7 +228,8 @@
   (define repr (test-output-repr test))
   (define preprocess
     (if (eq? (hash-ref result-hash 'status) 'success)
-        (hash-ref (hash-ref result-hash 'backend) 'preprocessing)
+        (map (compose read open-input-string)
+             (hash-ref (hash-ref result-hash 'backend) 'preprocessing))
         (test-preprocess test)))
   (table-row (test-name test)
              (test-identifier test)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -151,7 +151,6 @@
       (sample-points precondition (list specification) (list (*context*)))))
   (apply mk-pcontext sample))
 
-
 ;;
 ;;  Public interface
 ;;

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -147,11 +147,11 @@
 
 (define (get-json-converter command)
   (match (herbie-command-command command)
-    ['alternatives make-improve-result]
+    ['alternatives make-alternatives-result]
     ['cost make-cost-result]
     ['errors make-error-result]
     ['explanations make-explanation-result]
-    ['improve make-improve-result]
+    ['improve make-alternatives-result]
     ['local-error make-local-error-result]
     ['sample make-sample-result]
     [_ (error 'compute-result "unknown command ~a" command)]))
@@ -394,7 +394,7 @@
       (list pt (format-bits (ulps->bits err)))))
   (hasheq 'points errs))
 
-(define (make-improve-result herbie-result job-id)
+(define (make-alternatives-result herbie-result job-id)
   (define test (job-result-test herbie-result))
   (define ctx (context->json (test-context test)))
   (define backend (job-result-backend herbie-result))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -440,6 +440,8 @@
 
   (hasheq 'status
           (~a (job-result-status herbie-result))
+          'name
+          (test-name test)
           'test
           (~s test-fpcore)
           'time

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -409,16 +409,15 @@
       ['failure (exception->datum backend)]))
 
 
+  (define altns (map alt-analysis-alt (improve-result-end backend)))
   (match-define (list train-pcontext processed-pcontext) (improve-result-pctxs backend))
 
   (define fpcores
-    (for/list ([analysis (improve-result-end backend)])
-      (define altn (alt-analysis-alt analysis))
+    (for/list ([altn (in-list altns)])
       (~a (program->fpcore (alt-expr altn) (test-context test)))))
 
   (define histories
-    (for/list ([analysis (improve-result-end backend)])
-      (define altn (alt-analysis-alt analysis))
+    (for/list ([altn (in-list altns)])
       (define os (open-output-string))
       (parameterize ([current-output-port os])
         (write-xexpr
@@ -426,7 +425,7 @@
                (ol ,@(render-history altn processed-pcontext train-pcontext (test-context test)))))
         (get-output-string os))))
   (define derivations
-    (for/list ([altn altns])
+    (for/list ([altn (in-list altns)])
       (render-json altn processed-pcontext train-pcontext (test-context test))))
 
   (hasheq 'status

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -465,7 +465,7 @@
   (define repr (context-repr (test-context test)))
   (define pcontexts (improve-result-pctxs backend))
   (hasheq 'preprocessing
-          (improve-result-preprocess backend)
+          (map ~s (improve-result-preprocess backend))
           'pctxs
           (map (curryr pcontext->json repr) pcontexts)
           'start

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -396,7 +396,6 @@
 
 (define (make-alternatives-result herbie-result job-id)
   (define test (job-result-test herbie-result))
-  (define ctx (context->json (test-context test)))
   (define backend (job-result-backend herbie-result))
   (define job-time (job-result-time herbie-result))
   (define warnings (job-result-warnings herbie-result))
@@ -501,12 +500,6 @@
           cost
           'splitpoints
           splitpoints))
-
-(define (context->json ctx)
-  (hasheq 'vars (context-vars ctx) 'repr (repr->json (context-repr ctx))))
-
-(define (repr->json repr)
-  (hasheq 'name (~s (representation-name repr)) 'type (representation-type repr)))
 
 (define (alt->fpcore test altn)
   `(FPCore ,@(filter identity (list (test-identifier test)))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -481,8 +481,7 @@
   (define cost (alt-cost alt repr))
 
   (match-define (list train-pcontext processed-pcontext) pcontexts)
-  (define history
-    (render-history alt processed-pcontext train-pcontext (test-context test)))
+  (define history (render-history alt processed-pcontext train-pcontext (test-context test)))
 
   (define vars (test-vars test))
   (define splitpoints
@@ -508,10 +507,10 @@
 (define (alt->fpcore test altn)
   `(FPCore ,@(filter identity (list (test-identifier test)))
            ,(for/list ([var (in-list (test-vars test))])
-               (define repr (dict-ref (test-var-repr-names test) var))
-               (if (equal? repr (test-output-repr-name test))
-                   var
-                   (list '! ':precision repr var)))
+              (define repr (dict-ref (test-var-repr-names test) var))
+              (if (equal? repr (test-output-repr-name test))
+                  var
+                  (list '! ':precision repr var)))
            :name
            ,(test-name test)
            :precision

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -118,7 +118,7 @@
   finished-result)
 
 (define (manager-tell msg . args)
-  (log "Telling manager: ~a, ~a.\n" msg args)
+  (log "Telling manager: ~a.\n" msg)
   (if manager
       (place-channel-put manager (list* msg args))
       (match msg

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -508,30 +508,3 @@
 (define (repr->json repr)
   (hasheq 'name (representation-name repr) 'type (representation-type repr)))
 
-(define (make-alternatives-result herbie-result job-id)
-
-  (define test (job-result-test herbie-result))
-  (match-define (list altns test-pcontext processed-pcontext) (job-result-backend herbie-result))
-
-  (define fpcores
-    (for/list ([altn altns])
-      (~a (program->fpcore (alt-expr altn) (test-context test)))))
-
-  (define histories
-    (for/list ([altn altns])
-      (define os (open-output-string))
-      (parameterize ([current-output-port os])
-        (write-xexpr
-         `(div ([id "history"])
-               (ol ,@(render-history altn processed-pcontext test-pcontext (test-context test)))))
-        (get-output-string os))))
-  (define derivations
-    (for/list ([altn altns])
-      (render-json altn processed-pcontext test-pcontext (test-context test))))
-
-  (hasheq 'alternatives
-          fpcores
-          'histories ; FIXME: currently used by Odyssey but should switch to 'derivations below
-          histories
-          'derivations
-          derivations))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -29,8 +29,7 @@
   (for ([res results]
         [test tests]
         #:when res)
-    (define test (car (load-tests (open-input-string (hash-ref res 'test)))))
-    (define name (test-name test))
+    (define name (hash-ref res 'name))
     (match (hash-ref res 'status)
       ['failure
        (match-define (list 'exn type msg url locs traceback) (hash-ref res 'backend))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -78,4 +78,4 @@
            (printf ";   ~a:~a~a: ~a\n" file line col msg))
          (printf "; See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url)]
         ['timeout
-         (printf "Timeout in ~as (see --timeout option)\n" (/ (hash-ref result 'time) 1000))]))))
+         (printf "; Timeout in ~as (see --timeout option)\n" (/ (hash-ref result 'time) 1000))]))))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -31,11 +31,11 @@
         #:when res)
     (define name (hash-ref res 'name))
     (match (hash-ref res 'status)
-      ['failure
+      ["failure"
        (match-define (list 'exn type msg url locs traceback) (hash-ref res 'backend))
        (fprintf p ";; ~a in ~a\n" (if type "Error" "Crash") name)]
-      ['timeout (fprintf p ";; ~a times out in ~as\n" (/ (*timeout*) 1000) name)]
-      ['success (void)])
+      ["timeout" (fprintf p ";; ~a times out in ~as\n" (/ (*timeout*) 1000) name)]
+      ["success" (void)])
     (pretty-print (job-result->fpcore res) p 1)))
 
 (define (run-improve input output #:threads [threads #f])
@@ -68,13 +68,13 @@
           [idx (in-naturals)])
       (define result (wait-for-job (start-job 'improve test #:seed seed)))
       (match (hash-ref result 'status)
-        ['success (pretty-print (job-result->fpcore result) (current-output-port) 1)]
-        ['failure
+        ["success" (pretty-print (job-result->fpcore result) (current-output-port) 1)]
+        ["failure"
          (match-define (list 'exn type msg url locs traceback) (hash-ref result 'backend))
          (printf "; ~a\n" msg)
          (for ([loc (in-list locs)])
            (match-define (list msg file line col pos) loc)
            (printf ";   ~a:~a~a: ~a\n" file line col msg))
          (printf "; See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url)]
-        ['timeout
+        ["timeout"
          (printf "; Timeout in ~as (see --timeout option)\n" (/ (hash-ref result 'time) 1000))]))))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -1,52 +1,10 @@
 #lang racket
 
 (require "../syntax/read.rkt"
-         "../syntax/types.rkt"
-         "../syntax/sugar.rkt"
          "../utils/common.rkt"
-         "datafile.rkt"
-         "sandbox.rkt"
          "server.rkt")
 (provide run-shell
          run-improve)
-
-(define (unparse-result row)
-  (define vars (table-row-vars row))
-  (define repr (get-representation (table-row-precision row)))
-  (define ctx (context vars repr (map (const repr) vars))) ; TODO: this seems wrong
-  (define expr (or (table-row-output row) (table-row-input row)))
-  `(FPCore ,@(filter identity (list (table-row-identifier row)))
-           ,vars
-           :herbie-status
-           ,(string->symbol (table-row-status row))
-           :herbie-time
-           ,(table-row-time row)
-           :herbie-error-input
-           ([,(*num-points*) ,(table-row-start-est row)] [,(*reeval-pts*) ,(table-row-start row)])
-           :herbie-error-output
-           ([,(*num-points*) ,(table-row-result-est row)] [,(*reeval-pts*) ,(table-row-result row)])
-           ,@(apply append
-                    (for/list ([rec (in-list (table-row-target row))])
-                      (match-define (list cost score) rec)
-                      `(:herbie-error-target ([,(*reeval-pts*) ,(table-row-target row)]))))
-           ,@(if (empty? (table-row-warnings row))
-                 '()
-                 `(:herbie-warnings ,(table-row-warnings row)))
-           :name
-           ,(table-row-name row)
-           :precision
-           ,(table-row-precision row)
-           ,@(if (eq? (table-row-pre row) 'TRUE)
-                 '()
-                 `(:pre ,(table-row-pre row)))
-           ,@(if (equal? (table-row-preprocess row) empty)
-                 '()
-                 `(:herbie-preprocess ,(table-row-preprocess row)))
-           ,@(apply append
-                    (for/list ([(target enabled?) (in-dict (table-row-target-prog row))]
-                               #:when enabled?)
-                      `(:alt ,target)))
-           ,(prog->fpcore expr ctx)))
 
 (define (get-shell-input)
   (printf "herbie> ")
@@ -62,29 +20,24 @@
        eof]
       [else (parse-test input)])))
 
+(define (job-result->fpcore result)
+  (read (open-input-string (first (hash-ref result 'alternatives)))))
+
 (define (print-improve-outputs tests results p #:seed [seed #f])
   (when seed
     (fprintf p ";; seed: ~a\n\n" seed))
   (for ([res results]
         [test tests]
         #:when res)
-    (define name (table-row-name res))
-    (match (table-row-status res)
-      ["error"
-       (fprintf p ";; Error in ~a\n" name)
-       (write (unparse-result res) p)
-       (newline p)]
-      ["crash"
-       (fprintf p ";; Crash in ~a\n" name)
-       (write (unparse-result res) p)
-       (newline p)]
-      ["timeout"
-       (fprintf p ";; ~a times out in ~as\n" (/ (*timeout*) 1000) name)
-       (write (unparse-result res) p)
-       (newline p)]
-      [(? string?)
-       (write (unparse-result res) p)
-       (newline p)])))
+    (define test (hash-ref res 'test))
+    (define name (test-name test))
+    (match (hash-ref res 'status)
+      ['failure
+       (match-define (list 'exn type msg url locs traceback) (hash-ref res 'backend))
+       (fprintf p ";; ~a in ~a\n" (if type "Error" "Crash") name)]
+      ['timeout (fprintf p ";; ~a times out in ~as\n" (/ (*timeout*) 1000) name)]
+      ['success (void)])
+    (pretty-print (job-result->fpcore res) p 1)))
 
 (define (run-improve input output #:threads [threads #f])
   (define seed (get-seed))
@@ -95,7 +48,7 @@
       (start-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f)))
   (define results
     (for/list ([id ids])
-      (get-table-data-from-hash (wait-for-job id) "")))
+      (wait-for-job id)))
 
   (if (equal? output "-")
       (print-improve-outputs tests results (current-output-port) #:seed seed)
@@ -115,11 +68,8 @@
     (for ([test (in-producer get-shell-input eof-object?)]
           [idx (in-naturals)])
       (define result (wait-for-job (start-job 'improve test #:seed seed)))
-      (define status (hash-ref result 'status))
-      (define time (hash-ref result 'time))
-      (define table-data (get-table-data-from-hash result ""))
-      (match status
-        ['success (pretty-print (unparse-result table-data) (current-output-port) 1)]
+      (match (hash-ref result 'status)
+        ['success (pretty-print (job-result->fpcore result) (current-output-port) 1)]
         ['failure
          (match-define (list 'exn type msg url locs traceback) (hash-ref result 'backend))
          (printf "; ~a\n" msg)
@@ -127,5 +77,5 @@
            (match-define (list msg file line col pos) loc)
            (printf ";   ~a:~a~a: ~a\n" file line col msg))
          (printf "; See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url)]
-        ['timeout (printf "Timeout in ~as (see --timeout option)\n" (/ time 1000))]
-        [else (error 'run-shell "unknown result type ~a" status)]))))
+        ['timeout
+         (printf "Timeout in ~as (see --timeout option)\n" (/ (hash-ref result 'time) 1000))]))))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -29,7 +29,7 @@
   (for ([res results]
         [test tests]
         #:when res)
-    (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
+    (define test (car (load-tests (open-input-string (hash-ref res 'test)))))
     (define name (test-name test))
     (match (hash-ref res 'status)
       ['failure

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -29,7 +29,7 @@
   (for ([res results]
         [test tests]
         #:when res)
-    (define test (hash-ref res 'test))
+    (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
     (define name (test-name test))
     (match (hash-ref res 'status)
       ['failure

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -162,7 +162,8 @@
                        ,(render-help "report.html#alternatives"))
                    ,body
                    (details (summary "Derivation") (ol ((class "history")) ,@history))))
-     ,@(for/list ([i (in-naturals 1)] [target (in-list targets)])
+     ,@(for/list ([i (in-naturals 1)]
+                  [target (in-list targets)])
          (define target-error (hash-ref target 'errors))
          (define target-cost (hash-ref target 'cost))
          (define target-expr (read (open-input-string (hash-ref target 'expr))))

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -29,7 +29,7 @@
 
 (define (make-graph result-hash output? profile?)
   (define backend (hash-ref result-hash 'backend))
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define time (hash-ref result-hash 'time))
   (define warnings (hash-ref result-hash 'warnings))
   (define repr (test-output-repr test))

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -37,7 +37,7 @@
   (define ctx (test-context test))
   (define identifier (test-identifier test))
 
-  (define preprocessing (hash-ref backend 'preprocessing))
+  (define preprocessing (map (compose read open-input-string) (hash-ref backend 'preprocessing)))
   (define start-expr (read (open-input-string (hash-ref (hash-ref backend 'start) 'expr))))
   (define start-cost (hash-ref (hash-ref backend 'start) 'cost))
   (define start-error (hash-ref (hash-ref backend 'start) 'errors))

--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -19,8 +19,8 @@
   (append default-pages (if good? success-pages empty)))
 
 (define ((page-error-handler result-hash page out) e)
-  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
-  (eprintf "Error generating `~a` for \"~a\":\n  ~a\n" page (test-name test) (exn-message e))
+  (define name (hash-ref result-hash 'name))
+  (eprintf "Error generating `~a` for \"~a\":\n  ~a\n" page name (exn-message e))
   (eprintf "context:\n")
   (for ([(fn loc) (in-dict (continuation-mark-set->context (exn-continuation-marks e)))])
     (match loc
@@ -35,10 +35,8 @@
   (match page
     ["graph.html" (write-html (make-graph-html result-hash output? profile?) out)]
     ["timeline.html"
-     (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
-     (write-html (make-timeline (test-name test) (hash-ref result-hash 'timeline)
-                                #:path "..")
-                 out)]
+     (define name (hash-ref result-hash 'name))
+     (write-html (make-timeline name (hash-ref result-hash 'timeline) #:path "..") out)]
     ["timeline.json" (write-json (hash-ref result-hash 'timeline) out)]
     ["profile.json" (write-json (hash-ref result-hash 'profile) out)]
     ["points.json" (write-json (make-points-json result-hash) out)]))

--- a/src/reports/plot.rkt
+++ b/src/reports/plot.rkt
@@ -34,7 +34,7 @@
         '())))
 
 (define (make-points-json result-hash)
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define backend (hash-ref result-hash 'backend))
   (define test-points (map first (second (hash-ref backend 'pctxs))))
   (define start (hash-ref backend 'start))

--- a/src/reports/traceback.rkt
+++ b/src/reports/traceback.rkt
@@ -14,7 +14,7 @@
     [status (error 'make-traceback "unexpected status ~a" status)]))
 
 (define (render-failure result-hash)
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define warnings (hash-ref result-hash 'warnings))
   (define backend (hash-ref result-hash 'backend))
 
@@ -51,7 +51,7 @@
                      `(tr (td ((class "procedure")) ,(~a name)) ,@(render-loc loc))))))
 
 (define (render-timeout result-hash)
-  (define test (hash-ref result-hash 'test))
+  (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define time (hash-ref result-hash 'time))
   (define warnings (hash-ref result-hash 'warnings))
 

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -237,8 +237,9 @@
   (parameterize ([read-decimal-as-inexact false])
     (read-syntax port name)))
 
-(define (load-stdin)
-  (for/list ([test (in-port (curry our-read-syntax "stdin") (current-input-port))])
+(define (load-port port)
+  (port-count-lines! port)
+  (for/list ([test (in-port (curry our-read-syntax "stdin") port)])
     (parse-test test)))
 
 (define (load-file file)
@@ -262,7 +263,8 @@
         path))
   (define out
     (cond
-      [(equal? path "-") (load-stdin)]
+      [(port? path) (load-port path)]
+      [(equal? path "-") (load-port (current-input-port))]
       [(directory-exists? path*) (load-directory path*)]
       [else (load-file path*)]))
   (define duplicates (find-duplicates (map test-name out)))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -178,7 +178,7 @@
        (error! stx "FPCore identifier must be a symbol: ~a" name))
      (check-program* stx vars props body error!)]
     [#`(FPCore (#,vars ...) #,props ... #,body) (check-program* stx vars props body error!)]
-    [#`(FPCore #,something ...) (error! stx "FPCore not in a valid format: ~a" stx)]
+    [#`(FPCore #,something ...) (error! stx "FPCore not in a valid format: ~s" stx)]
     [_ (error! stx "Not an FPCore: ~a" stx)]))
 
 (define (assert-program! stx)

--- a/www/doc/2.2/input.html
+++ b/www/doc/2.2/input.html
@@ -237,24 +237,6 @@
   "developer targets"; these might be other alternatives you've tried
   that you want to compare against.</p>
 
-  <h2 id="output-properties">Additional Output Metadata</h2>
-
-  <p>Herbie's output provides additional information in custom
-  properties:</p>
-
-  <dl class="function-list">
-    <dt><code>:herbie-status <var>status</var></code></dt>
-    <dd><var>status</var> describes whether Herbie worked: it is one
-    of <code>success</code>, <code>timeout</code>, <code>error</code>,
-    or <code>crash</code>.</dd>
-    <dt><code>:herbie-time <var>ms</var></code></dt>
-    <dd>The time, in milliseconds, used by Herbie to find a more accurate formula.</dd>
-    <dt><code>:herbie-error-input<br/>([<var>pts</var> <var>err</var>] ...)</code></dt>
-    <dd>The average <var>err</var>or of the input program at <var>pts</var> points. Multiple entries correspond to Herbie's training and test sets.</dd>
-    <dt><code>:herbie-error-output<br/>([<var>pts</var> <var>err</var>] ...)</code></dt>
-    <dd>The computed average error of the output program, similar to <code>:herbie-error-input</code>.</dd>
-  </dl>
-
   <p>Herbie's benchmark suite also uses properties for continuous
   integration, but these are not officially supported and their use is
   discouraged.</p>


### PR DESCRIPTION
The core idea behind this PR is that both of these APIs return JSON blobs, and those JSON blobs have distinct sets of keys. So we can just merge both endpoints and return *both* sets of keys, and everyone will be happy.

Doing this is quite involved, and required:

- [x] Deleting `alternatives` in favor of `improve`
- [x] Adding `alternatives`, `histories`, and `derivations` keys to `make-improve-result`
- [x] Dropping `:herbie` keys from `unparse-result`
- [x] Dropping `unparse-result` in favor of `alternatives` (which is an FPCore)
- [x] Fixing the `alternatives` key in case of a string name with spaces