### PR TITLE
Remove the training pcontext from Herbie results

### DIFF
--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -47,7 +47,7 @@
     (match-define (job-result _ test status time timeline profile warnings backend) result)
     (match status
       ['success
-       (match-define (improve-result preprocess pctxs start targets end) backend)
+       (match-define (improve-result preprocess _ start targets end) backend)
        (match-define (alt-analysis start-alt _ start-error) start)
        (match-define (alt-analysis end-alt _ end-error) (first end))
 

--- a/infra/ci.rkt
+++ b/infra/ci.rkt
@@ -48,15 +48,15 @@
     (match status
       ['success
        (match-define (improve-result preprocess _ start targets end) backend)
-       (match-define (alt-analysis start-alt _ start-error) start)
-       (match-define (alt-analysis end-alt _ end-error) (first end))
+       (match-define (alt-analysis start-alt start-error) start)
+       (match-define (alt-analysis end-alt end-error) (first end))
 
        ;; Pick lowest target from all target
        (define target-error
          ; If the list is empty, return false
          (if (empty? targets)
              #f
-             (argmin errors-score (map alt-analysis-test-errors targets))))
+             (argmin errors-score (map alt-analysis-errors targets))))
 
        (printf "[ ~as]   ~a→~a\t~a\n"
                (~r (/ time 1000) #:min-width 7 #:precision '(= 3))

--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -29,8 +29,6 @@
               start
               result
               target
-              start-est
-              result-est
               time
               link
               cost-accuracy)
@@ -110,8 +108,6 @@
                              start-bits
                              end-bits
                              target-bits
-                             start-est
-                             end-est
                              time
                              link
                              cost-accuracy)
@@ -136,8 +132,6 @@
                                 (start . ,start-bits)
                                 (end . ,end-bits)
                                 (target . ,target-bits)
-                                (start-est . ,start-est)
-                                (end-est . ,end-est)
                                 (vars . ,(and vars (map symbol->string vars)))
                                 (warnings . ,(map ~s warnings))
                                 (input . ,(~s input))
@@ -226,8 +220,6 @@
                               (get 'start)
                               (get 'end)
                               (get 'target)
-                              (hash-ref test 'start-est 0)
-                              (hash-ref test 'end-est 0)
                               (get 'time)
                               (get 'link)
                               cost-accuracy)))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -82,7 +82,6 @@
                #:when is-valid?)
       (define target-expr (fpcore->prog expr (*context*)))
       (define target-errs (errors target-expr test-pcontext* (*context*)))
-
       (alt-analysis (make-alt target-expr) target-errs)))
 
   ;; compute error/cost for output expression

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -442,12 +442,12 @@
       (parameterize ([current-output-port os])
         (write-xexpr
          `(div ([id "history"])
-               (ol ,@(render-history altn processed-pcontext train-pcontext (test-context test)))))
+               (ol ,@(render-history altn processed-pcontext (test-context test)))))
         (get-output-string os))))
 
   (define derivations
     (for/list ([altn (in-list altns)])
-      (render-json altn processed-pcontext train-pcontext (test-context test))))
+      (render-json altn processed-pcontext (test-context test))))
 
   (hasheq 'test
           (~s test-fpcore)
@@ -484,7 +484,7 @@
   (define cost (alt-cost alt repr))
 
   (match-define (list train-pcontext processed-pcontext) pcontexts)
-  (define history (render-history alt processed-pcontext train-pcontext (test-context test)))
+  (define history (render-history alt processed-pcontext (test-context test)))
 
   (define vars (test-vars test))
   (define splitpoints

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -419,13 +419,13 @@
       ['timeout #f]
       ['failure (exception->datum backend)]))
 
-  (define-values (altns train-pcontext processed-pcontext)
+  (define-values (altns pcontext)
     (cond
       [(equal? (job-result-status herbie-result) 'success)
        (define altns (map alt-analysis-alt (improve-result-end backend)))
-       (match-define (list train-pcontext processed-pcontext) (improve-result-pctxs backend))
-       (values altns train-pcontext processed-pcontext)]
-      [else (values '() #f #f)]))
+       (define pcontext (improve-result-pcontext backend))
+       (values altns pcontext)]
+      [else (values '() #f)]))
 
   (define test-fpcore
     (alt->fpcore test (make-alt-preprocessing (test-input test) (test-preprocess test))))
@@ -441,12 +441,12 @@
       (define os (open-output-string))
       (parameterize ([current-output-port os])
         (write-xexpr `(div ([id "history"])
-                           (ol ,@(render-history altn processed-pcontext (test-context test)))))
+                           (ol ,@(render-history altn pcontext (test-context test)))))
         (get-output-string os))))
 
   (define derivations
     (for/list ([altn (in-list altns)])
-      (render-json altn processed-pcontext (test-context test))))
+      (render-json altn pcontext (test-context test))))
 
   (hasheq 'test
           (~s test-fpcore)
@@ -465,25 +465,24 @@
 
 (define (backend-improve-result-hash-table backend test)
   (define repr (context-repr (test-context test)))
-  (define pcontexts (improve-result-pctxs backend))
+  (define pcontext (improve-result-pcontext backend))
   (hasheq 'preprocessing
           (map ~s (improve-result-preprocess backend))
-          'pctxs
-          (map (curryr pcontext->json repr) pcontexts)
+          'pcontext
+          (pcontext->json pcontext repr)
           'start
-          (analysis->json (improve-result-start backend) pcontexts test)
+          (analysis->json (improve-result-start backend) pcontext test)
           'target
-          (map (curryr analysis->json pcontexts test) (improve-result-target backend))
+          (map (curryr analysis->json pcontext test) (improve-result-target backend))
           'end
-          (map (curryr analysis->json pcontexts test) (improve-result-end backend))))
+          (map (curryr analysis->json pcontext test) (improve-result-end backend))))
 
-(define (analysis->json analysis pcontexts test)
+(define (analysis->json analysis pcontext test)
   (define repr (context-repr (test-context test)))
-  (match-define (alt-analysis alt train-errors test-errors) analysis)
+  (match-define (alt-analysis alt test-errors) analysis)
   (define cost (alt-cost alt repr))
 
-  (match-define (list train-pcontext processed-pcontext) pcontexts)
-  (define history (render-history alt processed-pcontext (test-context test)))
+  (define history (render-history alt pcontext (test-context test)))
 
   (define vars (test-vars test))
   (define splitpoints
@@ -497,8 +496,6 @@
           (~s (alt-expr alt))
           'history
           (~s history)
-          'train-score
-          train-errors
           'errors
           test-errors
           'cost

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -440,9 +440,8 @@
     (for/list ([altn (in-list altns)])
       (define os (open-output-string))
       (parameterize ([current-output-port os])
-        (write-xexpr
-         `(div ([id "history"])
-               (ol ,@(render-history altn processed-pcontext (test-context test)))))
+        (write-xexpr `(div ([id "history"])
+                           (ol ,@(render-history altn processed-pcontext (test-context test)))))
         (get-output-string os))))
 
   (define derivations

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -198,9 +198,7 @@
 
   (match altn
     [(alt prog 'start (list) _)
-     `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
-            (type . "start")
-            (error . ,err))]
+     `#hash((program . ,(fpcore->string (expr->fpcore prog ctx))) (type . "start") (error . ,err))]
 
     [(alt prog `(regimes ,splitpoints) prevs _)
      (define intervals

--- a/src/reports/plot.rkt
+++ b/src/reports/plot.rkt
@@ -36,7 +36,7 @@
 (define (make-points-json result-hash)
   (define test (car (load-tests (open-input-string (hash-ref result-hash 'test)))))
   (define backend (hash-ref result-hash 'backend))
-  (define test-points (map first (second (hash-ref backend 'pctxs))))
+  (define test-points (map first (hash-ref backend 'pcontext)))
   (define start (hash-ref backend 'start))
   (define targets (hash-ref backend 'target))
   (define end (hash-ref backend 'end))


### PR DESCRIPTION
This PR removes the training error from HTML reports and the API.

Way way back in the day, before the timeline, we added training error to the derivations in the Herbie reports, in an attempt to aid debugging. I think it was never particularly useful, was broken at various points in time, and also at this point clearly inferior to the timeline, which is where we put all debugging-related information. More generally, I think we should maybe treat training error as an internal detail of Herbie—it's visible in other "internal" places like timeline but shouldn't be exposed to users and clients through reports or the API.

So let's just remove it. This PR removes training error from the `table-row` struct, the `alt-analysis` struct, the corresponding pcontext from the `improve-result` struct, and adjusts all the other code for the new data structures.