### PR TITLE
Make `in-u32vector` faster by writing a bunch of macros

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -37,11 +37,27 @@
 (define (u32vector-empty? x)
   (zero? (u32vector-length x)))
 
-(define (in-u32vector vec)
+(define (in-u32vector/proc vec)
   (make-do-sequence
    (lambda ()
      (define len (u32vector-length vec))
      (values (lambda (i) (u32vector-ref vec i)) add1 0 (lambda (i) (< i len)) #f #f))))
+
+(define-sequence-syntax in-u32vector
+                        (lambda () #'in-u32vector/proc)
+                        (lambda (stx)
+                          (syntax-case stx ()
+                            [[(x) (_ v)]
+                             #'[(x)
+                                (:do-in ([(len) (u32vector-length v)])
+                                        #t
+                                        ([i 0])
+                                        (< i len)
+                                        ([(x) (u32vector-ref v i)])
+                                        #t
+                                        #t
+                                        ((+ i 1)))]]
+                            [_ #f])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; egg FFI shim

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -25,8 +25,26 @@
 (define *pcontext* (make-parameter #f))
 (struct pcontext (points exacts) #:prefab)
 
-(define (in-pcontext pcontext)
+(define (in-pcontext/proc pcontext)
   (in-parallel (in-vector (pcontext-points pcontext)) (in-vector (pcontext-exacts pcontext))))
+
+(define-sequence-syntax
+ in-pcontext
+ (lambda () #'in-pcontext/proc)
+ (lambda (stx)
+   (syntax-case stx ()
+     [[(pt ex) (_ pctx)]
+      #'[(x)
+         (:do-in ([(pts) (pcontext-points pctx)] [(exs) (pcontext-exacts pctx)]
+                                                 [(len) (vector-length (pcontext-points pctx))])
+                 #t
+                 ([i 0])
+                 (< i len)
+                 ([(pt) (vector-ref pts i)] [(ex) (vector-ref exs i)])
+                 #t
+                 #t
+                 ((+ i 1)))]]
+     [_ #f])))
 
 (define (pcontext-length pcontext)
   (vector-length (pcontext-points pcontext)))


### PR DESCRIPTION
If you just define `in-u32vector` using `make-do-sequence`, it won't macro-expand into something nice; instead, it'll use the normal, slow generic sequence machinery. But there is a macro, `define-sequence-syntax`, which will actually allow you to unfold into something complicated, and this PR switches to it for the performance-critical `in-u32vector` function (and, for completeness, the non-performance-critical `in-pcontext` function).