### PR TITLE
Update server.rkt to include *functions* as a global state.

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -18,6 +18,7 @@
          "../utils/float.rkt"
          "../reports/pages.rkt"
          "datafile.rkt"
+         "../syntax/syntax.rkt"
          (submod "../utils/timeline.rkt" debug))
 
 (provide make-path
@@ -233,7 +234,8 @@
                          *max-find-range-depth*
                          *pareto-mode*
                          *platform-name*
-                         *loose-plugins*)
+                         *loose-plugins*
+                         *functions*)
    (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
      (load-herbie-plugins))
    ; not sure if the above code is actaully needed.
@@ -340,7 +342,8 @@
                          *max-find-range-depth*
                          *pareto-mode*
                          *platform-name*
-                         *loose-plugins*)
+                         *loose-plugins*
+                         *functions*)
    (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
      (load-herbie-plugins))
    (define worker-thread


### PR DESCRIPTION
Problem
Previously, there was an issue on nightly where functions could created and used across multiple fpcores. This issue came from thread isolation which caused functions defined in one thread to be inaccessible in others.

Solution
This PR adds the function state to be global variable that is shared across all threads. 