### PR TITLE
Speed up regimes pcontext splitting

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -20,7 +20,7 @@
 
 (provide combine-alts
          (struct-out sp)
-         splitpoints->point-preds)
+         regimes-split-pcontext)
 
 (module+ test
   (require rackunit
@@ -185,35 +185,26 @@
             (sp (si-cidx si1) expr split-at))
           (list (sp (si-cidx (last sindices)) expr +nan.0))))
 
-(define/contract (splitpoints->point-preds splitpoints alts ctx)
-  (-> valid-splitpoints? (listof alt?) context? (listof procedure?))
-
+(define (regimes-split-pcontext pcontext splitpoints alts ctx)
   (define bexpr (sp-bexpr (car splitpoints)))
   (define ctx* (struct-copy context ctx [repr (repr-of bexpr ctx)]))
   (define prog (compile-prog bexpr ctx*))
 
-  (for/list ([i (in-naturals)]
-             [alt alts]) ;; alts necessary to terminate loop
-    (λ (pt)
-      (define val (prog pt))
-      (for/first ([right splitpoints]
-                  #:when (or (equal? (sp-point right) +nan.0)
-                             (<=/total val (sp-point right) (context-repr ctx*))))
-        ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
-        (equal? (sp-cidx right) i)))))
+  (define pts-vector (make-vector (length alts) '()))
+  (define exs-vector (make-vector (length alts) '()))
 
-(module+ test
-  (define context (make-debug-context '(x y)))
-  (parameterize ([*start-prog* '(/.f64 x y)])
-    (define sps
-      (list (sp 0 '(/.f64 y x) -inf.0)
-            (sp 2 '(/.f64 y x) 0.0)
-            (sp 0 '(/.f64 y x) +inf.0)
-            (sp 1 '(/.f64 y x) +nan.0)))
-    (match-define (list p0? p1? p2?)
-      (splitpoints->point-preds sps (map make-alt (build-list 3 (const '(λ (x y) (/ x y))))) context))
+  (for ([(pt ex) (in-pcontext pcontext)])
+    (define val (prog pt))
+    (for/first ([right (in-list splitpoints)]
+                #:when (or (equal? (sp-point right) +nan.0)
+                           (<=/total val (sp-point right) (context-repr ctx*))))
+      ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
+      (vector-set! pts-vector (sp-cidx right) (cons pt (vector-ref pts-vector (sp-cidx right))))
+      (vector-set! exs-vector (sp-cidx right) (cons ex (vector-ref exs-vector (sp-cidx right))))))
 
-    (check-pred p0? #(0.0 -1.0))
-    (check-pred p2? #(-1.0 1.0))
-    (check-pred p0? #(+1.0 1.0))
-    (check-pred p1? #(0.0 0.0))))
+  (for/list ([sp (in-list splitpoints)])
+    (define pts (reverse (vector-ref pts-vector (sp-cidx sp))))
+    (define exs (reverse (vector-ref exs-vector (sp-cidx sp))))
+    (if (null? pts)
+        pcontext
+        (mk-pcontext pts exs))))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -196,9 +196,10 @@
                              (define entry-ivals
                                (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx)) intervals))
                              (map (curryr interval->string repr) entry-ivals)))
-            (prevs . ,(for/list ([entry prevs]
-                                 [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
-                        (render-json entry new-pcontext ctx))))]
+            (prevs .
+                   ,(for/list ([entry prevs]
+                               [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
+                      (render-json entry new-pcontext ctx))))]
 
     [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -17,23 +17,6 @@
 (provide render-history
          render-json)
 
-(define (split-pcontext pcontext splitpoints alts ctx)
-  (define preds (splitpoints->point-preds splitpoints alts ctx))
-
-  (for/list ([pred preds])
-    (define-values (pts* exs*)
-      (for/lists (pts exs) ([(pt ex) (in-pcontext pcontext)] #:when (pred pt)) (values pt ex)))
-
-    ;; TODO: The (if) here just corrects for the possibility that we
-    ;; might have sampled new points that include no points in a given
-    ;; regime. Instead it would be best to continue sampling until we
-    ;; actually have many points in each regime. That would require
-    ;; breaking some abstraction boundaries right now so we haven't
-    ;; done it yet.
-    (if (null? pts*)
-        pcontext
-        (mk-pcontext pts* exs*))))
-
 (struct interval (alt-idx start-point end-point expr))
 
 (define (interval->string ival repr)
@@ -136,7 +119,7 @@
        (li ,@(apply append
                     (for/list ([entry prevs]
                                [idx (in-naturals)]
-                               [new-pcontext (split-pcontext pcontext splitpoints prevs ctx)])
+                               [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
                       (define entry-ivals
                         (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx)) intervals))
                       (define condition
@@ -214,7 +197,7 @@
                                (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx)) intervals))
                              (map (curryr interval->string repr) entry-ivals)))
             (prevs . ,(for/list ([entry prevs]
-                                 [new-pcontext (split-pcontext pcontext splitpoints prevs ctx)])
+                                 [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
                         (render-json entry new-pcontext ctx))))]
 
     [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)


### PR DESCRIPTION
I'm trying to make `render-history` faster, since it turns out to take up a _huge_ amount of runtime. Now, _most_ of that function is spent in `errors`, which should be easy to speed up by just batching. But first I wanted to speed up `split-pcontext`, which turns out to be pretty dumb by default. This PR doesn't optimize it maximally but it still makes it about 2x faster, saving an estimated, I don't know, half a minute (?) on nightlies.