### PR TITLE
Reconstruct at all locations, not just one

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -173,10 +173,9 @@
                      (define start-expr (get-starting-expr altn))
                      (for ([full-altn (in-list (^next-alts^))])
                        (define expr (alt-expr full-altn))
-                       (sow
-                        (for/fold ([full-altn full-altn])
-                                  ([loc (in-list (get-locations expr start-expr))])
-                          (reconstruct-alt altn loc full-altn)))))))
+                       (sow (for/fold ([full-altn full-altn])
+                                      ([loc (in-list (get-locations expr start-expr))])
+                              (reconstruct-alt altn loc full-altn)))))))
 
   (void))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -173,8 +173,10 @@
                      (define start-expr (get-starting-expr altn))
                      (for ([full-altn (in-list (^next-alts^))])
                        (define expr (alt-expr full-altn))
-                       (for ([loc (in-list (get-locations expr start-expr))])
-                         (sow (reconstruct-alt altn loc full-altn)))))))
+                       (sow
+                        (for/fold ([full-altn full-altn])
+                                  ([loc (in-list (get-locations expr start-expr))])
+                          (reconstruct-alt altn loc full-altn)))))))
 
   (void))
 


### PR DESCRIPTION
This PR makes a subtle change to rewrite/series. Suppose we have an expression E where a subexpression S appears twice: `E[S, S]`. Rewrite/series gives us lots of variations of S: S1, S2, ... Then we "reconstruct" those into variations of E. At the moment we create `E[S1, S]`, `E[S2, S]`, ..., `E[Sn, S]` and also `E[S, S1]`, `E[S, S2]`, ... We never create, say, `E[S1, S1]` (let alone `E[S1, S2]`); if that is useful we'd need to do two iterations.

This PR changes things so we only make `E[S1, S1]`, `E[S2, S2]`, and so on. There are two reasons to do this:
- It might be slightly faster, since we generate fewer candidates. I guess that pans out. In principle it could be slightly better but in practice it doesn't seem to be; in a nightly run it's worse on `expfmod`, a benchmark I don't care much for (very fiddly, not realistic) and otherwise minutely better on a very few benchmarks.
- It should also be more amenable to living in a batch-based world, something I think is important because it seems critical for scaling to larger benchmarks.

I think it's not a big deal but I guess I'd lean toward merging.