### PR TITLE
Faster `get-fpcore-impl` and `make-alternative-result`

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -438,11 +438,11 @@
 
   (define histories
     (for/list ([altn (in-list altns)]
-               [analysis (if (hash? backend-hash) (hash-ref backend-hash 'end) '())])
+               [analysis (if (hash? backend-hash)
+                             (hash-ref backend-hash 'end)
+                             '())])
       (define history (read (open-input-string (hash-ref analysis 'history))))
-      (define block
-        `(div ([id "history"])
-              (ol ,@(render-history altn pcontext (test-context test)))))
+      (define block `(div ([id "history"]) (ol ,@(render-history altn pcontext (test-context test)))))
       (call-with-output-string (curry write-xexpr block))))
 
   (define derivations

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -437,12 +437,13 @@
         (list (~s test-fpcore))))
 
   (define histories
-    (for/list ([altn (in-list altns)])
-      (define os (open-output-string))
-      (parameterize ([current-output-port os])
-        (write-xexpr `(div ([id "history"])
-                           (ol ,@(render-history altn pcontext (test-context test)))))
-        (get-output-string os))))
+    (for/list ([altn (in-list altns)]
+               [analysis (if (hash? backend-hash) (hash-ref backend-hash 'end) '())])
+      (define history (read (open-input-string (hash-ref analysis 'history))))
+      (define block
+        `(div ([id "history"])
+              (ol ,@(render-history altn pcontext (test-context test)))))
+      (call-with-output-string (curry write-xexpr block))))
 
   (define derivations
     (for/list ([altn (in-list altns)])

--- a/src/utils/common.rkt
+++ b/src/utils/common.rkt
@@ -281,8 +281,7 @@
 (define prop-dict/c (listof (cons/c symbol? any/c)))
 
 ;; Prop list to dict
-(define/contract (props->dict props)
-  (-> list? (listof (cons/c symbol? any/c)))
+(define (props->dict props)
   (let loop ([props props]
              [dict '()])
     (match props
@@ -290,8 +289,7 @@
       [(list key) (error 'props->dict "unmatched key" key)]
       [(list) dict])))
 
-(define/contract (dict->props prop-dict)
-  (-> (listof (cons/c symbol? any/c)) list?)
+(define (dict->props prop-dict)
   (apply append
          (for/list ([(k v) (in-dict prop-dict)])
            (list k v))))


### PR DESCRIPTION
This PR speeds up `get-fpcore-impl` using a cache and `make-alternative-result` by reusing a `render-history` result instead of duplicating it. As a result, `make-alternative-result` for the colonnade benchmark goes from ~85s to ~40s, which still isn't great but is an improvement. The hope is that this makes the nightly reports run faster, too.