### PR TITLE
Adding support for Floating Point Costs in Egglog

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
-      - name: "Install egglog"
-        run: make egglog-herbie
 
       - name: "Test raco fmt compliance"
         run: make fmt && git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help:
 	@echo "Type 'make install' to install Herbie"
 	@echo "Then type 'racket -l herbie web' to run it."
 
-install: clean egg-herbie update
+install: clean egg-herbie update egglog-herbie
 
 clean:
 	raco pkg remove --force --no-docs herbie && echo "Uninstalled old herbie" || :

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -326,8 +326,8 @@
                                         [`(max ,n) n] ; Not quite right (copied from egg-herbie.rkt)
                                         [`(sum ,n) n])
                                       min-cost))
-                     (Approx M MTy)
-                     ,@(platform-impl-nodes pform min-cost)))
+               (Approx M MTy)
+               ,@(platform-impl-nodes pform min-cost)))
 
   (egglog-program-add! typed-graph curr-program)
 


### PR DESCRIPTION
This PR introduces a major change in how costs are integrated into the Egglog program.

Since Egglog does not support floating-point costs and throws the error `parse error: expected cost to be a nonnegative integer literal`, we work around this by traversing all nodes to accumulate their raw costs, computing the minimum cost, and then normalizing the values. The minimum is scaled to 100, and the rest are adjusted proportionally and rounded to the nearest integer.

Additionally, this PR adds `egglog-herbie` to the regular `make install`