### PR TITLE
Faster nightlies using `batch-errors`

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -423,9 +423,8 @@
        (values altns pcontext)]
       [else (values '() #f)]))
 
-  (define exprs
-    (append-map (curryr collect-expressions pcontext ctx) altns))
-  
+  (define exprs (append-map (curryr collect-expressions pcontext ctx) altns))
+
   (define pctx->exprs
     (for/hash ([group (in-list (group-by cdr exprs))])
       (values (cdar group) (map car group))))
@@ -433,9 +432,10 @@
   (define errcache
     (for/hash ([(pctx exprs) (in-hash pctx->exprs)])
       (define scores (map errors-score (batch-errors exprs pctx ctx)))
-      (values pctx (for/hash ([expr (in-list exprs)]
-                              [score (in-list scores)])
-                     (values expr score)))))
+      (values pctx
+              (for/hash ([expr (in-list exprs)]
+                         [score (in-list scores)])
+                (values expr score)))))
 
   (define test-fpcore
     (alt->fpcore test (make-alt-preprocessing (test-input test) (test-preprocess test))))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -414,12 +414,7 @@
   (define timeline (job-result-timeline herbie-result))
   (define profile (job-result-profile herbie-result))
 
-  (define backend-hash
-    (match (job-result-status herbie-result)
-      ['success (backend-improve-result-hash-table backend test)]
-      ['timeout #f]
-      ['failure (exception->datum backend)]))
-
+  (define ctx (test-context test))
   (define-values (altns pcontext)
     (cond
       [(equal? (job-result-status herbie-result) 'success)
@@ -427,6 +422,20 @@
        (define pcontext (improve-result-pcontext backend))
        (values altns pcontext)]
       [else (values '() #f)]))
+
+  (define exprs
+    (append-map (curryr collect-expressions pcontext ctx) altns))
+  
+  (define pctx->exprs
+    (for/hash ([group (in-list (group-by cdr exprs))])
+      (values (cdar group) (map car group))))
+
+  (define errcache
+    (for/hash ([(pctx exprs) (in-hash pctx->exprs)])
+      (define scores (map errors-score (batch-errors exprs pctx ctx)))
+      (values pctx (for/hash ([expr (in-list exprs)]
+                              [score (in-list scores)])
+                     (values expr score)))))
 
   (define test-fpcore
     (alt->fpcore test (make-alt-preprocessing (test-input test) (test-preprocess test))))
@@ -437,18 +446,24 @@
           (~s (alt->fpcore test altn)))
         (list (~s test-fpcore))))
 
+  (define backend-hash
+    (match (job-result-status herbie-result)
+      ['success (backend-improve-result-hash-table backend test errcache)]
+      ['timeout #f]
+      ['failure (exception->datum backend)]))
+
   (define histories
     (for/list ([altn (in-list altns)]
                [analysis (if (hash? backend-hash)
                              (hash-ref backend-hash 'end)
                              '())])
       (define history (read (open-input-string (hash-ref analysis 'history))))
-      (define block `(div ([id "history"]) (ol ,@(render-history altn pcontext (test-context test)))))
+      (define block `(div ([id "history"]) (ol ,@history)))
       (call-with-output-string (curry write-xexpr block))))
 
   (define derivations
     (for/list ([altn (in-list altns)])
-      (render-json altn pcontext (test-context test))))
+      (render-json altn pcontext (test-context test) errcache)))
 
   (hasheq 'test
           (~s test-fpcore)
@@ -465,7 +480,7 @@
           'backend
           backend-hash))
 
-(define (backend-improve-result-hash-table backend test)
+(define (backend-improve-result-hash-table backend test errcache)
   (define repr (context-repr (test-context test)))
   (define pcontext (improve-result-pcontext backend))
   (hasheq 'preprocessing
@@ -473,18 +488,18 @@
           'pcontext
           (pcontext->json pcontext repr)
           'start
-          (analysis->json (improve-result-start backend) pcontext test)
+          (analysis->json (improve-result-start backend) pcontext test errcache)
           'target
-          (map (curryr analysis->json pcontext test) (improve-result-target backend))
+          (map (curryr analysis->json pcontext test errcache) (improve-result-target backend))
           'end
-          (map (curryr analysis->json pcontext test) (improve-result-end backend))))
+          (map (curryr analysis->json pcontext test errcache) (improve-result-end backend))))
 
-(define (analysis->json analysis pcontext test)
+(define (analysis->json analysis pcontext test errcache)
   (define repr (context-repr (test-context test)))
   (match-define (alt-analysis alt test-errors) analysis)
   (define cost (alt-cost alt repr))
 
-  (define history (render-history alt pcontext (test-context test)))
+  (define history (render-history alt pcontext (test-context test) errcache))
 
   (define vars (test-vars test))
   (define splitpoints

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -423,7 +423,11 @@
        (values altns pcontext)]
       [else (values '() #f)]))
 
-  (define exprs (append-map (curryr collect-expressions pcontext ctx) altns))
+  (define exprs
+    (append-map (curryr collect-expressions pcontext ctx)
+                (append (list (improve-result-start backend))
+                        (improve-result-target backend)
+                        (improve-result-end backend))))
 
   (define pctx->exprs
     (for/hash ([group (in-list (group-by cdr exprs))])

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -425,9 +425,10 @@
 
   (define exprs
     (append-map (curryr collect-expressions pcontext ctx)
-                (append (list (improve-result-start backend))
-                        (improve-result-target backend)
-                        (improve-result-end backend))))
+                (map alt-analysis-alt
+                     (append (list (improve-result-start backend))
+                             (improve-result-target backend)
+                             (improve-result-end backend)))))
 
   (define pctx->exprs
     (for/hash ([group (in-list (group-by cdr exprs))])

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -425,10 +425,12 @@
 
   (define exprs
     (append-map (curryr collect-expressions pcontext ctx)
-                (map alt-analysis-alt
-                     (append (list (improve-result-start backend))
-                             (improve-result-target backend)
-                             (improve-result-end backend)))))
+                (if (equal? (job-result-status herbie-result) 'success)
+                    (map alt-analysis-alt
+                         (append (list (improve-result-start backend))
+                                 (improve-result-target backend)
+                                 (improve-result-end backend)))
+                    '())))
 
   (define pctx->exprs
     (for/hash ([group (in-list (group-by cdr exprs))])

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -14,7 +14,8 @@
          "../core/points.rkt"
          "../core/programs.rkt"
          "common.rkt")
-(provide render-history
+(provide collect-expressions
+         render-history
          render-json)
 
 (struct interval (alt-idx start-point end-point expr))
@@ -52,10 +53,10 @@
         [_ (void)]))
     (k 'Goal #f '() step)))
 
-(define (altn-errors altn pcontext ctx)
+(define (altn-errors altn pcontext ctx errcache)
   (define repr (context-repr ctx))
   (define repr-bits (representation-total-bits repr))
-  (define err (errors-score (errors (alt-expr altn) pcontext ctx)))
+  (define err (hash-ref (hash-ref errcache pcontext) (alt-expr altn)))
   (format-accuracy err repr-bits #:unit "%"))
 
 (define (expr->fpcore expr ctx #:ident [ident #f])
@@ -95,18 +96,45 @@
         [`(,op ,args ...) `(,op ,@(map loop args))])))
   `(FPCore ,(context-vars ctx) ,expr*))
 
+(define (collect-expressions altn pcontext ctx)
+  (reap [sow]
+        (let loop ([altn altn] [pcontext pcontext])
+          (when (impl-prog? (alt-expr altn))
+            (sow (cons (alt-expr altn) pcontext)))
+
+          (match altn
+            [(alt prog 'start (list) _)
+             (void)]
+            [(alt prog 'add-preprocessing `(,prev) _)
+             (loop prev pcontext)]
+            [(alt _ `(regimes ,splitpoints) prevs _)
+             (for ([entry prevs]
+                   [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
+               (loop entry new-pcontext))]
+
+            [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
+             (loop prev pcontext)]
+
+            [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
+             (loop prev pcontext)
+
+             (for ([step proof])
+               (define-values (dir rule loc expr) (splice-proof-step step))
+               (when (impl-prog? expr)
+                 (sow (cons expr pcontext))))]))))
+
 ;; HTML renderer for derivations
-(define/contract (render-history altn pcontext ctx)
-  (-> alt? pcontext? context? (listof xexpr?))
+(define/contract (render-history altn pcontext ctx errcache)
+  (-> alt? pcontext? context? any/c (listof xexpr?))
   (match altn
     [(alt prog 'start (list) _)
-     (define err (altn-errors altn pcontext ctx))
+     (define err (altn-errors altn pcontext ctx errcache))
      (list `(li (p "Initial program " (span ((class "error")) ,err))
                 (div ((class "math")) "\\[" ,(program->tex prog ctx) "\\]")))]
 
     [(alt prog 'add-preprocessing `(,prev) _)
      ;; TODO message to user is? proof later
-     `(,@(render-history prev pcontext ctx) (li "Add Preprocessing"))]
+     `(,@(render-history prev pcontext ctx errcache) (li "Add Preprocessing"))]
 
     [(alt _ `(regimes ,splitpoints) prevs _)
      (define intervals
@@ -125,12 +153,12 @@
                       (define condition
                         (string-join (map (curryr interval->string repr) entry-ivals) " or "))
                       `((h2 (code "if " (span ((class "condition")) ,condition)))
-                        (ol ,@(render-history entry new-pcontext ctx))))))
+                        (ol ,@(render-history entry new-pcontext ctx errcache))))))
        (li ((class "event")) "Recombined " ,(~a (length prevs)) " regimes into one program."))]
 
     [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
      (define core (mixed->fpcore prog ctx))
-     `(,@(render-history prev pcontext ctx)
+     `(,@(render-history prev pcontext ctx errcache)
        (li (p "Taylor expanded in " ,(~a var) " around " ,(~a pt))
            (div ((class "math"))
                 "\\[\\leadsto "
@@ -138,15 +166,15 @@
                 "\\]")))]
 
     [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
-     (define err (altn-errors altn pcontext ctx))
-     `(,@(render-history prev pcontext ctx)
+     (define err (altn-errors altn pcontext ctx errcache))
+     `(,@(render-history prev pcontext ctx errcache)
        (li ,(if proof
-                (render-proof proof pcontext ctx)
+                (render-proof proof pcontext ctx errcache)
                 ""))
        (li (p "Applied rewrites" (span ((class "error")) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]))
 
-(define (render-proof proof pcontext ctx)
+(define (render-proof proof pcontext ctx errcache)
   `(div ((class "proof"))
         (details (summary "Step-by-step derivation")
                  (ol ,@(for/list ([step proof])
@@ -155,7 +183,7 @@
                          (define-values (err prog)
                            (cond
                              [(impl-prog? expr) ; impl program?
-                              (values (format-accuracy (errors-score (errors expr pcontext ctx))
+                              (values (format-accuracy (hash-ref (hash-ref errcache pcontext) expr)
                                                        (representation-total-bits (context-repr ctx)))
                                       (program->fpcore expr ctx))]
                              [else (values "N/A" (mixed->fpcore expr ctx))]))
@@ -172,11 +200,11 @@
                                        ,(core->tex prog #:loc (and loc (cons 2 loc)) #:color "blue")
                                        "\\]"))))))))
 
-(define (render-json altn pcontext ctx)
+(define (render-json altn pcontext ctx errcache)
   (define repr (context-repr ctx))
   (define err
     (if (impl-prog? (alt-expr altn))
-        (errors-score (errors (alt-expr altn) pcontext ctx))
+        (hash-ref (hash-ref errcache pcontext) (alt-expr altn))
         "N/A"))
 
   (match altn
@@ -199,12 +227,12 @@
             (prevs .
                    ,(for/list ([entry prevs]
                                [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
-                      (render-json entry new-pcontext ctx))))]
+                      (render-json entry new-pcontext ctx errcache))))]
 
     [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "taylor")
-            (prev . ,(render-json prev pcontext ctx))
+            (prev . ,(render-json prev pcontext ctx errcache))
             (pt . ,(~a pt))
             (var . ,(~a var))
             (loc . ,loc)
@@ -213,9 +241,9 @@
     [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "rr")
-            (prev . ,(render-json prev pcontext ctx))
+            (prev . ,(render-json prev pcontext ctx errcache))
             (proof . ,(if proof
-                          (render-proof-json proof pcontext ctx)
+                          (render-proof-json proof pcontext ctx errcache)
                           (json-null)))
             (loc . ,loc)
             (error . ,err))]
@@ -223,16 +251,16 @@
     [(alt prog 'add-preprocessing `(,prev) preprocessing)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
             (type . "add-preprocessing")
-            (prev . ,(render-json prev pcontext ctx))
+            (prev . ,(render-json prev pcontext ctx errcache))
             (error . ,err)
             (preprocessing . ,(map (curry map symbol->string) preprocessing)))]))
 
-(define (render-proof-json proof pcontext ctx)
+(define (render-proof-json proof pcontext ctx errcache)
   (for/list ([step proof])
     (define-values (dir rule loc expr) (splice-proof-step step))
     (define err
       (if (impl-prog? expr)
-          (errors-score (errors expr pcontext ctx))
+          (hash-ref (hash-ref errcache pcontext) expr)
           "N/A"))
 
     `#hash((error . ,err)

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -98,22 +98,20 @@
 
 (define (collect-expressions altn pcontext ctx)
   (reap [sow]
-        (let loop ([altn altn] [pcontext pcontext])
+        (let loop ([altn altn]
+                   [pcontext pcontext])
           (when (impl-prog? (alt-expr altn))
             (sow (cons (alt-expr altn) pcontext)))
 
           (match altn
-            [(alt prog 'start (list) _)
-             (void)]
-            [(alt prog 'add-preprocessing `(,prev) _)
-             (loop prev pcontext)]
+            [(alt prog 'start (list) _) (void)]
+            [(alt prog 'add-preprocessing `(,prev) _) (loop prev pcontext)]
             [(alt _ `(regimes ,splitpoints) prevs _)
              (for ([entry prevs]
                    [new-pcontext (regimes-split-pcontext pcontext splitpoints prevs ctx)])
                (loop entry new-pcontext))]
 
-            [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
-             (loop prev pcontext)]
+            [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _) (loop prev pcontext)]
 
             [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
              (loop prev pcontext)
@@ -122,7 +120,7 @@
                (for ([step proof])
                  (define-values (dir rule loc expr) (splice-proof-step step))
                  (when (impl-prog? expr)
-                   (sow (cons expr pcontext))))])))))
+                   (sow (cons expr pcontext)))))]))))
 
 ;; HTML renderer for derivations
 (define/contract (render-history altn pcontext ctx errcache)

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -118,10 +118,11 @@
             [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
              (loop prev pcontext)
 
-             (for ([step proof])
-               (define-values (dir rule loc expr) (splice-proof-step step))
-               (when (impl-prog? expr)
-                 (sow (cons expr pcontext))))]))))
+             (when proof
+               (for ([step proof])
+                 (define-values (dir rule loc expr) (splice-proof-step step))
+                 (when (impl-prog? expr)
+                   (sow (cons expr pcontext))))])))))
 
 ;; HTML renderer for derivations
 (define/contract (render-history altn pcontext ctx errcache)


### PR DESCRIPTION
This PR adds a pretty ugly "errcache" to the JSONify code so that all alt evaluations in `render-history` and `render-json` use a single batch. This speeds up JSONify by ~2x, cutting nontrivial time off of each nightly run. It could be _even_ faster because it's not actually a single batch, it's a single batch _per pcontext_, and pcontexts differ because we split them during regimes. It would be better to, instead of filtering the pcontexts, just mask them out—then everything really could use one big batch—but for now let's pocket this speedup while we can.