### PR TITLE
Delete unneeded `expand-rules` function

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -314,7 +314,7 @@
             [(> end-score (+ start-test-score fuzz)) "lt-start"]
             [(> end-score (- start-test-score fuzz)) "eq-start"]
             [(> end-score (+ best-score fuzz)) "lt-target"])]
-       
+
          [(and (< start-test-score 1) (< end-score (+ start-test-score 1))) "ex-start"]
          [(< end-score (- start-test-score 1)) "imp-start"]
          [(< end-score (+ start-test-score fuzz)) "apx-start"]

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -179,14 +179,17 @@
                [errs (in-list errss)]
                [cost (in-list costs)])
       (atab-add-altn atab altn errs cost)))
-  (define atab**
-    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
-  (define atab*** (atab-prune atab**))
+  (define atab** (atab-dedup atab*))
+  (define atab***
+    (struct-copy alt-table
+                 atab**
+                 [alt->point-idxs (invert-index (alt-table-point-idx->alts atab**))]))
+  (define atab**** (atab-prune atab***))
   (struct-copy alt-table
-               atab***
-               [alt->point-idxs (invert-index (alt-table-point-idx->alts atab***))]
+               atab****
+               [alt->point-idxs (invert-index (alt-table-point-idx->alts atab****))]
                [all
-                (set-union (alt-table-all atab) (hash-keys (alt-table-alt->point-idxs atab***)))]))
+                (set-union (alt-table-all atab) (hash-keys (alt-table-alt->point-idxs atab****)))]))
 
 (define (invert-index point-idx->alts)
   (define alt->points* (make-hasheq))
@@ -197,6 +200,15 @@
       (hash-set! alt->points* alt (cons idx (hash-ref alt->points* alt '())))))
   (make-immutable-hasheq (hash->list alt->points*)))
 
+(define (atab-dedup atab)
+  (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
+  (define point-idx->alts*
+    (for/vector #:length (vector-length point-idx->alts)
+                ([pcurve (in-vector point-idx->alts)])
+      (pareto-map (lambda (alts) (reverse (remove-duplicates (reverse alts) #:key alt-expr)))
+                  pcurve)))
+  (struct-copy alt-table atab [point-idx->alts point-idx->alts*]))
+
 (define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
 
@@ -205,7 +217,7 @@
                 ([pcurve (in-vector point-idx->alts)]
                  [err (in-list errs)])
       (define ppt (pareto-point cost err (list altn)))
-      ;; Duplicate points are removed by `alt-prune`
+      ;; This creates duplicate points, but they are removed by `alt-dedup`
       (pareto-union (list ppt) pcurve #:combine append)))
 
   (alt-table point-idx->alts*

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -180,9 +180,7 @@
                [cost (in-list costs)])
       (atab-add-altn atab altn errs cost)))
   (define atab**
-    (struct-copy alt-table
-                 atab*
-                 [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
+    (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
   (define atab*** (atab-prune atab**))
   (struct-copy alt-table
                atab***

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1234,9 +1234,7 @@
       [(cons rules params)
        ;; `run` instruction
 
-       (unless (or (equal? `lift rules)
-                   (equal? `lower rules)
-                   (and (list? rules) (andmap rule? rules)))
+       (unless (and (list? rules) (andmap rule? rules))
          (oops! "expected list of rules: `~a`" rules))
 
        (for ([param (in-list params)])

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -613,12 +613,12 @@
         #f)] ;; If symbol, assume not a spec could be either (find way to distinguish) : PREPROCESS
       [(hole _ _) (vector-set! spec-mask n #f)] ;; If hole, not a spec
       [(approx _ _) (vector-set! spec-mask n #f)] ;; If approx, not a spec
-    
+
       [(list appl args ...)
        (if (hash-has-key? (id->e1) appl)
            (vector-set! spec-mask n #t) ;; appl with op -> Is a spec
            (vector-set! spec-mask n #f))] ;; appl impl -> Not a spec
-    
+
       ;; If the condition or any branch is a spec, then this is a spec
       [`(if ,cond ,ift ,iff) (vector-set! spec-mask n (vector-ref spec-mask cond))]))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -71,16 +71,11 @@
 (define (run-rr altns global-batch)
   (timeline-event! 'rewrite)
 
-  ; generate required rules
-  (define rules (*rules*))
-  (define lifting-rules (platform-lifting-rules))
-  (define lowering-rules (platform-lowering-rules))
-
   ; egg schedule (3-phases for mathematical rewrites and implementation selection)
   (define schedule
-    `((lift . ((iteration . 1) (scheduler . simple))) (,rules . ((node . ,(*node-limit*))))
-                                                      (lower . ((iteration . 1) (scheduler .
-                                                                                           simple)))))
+    (list `(,(platform-lifting-rules) . ((iteration . 1) (scheduler . simple)))
+          `(,(*rules*) . ((node . ,(*node-limit*))))
+          `(,(platform-lowering-rules) . ((iteration . 1) (scheduler . simple)))))
 
   ; run egg
   (define exprs (map (compose debatchref alt-expr) altns))


### PR DESCRIPTION
It is, I think, unnecessary, and it costs a bit of time (though not a lot). I also removed the cache—let's see if it pays for itself.