### PR TITLE
Faster pruning by deduplicating alts less often

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -203,7 +203,8 @@
   (define point-idx->alts*
     (for/vector #:length (vector-length point-idx->alts)
                 ([pcurve (in-vector point-idx->alts)])
-      (pareto-map (lambda (alts) (remove-duplicates alts #:key alt-expr)) pcurve)))
+      (reverse (pareto-map (lambda (alts) (remove-duplicates alts #:key alt-expr))
+                           (reverse pcurve)))))
   (struct-copy alt-table atab [point-idx->alts point-idx->alts*]))
 
 (define (atab-add-altn atab altn errs cost)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -205,8 +205,8 @@
   (define point-idx->alts*
     (for/vector #:length (vector-length point-idx->alts)
                 ([pcurve (in-vector point-idx->alts)])
-      (reverse (pareto-map (lambda (alts) (remove-duplicates alts #:key alt-expr))
-                           (reverse pcurve)))))
+      (pareto-map (lambda (alts) (reverse (remove-duplicates (reverse alts) #:key alt-expr)))
+                  pcurve)))
   (struct-copy alt-table atab [point-idx->alts point-idx->alts*]))
 
 (define (atab-add-altn atab altn errs cost)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -181,7 +181,7 @@
       (atab-add-altn atab altn errs cost)))
   (define atab** (atab-dedup atab*))
   (define atab***
-    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
+    (struct-copy alt-table atab** [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
   (define atab**** (atab-prune atab***))
   (struct-copy alt-table
                atab****

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -179,14 +179,15 @@
                [errs (in-list errss)]
                [cost (in-list costs)])
       (atab-add-altn atab altn errs cost)))
-  (define atab**
-    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
-  (define atab*** (atab-prune atab**))
+  (define atab** (atab-dedup atab*))
+  (define atab***
+    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
+  (define atab**** (atab-prune atab***))
   (struct-copy alt-table
-               atab***
-               [alt->point-idxs (invert-index (alt-table-point-idx->alts atab***))]
+               atab****
+               [alt->point-idxs (invert-index (alt-table-point-idx->alts atab****))]
                [all
-                (set-union (alt-table-all atab) (hash-keys (alt-table-alt->point-idxs atab***)))]))
+                (set-union (alt-table-all atab) (hash-keys (alt-table-alt->point-idxs atab****)))]))
 
 (define (invert-index point-idx->alts)
   (define alt->points* (make-hasheq))
@@ -197,6 +198,14 @@
       (hash-set! alt->points* alt (cons idx (hash-ref alt->points* alt '())))))
   (make-immutable-hasheq (hash->list alt->points*)))
 
+(define (atab-dedup atab)
+  (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
+  (define point-idx->alts*
+    (for/vector #:length (vector-length point-idx->alts)
+                ([pcurve (in-vector point-idx->alts)])
+      (pareto-map (lambda (alts) (remove-duplicates alts #:key alt-expr)) pcurve)))
+  (struct-copy alt-table atab [point-idx->alts point-idx->alts*]))
+
 (define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
 
@@ -205,16 +214,8 @@
                 ([pcurve (in-vector point-idx->alts)]
                  [err (in-list errs)])
       (define ppt (pareto-point cost err (list altn)))
-      (pareto-union (list ppt)
-                    pcurve
-                    #:combine (lambda (alts1 alts2)
-                                ; dedup by program
-                                ; optimization: combining means that `alts1` corresponds to
-                                ; the new pareto point
-                                (match-define (list altn) alts1)
-                                (if (ormap (lambda (a) (alt-equal? a altn)) alts2)
-                                    alts2
-                                    (cons altn alts2))))))
+      ;; This creates duplicate points, but they are removed by `alt-dedup`
+      (pareto-union (list ppt) pcurve #:combine append)))
 
   (alt-table point-idx->alts*
              (hash-set alt->point-idxs altn #f)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -181,7 +181,9 @@
       (atab-add-altn atab altn errs cost)))
   (define atab** (atab-dedup atab*))
   (define atab***
-    (struct-copy alt-table atab** [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
+    (struct-copy alt-table
+                 atab**
+                 [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
   (define atab**** (atab-prune atab***))
   (struct-copy alt-table
                atab****

--- a/src/reports/traceback.rkt
+++ b/src/reports/traceback.rkt
@@ -9,8 +9,8 @@
 
 (define (make-traceback result-hash)
   (match (hash-ref result-hash 'status)
-    ['timeout (render-timeout result-hash)]
-    ['failure (render-failure result-hash)]
+    ["timeout" (render-timeout result-hash)]
+    ["failure" (render-failure result-hash)]
     [status (error 'make-traceback "unexpected status ~a" status)]))
 
 (define (render-failure result-hash)


### PR DESCRIPTION
This PR speeds up the "pruning" phase, a.k.a. `atab-add-altns`. Currently, every time we add an alt to the alt-table, we deduplicate the alts by expression. This is wasteful. There are various possible fixes, but this PR does the simplest thing: it deduplicates once instead of per-alt. I did a quick test and the "ratio of anisotropy" benchmark is about 5x faster with this PR on my local machine; I expect an overall savings across the whole benchmark suite of about 2–3 minutes, or about 5% of runtime in the best case.