### PR TITLE
Remove exactness 

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -67,9 +67,8 @@
   (timeline-push-alts! '())
 
   (define all-alts (atab-all-alts (^table^)))
-  (define joined-alts (make-regime! all-alts))
-  (define cleaned-alts (final-simplify! joined-alts))
-  (define annotated-alts (add-derivations! cleaned-alts))
+  (define joined-alts (make-regime! all-alts)) ;; HERE
+  (define annotated-alts (add-derivations! joined-alts))
 
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
   (sort-alts annotated-alts))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -92,7 +92,6 @@
                      (match-define (vector v1 v2) (apply prog pt))
                      (check-equal? v1 v2))))
 
-
 (define (check-rule rule)
   (check-rule-correct rule)
   (when (set-member? (rule-tags rule) 'sound)

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -92,15 +92,6 @@
                      (match-define (vector v1 v2) (apply prog pt))
                      (check-equal? v1 v2))))
 
-(define (check-platform pform)
-  (define simplify-rules
-    (parameterize ([*active-platform* pform])
-      (platform-simplify-rules)))
-  (for ([rule (in-list simplify-rules)]
-        ; "exact" rules use spec outputs; we don't test those
-        #:unless (spec-prog? (rule-output rule)))
-    (test-case (~a (rule-name rule))
-      (check-rule-fp-safe rule))))
 
 (define (check-rule rule)
   (check-rule-correct rule)
@@ -119,5 +110,4 @@
 (module+ test
   (for* ([rule (in-list (*rules*))])
     (test-case (~a (rule-name rule))
-      (check-rule rule)))
-  (check-platform (*active-platform*)))
+      (check-rule rule))))

--- a/src/platforms/binary32.rkt
+++ b/src/platforms/binary32.rkt
@@ -56,7 +56,7 @@
                       #:spec (+ x y)
                       #:fpcore (! :precision binary32 (+ x y))
                       #:fl fl32+
-                      #:commutes)
+                     )
 
 (define-operator-impl (-.f32 [x : binary32] [y : binary32])
                       binary32
@@ -69,7 +69,7 @@
                       #:spec (* x y)
                       #:fpcore (! :precision binary32 (* x y))
                       #:fl fl32*
-                      #:commutes)
+                      )
 
 (define-operator-impl (/.f32 [x : binary32] [y : binary32])
                       binary32

--- a/src/platforms/binary32.rkt
+++ b/src/platforms/binary32.rkt
@@ -45,84 +45,53 @@
   (begin
     (define-libm-impls/binary32* (itype ... otype) name ...) ...))
 
-(define-operator-impl
- (neg.f32 [x : binary32])
- binary32
- #:spec (neg x)
- #:fpcore (! :precision binary32 (- x))
- #:fl fl32-)
+(define-operator-impl (neg.f32 [x : binary32])
+                      binary32
+                      #:spec (neg x)
+                      #:fpcore (! :precision binary32 (- x))
+                      #:fl fl32-)
 
 (define-operator-impl (+.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (+ x y)
                       #:fpcore (! :precision binary32 (+ x y))
                       #:fl fl32+
-                      #:commutes
-                     )
+                      #:commutes)
 
 (define-operator-impl (-.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (- x y)
                       #:fpcore (! :precision binary32 (- x y))
-                      #:fl fl32-
-                      )
+                      #:fl fl32-)
 
 (define-operator-impl (*.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (* x y)
                       #:fpcore (! :precision binary32 (* x y))
                       #:fl fl32*
-                      #:commutes
-                      )
+                      #:commutes)
 
 (define-operator-impl (/.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (/ x y)
                       #:fpcore (! :precision binary32 (/ x y))
-                      #:fl fl32/
-                      )
+                      #:fl fl32/)
 
-(define-libm-impl/binary32 fabs
-                           (binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 fabs (binary32) binary32)
 
-(define-libm-impl/binary32 exp
-                           (binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 exp (binary32) binary32)
 
-(define-libm-impl/binary32 pow
-                           (binary32 binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 pow (binary32 binary32) binary32)
 
-(define-libm-impl/binary32
- sin
- (binary32)
- binary32
- )
+(define-libm-impl/binary32 sin (binary32) binary32)
 
-(define-libm-impl/binary32 cos
-                           (binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 cos (binary32) binary32)
 
-(define-libm-impl/binary32
- tan
- (binary32)
- binary32
- )
+(define-libm-impl/binary32 tan (binary32) binary32)
 
-(define-libm-impl/binary32 sinh
-                           (binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 sinh (binary32) binary32)
 
-(define-libm-impl/binary32 cosh
-                           (binary32)
-                           binary32
-                           )
+(define-libm-impl/binary32 cosh (binary32) binary32)
 
 (define-comparator-impls binary32
                          [== ==.f32 =]

--- a/src/platforms/binary32.rkt
+++ b/src/platforms/binary32.rkt
@@ -55,8 +55,7 @@
                       binary32
                       #:spec (+ x y)
                       #:fpcore (! :precision binary32 (+ x y))
-                      #:fl fl32+
-                     )
+                      #:fl fl32+)
 
 (define-operator-impl (-.f32 [x : binary32] [y : binary32])
                       binary32
@@ -68,8 +67,7 @@
                       binary32
                       #:spec (* x y)
                       #:fpcore (! :precision binary32 (* x y))
-                      #:fl fl32*
-                      )
+                      #:fl fl32*)
 
 (define-operator-impl (/.f32 [x : binary32] [y : binary32])
                       binary32

--- a/src/platforms/binary32.rkt
+++ b/src/platforms/binary32.rkt
@@ -50,16 +50,7 @@
  binary32
  #:spec (neg x)
  #:fpcore (! :precision binary32 (- x))
- #:fl fl32-
- #:identities (#:exact (neg.f32 x)
-                       [distribute-lft-neg-in (neg.f32 (*.f32 a b)) (*.f32 (neg.f32 a) b)]
-                       [distribute-rgt-neg-in (neg.f32 (*.f32 a b)) (*.f32 a (neg.f32 b))]
-                       [distribute-neg-in (neg.f32 (+.f32 a b)) (+.f32 (neg.f32 a) (neg.f32 b))]
-                       [distribute-neg-frac (neg.f32 (/.f32 a b)) (/.f32 (neg.f32 a) b)]
-                       [distribute-neg-frac2 (neg.f32 (/.f32 a b)) (/.f32 a (neg.f32 b))]
-                       [remove-double-neg (neg.f32 (neg.f32 a)) a]
-                       [neg-sub0 (neg.f32 b) (-.f32 0 b)]
-                       [neg-mul-1 (neg.f32 a) (*.f32 -1 a)]))
+ #:fl fl32-)
 
 (define-operator-impl (+.f32 [x : binary32] [y : binary32])
                       binary32
@@ -67,24 +58,14 @@
                       #:fpcore (! :precision binary32 (+ x y))
                       #:fl fl32+
                       #:commutes
-                      #:identities
-                      ([distribute-neg-out (+.f32 (neg.f32 a) (neg.f32 b)) (neg.f32 (+.f32 a b))]
-                       [+-lft-identity (+.f32 0 a) a]
-                       [+-rgt-identity (+.f32 a 0) a]
-                       [unsub-neg (+.f32 a (neg.f32 b)) (-.f32 a b)]))
+                     )
 
 (define-operator-impl (-.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (- x y)
                       #:fpcore (! :precision binary32 (- x y))
                       #:fl fl32-
-                      #:identities
-                      ([cancel-sign-sub (-.f32 a (*.f32 (neg.f32 b) c)) (+.f32 a (*.f32 b c))]
-                       [cancel-sign-sub-inv (-.f32 a (*.f32 b c)) (+.f32 a (*.f32 (neg.f32 b) c))]
-                       #:exact (-.f32 a a)
-                       #:exact (-.f32 a 0)
-                       [sub0-neg (-.f32 0 a) (neg.f32 a)]
-                       [sub-neg (-.f32 a b) (+.f32 a (neg.f32 b))]))
+                      )
 
 (define-operator-impl (*.f32 [x : binary32] [y : binary32])
                       binary32
@@ -92,82 +73,56 @@
                       #:fpcore (! :precision binary32 (* x y))
                       #:fl fl32*
                       #:commutes
-                      #:identities
-                      ([distribute-lft-neg-out (*.f32 (neg.f32 x) y) (neg.f32 (*.f32 x y))]
-                       [distribute-rgt-neg-out (*.f32 x (neg.f32 y)) (neg.f32 (*.f32 x y))]
-                       [*-lft-identity (*.f32 1 a) a]
-                       [*-rgt-identity (*.f32 a 1) a]
-                       [mul-1-neg (*.f32 -1 a) (neg.f32 a)]
-                       [*-un-lft-identity a (*.f32 1 a)]
-                       [sqr-neg (*.f32 (neg.f32 x) (neg.f32 x)) (*.f32 x x)]
-                       [sqr-abs (*.f32 (fabs.f32 x) (fabs.f32 x)) (*.f32 x x)]
-                       [mul-fabs (*.f32 (fabs.f32 a) (fabs.f32 b)) (fabs.f32 (*.f32 a b))]))
+                      )
 
 (define-operator-impl (/.f32 [x : binary32] [y : binary32])
                       binary32
                       #:spec (/ x y)
                       #:fpcore (! :precision binary32 (/ x y))
                       #:fl fl32/
-                      #:identities ([distribute-frac-neg (/.f32 (neg.f32 x) y) (neg.f32 (/.f32 x y))]
-                                    [distribute-frac-neg2 (/.f32 x (neg.f32 y)) (neg.f32 (/.f32 x y))]
-                                    [/-rgt-identity (/.f32 a 1) a]))
+                      )
 
 (define-libm-impl/binary32 fabs
                            (binary32)
                            binary32
-                           #:identities
-                           ([fabs-fabs (fabs.f32 (fabs.f32 a)) (fabs.f32 a)]
-                            [fabs-sub (fabs.f32 (-.f32 a b)) (fabs.f32 (-.f32 b a))]
-                            [fabs-neg (fabs.f32 (neg.f32 a)) (fabs.f32 a)]
-                            [fabs-sqr (fabs.f32 (*.f32 a a)) (*.f32 a a)]
-                            [fabs-mul (fabs.f32 (*.f32 a b)) (*.f32 (fabs.f32 a) (fabs.f32 b))]
-                            [fabs-div (fabs.f32 (/.f32 a b)) (/.f32 (fabs.f32 a) (fabs.f32 b))]
-                            [neg-fabs (fabs.f32 x) (fabs.f32 (neg.f32 x))]))
+                           )
 
 (define-libm-impl/binary32 exp
                            (binary32)
                            binary32
-                           #:identities ([exp-0 (exp.f32 0) 1] [exp-1-e (exp.f32 1) (E)]
-                                                               [1-exp 1 (exp.f32 0)]
-                                                               [e-exp-1 (E) (exp.f32 1)]))
+                           )
 
 (define-libm-impl/binary32 pow
                            (binary32 binary32)
                            binary32
-                           #:identities ([unpow1 (pow.f32 a 1) a] [unpow0 (pow.f32 a 0) 1]
-                                                                  [pow-base-1 (pow.f32 1 a) 1]
-                                                                  [pow1 a (pow.f32 a 1)]
-                                                                  [pow-base-0 (pow.f32 0 a) 0]))
+                           )
 
 (define-libm-impl/binary32
  sin
  (binary32)
  binary32
- #:identities ([sin-0 (sin.f32 0) 0] [sin-neg (sin.f32 (neg.f32 x)) (neg.f32 (sin.f32 x))]))
+ )
 
 (define-libm-impl/binary32 cos
                            (binary32)
                            binary32
-                           #:identities
-                           ([cos-0 (cos.f32 0) 1] [cos-neg (cos.f32 (neg.f32 x)) (cos.f32 x)]))
+                           )
 
 (define-libm-impl/binary32
  tan
  (binary32)
  binary32
- #:identities ([tan-0 (tan.f32 0) 0] [tan-neg (tan.f32 (neg.f32 x)) (neg.f32 (tan.f32 x))]))
+ )
 
 (define-libm-impl/binary32 sinh
                            (binary32)
                            binary32
-                           #:identities ([sinh-neg (sinh.f32 (neg.f32 x)) (neg.f32 (sinh.f32 x))]
-                                         [sinh-0 (sinh.f32 0) 0]))
+                           )
 
 (define-libm-impl/binary32 cosh
                            (binary32)
                            binary32
-                           #:identities
-                           ([cosh-neg (cosh.f32 (neg.f32 x)) (cosh.f32 x)] [cosh-0 (cosh.f32 0) 1]))
+                           )
 
 (define-comparator-impls binary32
                          [== ==.f32 =]

--- a/src/platforms/binary64.rkt
+++ b/src/platforms/binary64.rkt
@@ -46,81 +46,49 @@
   (begin
     (define-libm-impls/binary64* (itype ... otype) name ...) ...))
 
-(define-operator-impl
- (neg.f64 [x : binary64])
- binary64
- #:spec (neg x)
- #:fpcore (! :precision binary64 (- x))
- #:fl -
- )
+(define-operator-impl (neg.f64 [x : binary64])
+                      binary64
+                      #:spec (neg x)
+                      #:fpcore (! :precision binary64 (- x))
+                      #:fl -)
 (define-operator-impl (+.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (+ x y)
                       #:fpcore (! :precision binary64 (+ x y))
                       #:fl +
-                      #:commutes
-                      )
+                      #:commutes)
 (define-operator-impl (-.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (- x y)
                       #:fpcore (! :precision binary64 (- x y))
-                      #:fl -
-                      )
+                      #:fl -)
 (define-operator-impl (*.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (* x y)
                       #:fpcore (! :precision binary64 (* x y))
                       #:fl *
-                      #:commutes
-                      )
+                      #:commutes)
 (define-operator-impl (/.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (/ x y)
                       #:fpcore (! :precision binary64 (/ x y))
-                      #:fl /
-                      )
+                      #:fl /)
 
-(define-libm-impl/binary64 fabs
-                           (binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 fabs (binary64) binary64)
 
-(define-libm-impl/binary64 exp
-                           (binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 exp (binary64) binary64)
 
-(define-libm-impl/binary64 pow
-                           (binary64 binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 pow (binary64 binary64) binary64)
 
-(define-libm-impl/binary64
- sin
- (binary64)
- binary64
- )
+(define-libm-impl/binary64 sin (binary64) binary64)
 
-(define-libm-impl/binary64 cos
-                           (binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 cos (binary64) binary64)
 
-(define-libm-impl/binary64
- tan
- (binary64)
- binary64
- )
+(define-libm-impl/binary64 tan (binary64) binary64)
 
-(define-libm-impl/binary64 sinh
-                           (binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 sinh (binary64) binary64)
 
-(define-libm-impl/binary64 cosh
-                           (binary64)
-                           binary64
-                           )
+(define-libm-impl/binary64 cosh (binary64) binary64)
 
 (define-libm-impls/binary64 [(binary64 binary64)
                              (acos acosh

--- a/src/platforms/binary64.rkt
+++ b/src/platforms/binary64.rkt
@@ -52,121 +52,75 @@
  #:spec (neg x)
  #:fpcore (! :precision binary64 (- x))
  #:fl -
- #:identities (#:exact (neg.f64 a)
-                       [distribute-lft-neg-in (neg.f64 (*.f64 a b)) (*.f64 (neg.f64 a) b)]
-                       [distribute-rgt-neg-in (neg.f64 (*.f64 a b)) (*.f64 a (neg.f64 b))]
-                       [distribute-neg-in (neg.f64 (+.f64 a b)) (+.f64 (neg.f64 a) (neg.f64 b))]
-                       [distribute-neg-frac (neg.f64 (/.f64 a b)) (/.f64 (neg.f64 a) b)]
-                       [distribute-neg-frac2 (neg.f64 (/.f64 a b)) (/.f64 a (neg.f64 b))]
-                       [remove-double-neg (neg.f64 (neg.f64 a)) a]
-                       [neg-sub0 (neg.f64 b) (-.f64 0 b)]
-                       [neg-mul-1 (neg.f64 a) (*.f64 -1 a)]))
+ )
 (define-operator-impl (+.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (+ x y)
                       #:fpcore (! :precision binary64 (+ x y))
                       #:fl +
                       #:commutes
-                      #:identities
-                      ([distribute-neg-out (+.f64 (neg.f64 a) (neg.f64 b)) (neg.f64 (+.f64 a b))]
-                       [+-lft-identity (+.f64 0 a) a]
-                       [+-rgt-identity (+.f64 a 0) a]
-                       [unsub-neg (+.f64 a (neg.f64 b)) (-.f64 a b)]))
+                      )
 (define-operator-impl (-.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (- x y)
                       #:fpcore (! :precision binary64 (- x y))
                       #:fl -
-                      #:identities
-                      ([cancel-sign-sub (-.f64 a (*.f64 (neg.f64 b) c)) (+.f64 a (*.f64 b c))]
-                       [cancel-sign-sub-inv (-.f64 a (*.f64 b c)) (+.f64 a (*.f64 (neg.f64 b) c))]
-                       #:exact (-.f64 a a)
-                       #:exact (-.f64 a 0)
-                       [sub0-neg (-.f64 0 a) (neg.f64 a)]
-                       [sub-neg (-.f64 a b) (+.f64 a (neg.f64 b))]))
+                      )
 (define-operator-impl (*.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (* x y)
                       #:fpcore (! :precision binary64 (* x y))
                       #:fl *
                       #:commutes
-                      #:identities
-                      ([distribute-lft-neg-out (*.f64 (neg.f64 a) b) (neg.f64 (*.f64 a b))]
-                       [distribute-rgt-neg-out (*.f64 a (neg.f64 b)) (neg.f64 (*.f64 a b))]
-                       [*-lft-identity (*.f64 1 a) a]
-                       [*-rgt-identity (*.f64 a 1) a]
-                       [mul-1-neg (*.f64 -1 a) (neg.f64 a)]
-                       [*-un-lft-identity a (*.f64 1 a)]
-                       [sqr-neg (*.f64 (neg.f64 a) (neg.f64 a)) (*.f64 a a)]
-                       [sqr-abs (*.f64 (fabs.f64 a) (fabs.f64 a)) (*.f64 a a)]
-                       [mul-fabs (*.f64 (fabs.f64 a) (fabs.f64 b)) (fabs.f64 (*.f64 a b))]))
+                      )
 (define-operator-impl (/.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (/ x y)
                       #:fpcore (! :precision binary64 (/ x y))
                       #:fl /
-                      #:identities
-                      ([distribute-frac-neg (/.f64 (neg.f64 a) b) (neg.f64 (/.f64 a b))]
-                       [distribute-frac-neg2 (/.f64 a (neg.f64 b)) (neg.f64 (/.f64 a b))]
-                       [/-rgt-identity (/.f64 a 1) a]
-                       [div-fabs (/.f64 (fabs.f64 a) (fabs.f64 b)) (fabs.f64 (/.f64 a b))]))
+                      )
 
 (define-libm-impl/binary64 fabs
                            (binary64)
                            binary64
-                           #:identities
-                           ([fabs-fabs (fabs.f64 (fabs.f64 a)) (fabs.f64 a)]
-                            [fabs-sub (fabs.f64 (-.f64 a b)) (fabs.f64 (-.f64 b a))]
-                            [fabs-neg (fabs.f64 (neg.f64 a)) (fabs.f64 a)]
-                            [fabs-sqr (fabs.f64 (*.f64 a a)) (*.f64 a a)]
-                            [fabs-mul (fabs.f64 (*.f64 a b)) (*.f64 (fabs.f64 a) (fabs.f64 b))]
-                            [fabs-div (fabs.f64 (/.f64 a b)) (/.f64 (fabs.f64 a) (fabs.f64 b))]
-                            [neg-fabs (fabs.f64 x) (fabs.f64 (neg.f64 x))]))
+                           )
 
 (define-libm-impl/binary64 exp
                            (binary64)
                            binary64
-                           #:identities ([exp-0 (exp.f64 0) 1] [exp-1-e (exp.f64 1) (E)]
-                                                               [1-exp 1 (exp.f64 0)]
-                                                               [e-exp-1 (E) (exp.f64 1)]))
+                           )
 
 (define-libm-impl/binary64 pow
                            (binary64 binary64)
                            binary64
-                           #:identities ([unpow1 (pow.f64 a 1) a] [unpow0 (pow.f64 a 0) 1]
-                                                                  [pow-base-1 (pow.f64 1 a) 1]
-                                                                  [pow1 a (pow.f64 a 1)]
-                                                                  [pow-base-0 (pow.f64 0 a) 0]))
+                           )
 
 (define-libm-impl/binary64
  sin
  (binary64)
  binary64
- #:identities ([sin-0 (sin.f64 0) 0] [sin-neg (sin.f64 (neg.f64 x)) (neg.f64 (sin.f64 x))]))
+ )
 
 (define-libm-impl/binary64 cos
                            (binary64)
                            binary64
-                           #:identities
-                           ([cos-0 (cos.f64 0) 1] [cos-neg (cos.f64 (neg.f64 x)) (cos.f64 x)]))
+                           )
 
 (define-libm-impl/binary64
  tan
  (binary64)
  binary64
- #:identities ([tan-0 (tan.f64 0) 0] [tan-neg (tan.f64 (neg.f64 x)) (neg.f64 (tan.f64 x))]))
+ )
 
 (define-libm-impl/binary64 sinh
                            (binary64)
                            binary64
-                           #:identities ([sinh-neg (sinh.f64 (neg.f64 x)) (neg.f64 (sinh.f64 x))]
-                                         [sinh-0 (sinh.f64 0) 0]))
+                           )
 
 (define-libm-impl/binary64 cosh
                            (binary64)
                            binary64
-                           #:identities
-                           ([cosh-neg (cosh.f64 (neg.f64 x)) (cosh.f64 x)] [cosh-0 (cosh.f64 0) 1]))
+                           )
 
 (define-libm-impls/binary64 [(binary64 binary64)
                              (acos acosh

--- a/src/platforms/binary64.rkt
+++ b/src/platforms/binary64.rkt
@@ -55,8 +55,7 @@
                       binary64
                       #:spec (+ x y)
                       #:fpcore (! :precision binary64 (+ x y))
-                      #:fl +
-                      )
+                      #:fl +)
 (define-operator-impl (-.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (- x y)
@@ -66,8 +65,7 @@
                       binary64
                       #:spec (* x y)
                       #:fpcore (! :precision binary64 (* x y))
-                      #:fl *
-                      )
+                      #:fl *)
 (define-operator-impl (/.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (/ x y)

--- a/src/platforms/binary64.rkt
+++ b/src/platforms/binary64.rkt
@@ -56,7 +56,7 @@
                       #:spec (+ x y)
                       #:fpcore (! :precision binary64 (+ x y))
                       #:fl +
-                      #:commutes)
+                      )
 (define-operator-impl (-.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (- x y)
@@ -67,7 +67,7 @@
                       #:spec (* x y)
                       #:fpcore (! :precision binary64 (* x y))
                       #:fl *
-                      #:commutes)
+                      )
 (define-operator-impl (/.f64 [x : binary64] [y : binary64])
                       binary64
                       #:spec (/ x y)

--- a/src/platforms/bool.rkt
+++ b/src/platforms/bool.rkt
@@ -29,16 +29,8 @@
 (define (or-fn . as)
   (ormap identity as))
 
-(define-operator-impl (not [x : bool]) bool #:spec (not x) #:fl not )
+(define-operator-impl (not [x : bool]) bool #:spec (not x) #:fl not)
 
-(define-operator-impl (and [x : bool] [y : bool])
-                      bool
-                      #:spec (and x y)
-                      #:fl and-fn
-                     )
+(define-operator-impl (and [x : bool] [y : bool]) bool #:spec (and x y) #:fl and-fn)
 
-(define-operator-impl (or [x : bool] [y : bool])
-                      bool
-                      #:spec (or x y)
-                      #:fl or-fn
-                      )
+(define-operator-impl (or [x : bool] [y : bool]) bool #:spec (or x y) #:fl or-fn)

--- a/src/platforms/bool.rkt
+++ b/src/platforms/bool.rkt
@@ -29,16 +29,16 @@
 (define (or-fn . as)
   (ormap identity as))
 
-(define-operator-impl (not [x : bool]) bool #:spec (not x) #:fl not #:identities (#:exact (not a)))
+(define-operator-impl (not [x : bool]) bool #:spec (not x) #:fl not )
 
 (define-operator-impl (and [x : bool] [y : bool])
                       bool
                       #:spec (and x y)
                       #:fl and-fn
-                      #:identities (#:exact (and a b)))
+                     )
 
 (define-operator-impl (or [x : bool] [y : bool])
                       bool
                       #:spec (or x y)
                       #:fl or-fn
-                      #:identities (#:exact (or a b)))
+                      )

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -199,7 +199,7 @@
 ;; Looks up a property `field` of an real operator `op`.
 ;; Panics if the operator is not found.
 (define/contract (impl-info impl field)
-  (-> symbol? (or/c 'vars 'itype 'otype 'spec 'fpcore 'fl ) any/c)
+  (-> symbol? (or/c 'vars 'itype 'otype 'spec 'fpcore 'fl) any/c)
   (unless (hash-has-key? operator-impls impl)
     (error 'impl-info "Unknown operator implementation ~a" impl))
   (define info (hash-ref operator-impls impl))
@@ -268,12 +268,8 @@
 
 ; Registers an operator implementation `name` with context `ctx` and spec `spec.
 ; Can optionally specify a floating-point implementation and fpcore translation.
-(define/contract (register-operator-impl! name
-                                          ctx
-                                          spec
-                                          #:fl [fl-proc #f]
-                                          #:fpcore [fpcore #f]) 
-  (->* (symbol? context? any/c) (#:fl (or/c procedure? #f) #:fpcore any/c) void?) 
+(define/contract (register-operator-impl! name ctx spec #:fl [fl-proc #f] #:fpcore [fpcore #f])
+  (->* (symbol? context? any/c) (#:fl (or/c procedure? #f) #:fpcore any/c) void?)
   ; check specification
   (check-spec! name ctx spec)
   (define vars (context-vars ctx))
@@ -371,7 +367,6 @@
                                                   (get-representation 'rtype)
                                                   (list (get-representation 'repr) ...))
                                          'spec
-                                         
                                          #:fl fl-expr
                                          #:fpcore 'core))]
            [(#:spec expr rest ...)
@@ -395,7 +390,7 @@
                (set! fl-expr #'expr)
                (loop #'(rest ...))])]
            [(#:fl) (oops! "expected value after keyword `#:fl`" stx)]
-          
+
            ; bad
            [_ (oops! "bad syntax" fields)])))]
     [_ (oops! "bad syntax")]))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -274,11 +274,8 @@
                                           spec
                                           #:commutes? [commutes? #f]
                                           #:fl [fl-proc #f]
-                                          #:fpcore [fpcore #f]
-                                         );; #:identities [identities #f]
-  (->* (symbol? context? any/c)
-       (#:commutes? boolean? #:fl (or/c procedure? #f) #:fpcore any/c)
-       void?)
+                                          #:fpcore [fpcore #f]) ;; #:identities [identities #f]
+  (->* (symbol? context? any/c) (#:commutes? boolean? #:fl (or/c procedure? #f) #:fpcore any/c) void?)
   ; check specification
   (check-spec! name ctx spec)
   (define vars (context-vars ctx))
@@ -367,7 +364,7 @@
        (define spec #f)
        (define core #f)
        (define fl-expr #f)
-       
+
        (let loop ([fields fields])
          (syntax-case fields ()
            [()
@@ -377,8 +374,7 @@
                           [spec spec]
                           [core core]
                           [commutes? commutes?]
-                          [fl-expr fl-expr]
-                          )
+                          [fl-expr fl-expr])
               #'(register-operator-impl! 'id
                                          (context '(var ...)
                                                   (get-representation 'rtype)
@@ -386,8 +382,7 @@
                                          'spec
                                          #:commutes? 'commutes?
                                          #:fl fl-expr
-                                         #:fpcore 'core
-                                         ))]
+                                         #:fpcore 'core))]
            [(#:spec expr rest ...)
             (cond
               [spec (oops! "multiple #:spec clauses" stx)]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -272,10 +272,9 @@
 (define/contract (register-operator-impl! name
                                           ctx
                                           spec
-                                          #:commutes? [commutes? #f]
                                           #:fl [fl-proc #f]
                                           #:fpcore [fpcore #f]) ;; #:identities [identities #f]
-  (->* (symbol? context? any/c) (#:commutes? boolean? #:fl (or/c procedure? #f) #:fpcore any/c) void?)
+  (->* (symbol? context? any/c) (#:fl (or/c procedure? #f) #:fpcore any/c) void?) ;????
   ; check specification
   (check-spec! name ctx spec)
   (define vars (context-vars ctx))
@@ -380,7 +379,7 @@
                                                   (get-representation 'rtype)
                                                   (list (get-representation 'repr) ...))
                                          'spec
-                                         #:commutes? 'commutes?
+                                         
                                          #:fl fl-expr
                                          #:fpcore 'core))]
            [(#:spec expr rest ...)
@@ -404,12 +403,7 @@
                (set! fl-expr #'expr)
                (loop #'(rest ...))])]
            [(#:fl) (oops! "expected value after keyword `#:fl`" stx)]
-           [(#:commutes rest ...)
-            (cond
-              [commutes? (oops! "multiple #:commutes clauses" stx)]
-              [else
-               (set! commutes? #t)
-               (loop #'(rest ...))])]
+          
            ; bad
            [_ (oops! "bad syntax" fields)])))]
     [_ (oops! "bad syntax")]))


### PR DESCRIPTION
This PR removes all components in Herbie related to exactness, including the application of identities, after it was determined that removing them entirely added a speedup to Herbie without any changes results. 

