### PR TITLE
Faster `atab-eval-altns` using more batches

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -64,8 +64,7 @@
        (vector-set! costs i cost))
      (for/list ([root (in-vector (batch-roots batch))])
        (vector-ref costs root))]
-    [else
-     (make-list (vector-length (batch-roots batch)) 1)]))
+    [else (make-list (vector-length (batch-roots batch)) 1)]))
 
 (define (make-alt-table pcontext initial-alt ctx)
   (define cost (alt-cost* initial-alt (context-repr ctx)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -175,8 +175,9 @@
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (atab-eval-altns atab altns ctx)
-  (define errss (batch-errors (map alt-expr altns) (alt-table-pcontext atab) ctx))
   (define costs (map (curryr alt-cost* (context-repr ctx)) altns))
+  (define batch (progs->batch (map alt-expr altns) #:timeline-push #t #:vars (context-vars ctx)))
+  (define errss (batch-errors batch (alt-table-pcontext atab) ctx))
   (values errss costs))
 
 (define (atab-add-altns atab altns errss costs)

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -89,7 +89,8 @@
 
   (define size 0)
   (define (munge prog)
-    (hash-ref! cache prog
+    (hash-ref! cache
+               prog
                (lambda ()
                  (set! size (+ 1 size))
                  (mutable-batch-push! out (expr-recurse prog munge)))))

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -85,10 +85,14 @@
   (for ([var (in-list vars)])
     (mutable-batch-push! out var))
 
+  (define cache (make-hasheq))
+
   (define size 0)
   (define (munge prog)
-    (set! size (+ 1 size))
-    (mutable-batch-push! out (expr-recurse prog munge)))
+    (hash-ref! cache prog
+               (lambda ()
+                 (set! size (+ 1 size))
+                 (mutable-batch-push! out (expr-recurse prog munge)))))
 
   (define roots (list->vector (map munge exprs)))
   (define final (mutable-batch->batch out roots))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -62,7 +62,10 @@
 (define (compile-progs exprs ctx)
   (define vars (context-vars ctx))
   (define num-vars (length vars))
-  (define batch (if (batch? exprs) exprs (progs->batch exprs #:timeline-push #t #:vars vars)))
+  (define batch
+    (if (batch? exprs)
+        exprs
+        (progs->batch exprs #:timeline-push #t #:vars vars)))
 
   ; Here we need to keep vars even though no roots refer to the vars
   (define batch* (batch-remove-zombie (batch-remove-approx batch) #:keep-vars #t))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -62,21 +62,20 @@
 (define (compile-progs exprs ctx)
   (define vars (context-vars ctx))
   (define num-vars (length vars))
+  (define batch (if (batch? exprs) exprs (progs->batch exprs #:timeline-push #t #:vars vars)))
 
   ; Here we need to keep vars even though no roots refer to the vars
-  (define batch
-    (batch-remove-zombie (batch-remove-approx (progs->batch exprs #:timeline-push #t #:vars vars))
-                         #:keep-vars #t))
+  (define batch* (batch-remove-zombie (batch-remove-approx batch) #:keep-vars #t))
 
   (define instructions
-    (for/vector #:length (- (batch-length batch) num-vars)
-                ([node (in-vector (batch-nodes batch) num-vars)])
+    (for/vector #:length (- (batch-length batch*) num-vars)
+                ([node (in-vector (batch-nodes batch*) num-vars)])
       (match node
         [(literal value (app get-representation repr)) (list (const (real->repr value repr)))]
         [(list 'if c t f) (list if-proc c t f)]
         [(list op args ...) (cons (impl-info op 'fl) args)])))
 
-  (make-progs-interpreter (batch-vars batch) instructions (batch-roots batch)))
+  (make-progs-interpreter (batch-vars batch*) instructions (batch-roots batch*)))
 
 ;; Like `compile-progs`, but a single prog.
 (define (compile-prog expr ctx)

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -72,7 +72,10 @@
   (define max-error (+ 1 (expt 2 (representation-total-bits repr))))
 
   ;; This generates the errors array in reverse because that's how lists work
-  (define num-exprs (if (batch? exprs) (vector-length (batch-roots exprs)) (length exprs)))
+  (define num-exprs
+    (if (batch? exprs)
+        (vector-length (batch-roots exprs))
+        (length exprs)))
   (define num-points (pcontext-length pcontext))
   (for/fold ([result (make-list num-exprs '())])
             ([point (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)]

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -2,6 +2,7 @@
 
 (require "../utils/float.rkt"
          "../syntax/types.rkt"
+         "batch.rkt"
          "compiler.rkt")
 
 (provide *pcontext*
@@ -71,8 +72,9 @@
   (define max-error (+ 1 (expt 2 (representation-total-bits repr))))
 
   ;; This generates the errors array in reverse because that's how lists work
+  (define num-exprs (if (batch? exprs) (vector-length (batch-roots exprs)) (length exprs)))
   (define num-points (pcontext-length pcontext))
-  (for/fold ([result (make-list (length exprs) '())])
+  (for/fold ([result (make-list num-exprs '())])
             ([point (in-vector (pcontext-points pcontext) (- num-points 1) -1 -1)]
              [exact (in-vector (pcontext-exacts pcontext) (- num-points 1) -1 -1)])
     (for/list ([out (in-vector (fn point))]


### PR DESCRIPTION
This PR makes a few small optimizations to `atab-eval-altns`:

- In `progs->batch`, use an eq-cache to speed up batch-construction from expressions that came from a batch. Note that this messes with the statistics a bit, but maybe in a good way (?)
- In `compile-progs` and `batch-errors`, allow passing in a pre-constructed batch
- In `atab-eval-altns` compute the cost directly from the batch to skip duplicates

The end result is that `fidget/colonnade.fpcore` goes from 202s to 107s on my macOS machine, which seems worth it.