### PR TITLE
Enforce rule soundness using a little proof assistant

### DIFF
--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -60,7 +60,7 @@
   (define identities (append even-identities odd-identities swap-identities))
 
   ;; make egg runner
-  (define rules (*simplify-rules*))
+  (define rules (*sound-rules*))
 
   (define batch (progs->batch (cons spec (map cdr identities))))
   (define runner

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -21,7 +21,7 @@
             [`(sqrt ,x) (list `(< ,x 0))]
             [`(tan ,x) (list `(== (cos ,x) 0))]
             [`(tgamma ,x) (list `(and (<= ,x 0) (integer? ,x)))]
-            [`(pow ,a ,b) (list `(and (< ,a 0) (even-fraction? ,b)) `(and (== ,a 0) (< ,b 0)))]
+            [`(pow ,a ,b) (list `(and (< ,a 0) (even-denominator? ,b)) `(and (== ,a 0) (< ,b 0)))]
             [`(/ ,a ,b) (list `(== ,b 0))]
             [else '()])
           (if (list? x)
@@ -117,9 +117,9 @@
     [`(== (cos (* 2 ,a)) 0) (list `(== (tan ,a) 1) `(== (tan ,a) -1))]
     [`(== (tan ,a) 0) (list `(== (sin ,a) 0))]
 
-    [`(even-fraction? (neg ,b)) (list `(even-fraction? ,b))]
-    [`(even-fraction? (+ ,b 1)) (list `(even-fraction? ,b))]
-    [`(even-fraction? ,(? rational? a))
+    [`(even-denominator? (neg ,b)) (list `(even-denominator? ,b))]
+    [`(even-denominator? (+ ,b 1)) (list `(even-denominator? ,b))]
+    [`(even-denominator? ,(? rational? a))
      (if (even? (denominator a))
          '((TRUE))
          '())]
@@ -146,7 +146,7 @@
 
 (define soundness-proofs
   '((pow-plus (implies (< b -1) (< b 0)))
-    (pow-sqr (implies (even-fraction? (* 2 b)) (even-fraction? b)))
+    (pow-sqr (implies (even-denominator? (* 2 b)) (even-denominator? b)))
     (hang-0p-tan (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
     (hang-0p-tan-rev (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
     (hang-0m-tan (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
@@ -168,9 +168,10 @@
     (hang-m0-tan (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
     (sqrt-pow2 (implies (and a b) a))
     (pow-div (implies (< (- b c) 0) (or (< b 0) (> c 0)))
-             (implies (even-fraction? (- b c)) (or (even-fraction? b) (even-fraction? c))))
+             (implies (even-denominator? (- b c)) (or (even-denominator? b) (even-denominator? c))))
     (pow-prod-up (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
-                 (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
+                 (implies (even-denominator? (+ b c))
+                          (or (even-denominator? b) (even-denominator? c))))
     (pow-prod-down (implies (< (* b c) 0) (or (< b 0) (< c 0))))
     (log-pow-rev (implies (and a b) a) (implies (< (pow a b) 0) (< a 0)))))
 

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -50,9 +50,9 @@
 (define (simplify-expression expr)
   (define patterns
     (list '[(cos (neg a)) . (cos a)]
-          '[(sin (neg a)) . (sin a)]
+          '[(sin (neg a)) . (neg (sin a))]
           '[(cos (+ a (PI))) . (neg (cos a))]
-          '[(cos (+ a (/ (PI) 2))) . (sin a)]
+          '[(cos (+ a (/ (PI) 2))) . (neg (sin a))]
           '[(cos (acos a)) . a]
           '[(cos (asin a)) . (sqrt (- 1 (* a a)))]
           '[(fabs (neg a)) . (fabs a)]
@@ -172,9 +172,6 @@
     (pow-prod-up (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
                  (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
     (pow-prod-down (implies (< (* b c) 0) (or (< b 0) (< c 0))))
-    ;; If y / 2 is an even fraction, y cannot have a factor of 2 in the numerator
-    (sqrt-pow1 (implies (and (< x 0) (even-fraction? (/ y 2)))
-                        (or (and (< x 0) (even-fraction? y)) (< (pow x y) 0))))
     (log-pow-rev (implies (and a b) a) (implies (< (pow a b) 0) (< a 0)))))
 
 (define (execute-proof proof terms)

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -1,0 +1,229 @@
+#lang racket
+
+(require rackunit)
+(require "../syntax/matcher.rkt"
+         "programs.rkt"
+         "rules.rkt")
+
+(define (validity-conditions x)
+  (append
+   (match x
+     [`(acos ,x)
+      (list `(< 1 (fabs ,x)))]
+     [`(acosh ,x)
+      (list `(< ,x 1))]
+     [`(asin ,x)
+      (list `(< 1 (fabs ,x)))]
+     [`(atanh ,x)
+      (list `(<= 1 (fabs ,x)))]
+     [`(fmod ,x ,y)
+      (list `(== ,y 0))]
+     [`(lgamma ,x)
+      (list `(and (<= ,x 0) (integer? ,x)))]
+     [`(log ,x)
+      (list `(<= ,x 0))]
+     [`(log10 ,x)
+      (list `(<= ,x 0))]
+     [`(log2 ,x)
+      (list `(<= ,x 0))]
+     [`(logb ,x)
+      (list `(== ,x 0))]
+     [`(remainder ,x ,y)
+      (list `(== ,y 0))]
+     [`(sqrt ,x)
+      (list `(< ,x 0))]
+     [`(tan ,x)
+      (list `(== (cos ,x) 0))]
+     [`(tgamma ,x)
+      (list `(and (<= ,x 0) (integer? ,x)))]
+     [`(pow ,a ,b)
+      (list `(and (< ,a 0) (even-fraction? ,b))
+            `(and (== ,a 0) (< ,b 0)))]
+     [`(/ ,a ,b)
+      (list `(== ,b 0))]
+     [else '()])
+   (if (list? x)
+       (append-map validity-conditions (cdr x))
+       '())))
+
+(define (simplify-conditions xs)
+  (define simple1
+    (apply append
+           (for/list ([x (remove-duplicates xs)])
+             (match x
+               [`(== ,(? number? a) ,(? number? b))
+                (if (= a b) '((TRUE)) '())]
+               [`(< ,(? number? a) ,(? number? b))
+                (if (< a b) '((TRUE)) '())]
+               [`(> ,(? number? a) ,(? number? b))
+                (if (> a b) '((TRUE)) '())]
+               [`(<= (/ 1 ,a) 0) (list `(<= ,a 0))]
+               [`(,(or '== '<= '<) (exp ,a) 0) '()]
+               [`(== (PI) 0) '()]
+               [`(== (* 2 (PI)) 0) '()]
+               [`(== (cbrt ,a) 0) (list `(== ,a 0))]
+               [`(== (sqrt ,a) 0) (list `(== ,a 0))]
+               [`(== (neg ,a) 0) (list `(== ,a 0))]
+               [`(== (- 1 ,a) 0) (list `(== ,a 1))]
+               [`(== (fabs ,a) 0) (list `(== ,a 0))]
+               [`(== (fabs ,a) 1) (list `(== ,a 1) `(== ,a -1))]
+               [`(== (pow ,a 3) 0) (list `(== ,a 0))]
+               [`(== (* ,a ,b) 0) (list `(== ,a 0) `(== ,b 0))]
+               [`(== (cos (neg ,a)) 0) (list `(== (cos ,a) 0))]
+               [`(== (cos (neg ,a)) -1) (list `(== (cos ,a) -1))]
+               [`(== (cos (+ ,a (PI))) 0) (list `(== (cos ,a) 0))]
+               [`(== ,(? number? a) ,b) `((== ,b ,a))] ; canonicalize
+               [`(,(or '== '<= '<) (+ 1 (* ,a ,a)) 0) '()]
+               [`(,(or '== '<= '<) (+ (* ,a ,a) 1) 0) '()]
+               [`(< (* ,a ,a) 0) '()]
+               [`(< (sqrt ,a) 0) '()]
+               [`(< (neg ,a) 0) (list `(> ,a 0))]
+               [`(== (pow ,a ,b) 0) (list `(and (== ,a 0) (> ,b 0)))]
+               [`(< (* 2 ,a) 0) (list `(< ,a 0))]
+               [`(<= ,a ,b) (list `(< ,a ,b) `(== ,a ,b))]
+               [`(== (* ,a ,a) 1) (list `(== (fabs ,a) 1))]
+               [`(< (- 1 (* ,a ,a)) 0) (list `(< 1 (fabs ,a)))]
+               [`(< (- (* ,a ,a) 1) 0) (list `(< (fabs ,a) 1))]
+               [`(== (+ (* ,a ,a) (,(or '- '+) (* ,b ,b) (* ,a ,b))) 0)
+                (list `(and (== ,a 0) (== ,b 0)))]
+               [`(< 1 (fabs (neg x))) (list `(< 1 (fabs x)))]
+               [`(== (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
+               [`(== (+ ,x (sqrt (- (* ,x ,x) 1))) 0) '()]
+               [`(< (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
+               [`(< 1 (fabs (,(or 'cos 'sin) x))) '()]
+               [`(< (+ ,x (sqrt (- (* ,x ,x) 1))) 0) (list `(<= x -1))]
+               [`(== (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(== ,x -1))]
+               [`(< (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(< 1 (fabs x)))]
+               [`(,(or '< '== '<=) (fabs ,a) ,(? (conjoin number? negative?) b)) '()]
+               [`(== (/ ,a ,b) 0) (list `(== ,a 0))]
+
+               [`(< (/ ,x 2) 0) (list `(< ,x 0))]
+               [`(< (+ ,x 1) 0) (list `(< ,x -1))]
+               [`(== (+ ,x 1) 0) (list `(== ,x -1))]
+               [`(== (+ 1 ,x) 0) (list `(== ,x -1))]
+               [`(,(or '< '==) (cosh ,x) 0) '()]
+               [`(,(or '< '==) (cosh ,x) -1) '()]
+               [`(== (exp ,a) -1) '()]
+               [`(== (exp ,a) 0) '()]
+               [`(== (+ (exp ,a) (exp ,b)) 0) '()]
+
+               [`(== (* (tan ,x) (tan ,y)) 1) (list `(== (cos (+ ,x ,y)) 0))]
+
+               [`(== (+ (cos ,a) (cos ,b)) 0) (list `(== (cos (/ (+ ,a ,b) 2)) 0)
+                                                    `(== (cos (/ (- ,a ,b) 2)) 0))]
+
+               [`(== (cos (* 2 ,a)) 0) (list `(== (tan ,a) 1)
+                                             `(== (tan ,a) -1))]
+               [`(== (cos (acos ,a)) 0) (list `(== ,a 0))]
+               [`(== (cos (asin ,a)) 0) (list `(== ,a 1) `(== ,a -1))]
+
+               [`(even-fraction? (neg ,b)) (list `(even-fraction? ,b))]
+               [`(even-fraction? (+ ,b 1)) (list `(even-fraction? ,b))]
+               [`(even-fraction? ,(? rational? a))
+                (if (even? (denominator a))
+                    '((TRUE))
+                    '())]
+
+               [`(or ,sub ...)
+                sub]
+               [`(and ,sub ...)
+                (define subs (map (compose simplify-conditions list) sub))
+                (define conjunctions (apply cartesian-product subs))
+                (for/list ([conj (in-list conjunctions)])
+                  (match (set-remove conj '(TRUE))
+                    ['() '(TRUE)]
+                    [(list a) a]
+                    [(list as ...) (cons 'and as)]))]
+               [x (list x)]))))
+  (if (equal? simple1 xs)
+      xs
+      (simplify-conditions simple1)))
+
+(define soundness-proofs
+  '((pow-plus
+     (implies (< b -1) (< b 0)))
+    (pow-sqr
+     (implies (even-fraction? (* 2 b)) (even-fraction? b)))
+    (hang-0p-tan
+     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0p-tan-rev
+     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0m-tan
+     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0m-tan-rev
+     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (tanh-sum
+     (implies (== (* (tanh x) (tanh y)) -1) (FALSE)))
+    (acosh-def
+     (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
+     (rewrite (fabs (fabs x)) (fabs x)))
+    (acosh-def-rev
+     (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
+     (rewrite (fabs (fabs x)) (fabs x)))
+    (sqrt-undiv
+     (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
+    (sqrt-unprod
+     (implies (< (* x y) 0) (or (< x 0) (< y 0))))
+    (sum-log 
+     (implies (< (* x y) 0) (or (< x 0) (< y 0))))
+    (diff-log 
+     (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
+    (exp-to-pow
+     (implies (and a b) a))
+    (sinh-acosh
+     (implies (< (fabs x) 1) (< x 1)))
+    (tanh-acosh
+     (implies (< (fabs x) 1) (< x 1))
+     (implies (== x 0) (< x 1)))
+    (hang-p0-tan
+     (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
+    (hang-m0-tan
+     (implies (== (cos (/ a 2)) 0) (== (sin a) 0))
+     (rewrite (sin (neg a)) (neg (sin a))))
+    (sqrt-pow2
+     (implies (and a b) a))
+    (pow-div
+     (implies (< (- b c) 0) (or (< b 0) (> c 0)))
+     (implies (even-fraction? (- b c)) (or (even-fraction? b) (even-fraction? c))))
+    (pow-prod-up
+     (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
+     (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
+    (pow-prod-down
+     (implies (< (* b c) 0) (or (< b 0) (< c 0))))))
+
+
+(define (execute-proof-step step term)
+  (match step
+    [`(,(or 'implies 'rewrite) ,a ,b)
+     (define matches 
+       (for/list ([subexpr (in-list (all-subexpressions term))]
+                  #:when (pattern-match a subexpr))
+         (cons subexpr (pattern-substitute b (pattern-match a subexpr)))))
+     (for/fold ([term term])
+               ([(from to) (in-dict matches)])
+       (replace-expression term from to))]))
+
+(define (execute-proof proof terms)
+  (for/fold ([terms (simplify-conditions terms)])
+            ([step (in-list proof)])
+    (simplify-conditions (map (curry execute-proof-step step) terms))))
+
+(define (potentially-unsound)
+  (define num 0)
+  (for ([rule (in-list (*sound-rules*))])
+    (test-case (~a (rule-name rule))
+      (define proof (dict-ref soundness-proofs (rule-name rule) '()))
+      (define lhs-bad (execute-proof proof (validity-conditions (rule-input rule))))
+      (define rhs-bad (execute-proof proof (validity-conditions (rule-output rule))))
+      (define extra (set-remove (set-subtract rhs-bad lhs-bad) '(FALSE)))
+      (when (not (null? extra))
+        (eprintf "Cannot prove rule ~a valid\n" (rule-name rule))
+        (for ([term (in-list lhs-bad)])
+          (eprintf "  ~a\n" term))
+        (eprintf "  --------------------\n")
+        (for ([term (in-list extra)])
+          (eprintf "  ~a\n" term))
+        (fail)))))
+
+(module+ test
+  (potentially-unsound))

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -52,6 +52,7 @@
     (list '[(cos (neg a)) . (cos a)]
           '[(sin (neg a)) . (sin a)]
           '[(cos (+ a (PI))) . (neg (cos a))]
+          '[(cos (+ a (/ (PI) 2))) . (sin a)]
           '[(cos (acos a)) . a]
           '[(cos (asin a)) . (sqrt (- 1 (* a a)))]
           '[(fabs (neg a)) . (fabs a)]
@@ -92,13 +93,15 @@
 
     [`(< (/ 1 ,a) 0) (list `(< ,a 0))]
     [`(< (neg ,a) 0) (list `(> ,a 0))]
-    [`(< (* 2 ,a) 0) (list `(< ,a 0))]
+    [`(< (* 2 ,a) ,(? number? b)) (list `(< ,a ,(/ b 2)))]
     [`(< (+ 1 ,a) 0) (list `(< ,a -1))]
     [`(< (/ ,x 2) 0) (list `(< ,x 0))]
     [`(< (+ ,x 1) 0) (list `(< ,x -1))]
+    [`(< (- ,a 1) ,(? number? b)) (list `(< ,a ,(+ b 1)))]
+    [`(< (- 1 ,x) 0) (list `(< 1 ,x))]
 
-    [`(< (- 1 (* ,a ,a)) 0) (list `(< 1 (fabs ,a)))]
-    [`(< (- (* ,a ,a) 1) 0) (list `(< (fabs ,a) 1))]
+    [`(< (* ,a ,a) 1) (list `(< (fabs ,a) 1))]
+    [`(< 1 (* ,a ,a)) (list `(< 1 (fabs ,a)))]
 
     [`(== (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
     [`(== (+ ,x (sqrt (- (* ,x ,x) 1))) 0) '()]
@@ -112,6 +115,7 @@
 
     [`(== (+ (cos ,a) (cos ,b)) 0) (list `(== (cos (/ (+ ,a ,b) 2)) 0) `(== (cos (/ (- ,a ,b) 2)) 0))]
     [`(== (cos (* 2 ,a)) 0) (list `(== (tan ,a) 1) `(== (tan ,a) -1))]
+    [`(== (tan ,a) 0) (list `(== (sin ,a) 0))]
 
     [`(even-fraction? (neg ,b)) (list `(even-fraction? ,b))]
     [`(even-fraction? (+ ,b 1)) (list `(even-fraction? ,b))]
@@ -158,6 +162,7 @@
     (diff-log (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
     (exp-to-pow (implies (and a b) a))
     (sinh-acosh (implies (< (fabs x) 1) (< x 1)))
+    (acosh-2-rev (implies (< (fabs x) 1) (< x 1)))
     (tanh-acosh (implies (< (fabs x) 1) (< x 1)) (implies (== x 0) (< x 1)))
     (hang-p0-tan (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
     (hang-m0-tan (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
@@ -166,7 +171,11 @@
              (implies (even-fraction? (- b c)) (or (even-fraction? b) (even-fraction? c))))
     (pow-prod-up (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
                  (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
-    (pow-prod-down (implies (< (* b c) 0) (or (< b 0) (< c 0))))))
+    (pow-prod-down (implies (< (* b c) 0) (or (< b 0) (< c 0))))
+    ;; If y / 2 is an even fraction, y cannot have a factor of 2 in the numerator
+    (sqrt-pow1 (implies (and (< x 0) (even-fraction? (/ y 2)))
+                        (or (and (< x 0) (even-fraction? y)) (< (pow x y) 0))))
+    (log-pow-rev (implies (and a b) a) (implies (< (pow a b) 0) (< a 0)))))
 
 (define (execute-proof proof terms)
   (for/fold ([terms (simplify-conditions terms)]) ([step (in-list proof)])

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -6,206 +6,165 @@
          "rules.rkt")
 
 (define (validity-conditions x)
-  (append
-   (match x
-     [`(acos ,x)
-      (list `(< 1 (fabs ,x)))]
-     [`(acosh ,x)
-      (list `(< ,x 1))]
-     [`(asin ,x)
-      (list `(< 1 (fabs ,x)))]
-     [`(atanh ,x)
-      (list `(<= 1 (fabs ,x)))]
-     [`(fmod ,x ,y)
-      (list `(== ,y 0))]
-     [`(lgamma ,x)
-      (list `(and (<= ,x 0) (integer? ,x)))]
-     [`(log ,x)
-      (list `(<= ,x 0))]
-     [`(log10 ,x)
-      (list `(<= ,x 0))]
-     [`(log2 ,x)
-      (list `(<= ,x 0))]
-     [`(logb ,x)
-      (list `(== ,x 0))]
-     [`(remainder ,x ,y)
-      (list `(== ,y 0))]
-     [`(sqrt ,x)
-      (list `(< ,x 0))]
-     [`(tan ,x)
-      (list `(== (cos ,x) 0))]
-     [`(tgamma ,x)
-      (list `(and (<= ,x 0) (integer? ,x)))]
-     [`(pow ,a ,b)
-      (list `(and (< ,a 0) (even-fraction? ,b))
-            `(and (== ,a 0) (< ,b 0)))]
-     [`(/ ,a ,b)
-      (list `(== ,b 0))]
-     [else '()])
-   (if (list? x)
-       (append-map validity-conditions (cdr x))
-       '())))
+  (append (match x
+            [`(acos ,x) (list `(< 1 (fabs ,x)))]
+            [`(acosh ,x) (list `(< ,x 1))]
+            [`(asin ,x) (list `(< 1 (fabs ,x)))]
+            [`(atanh ,x) (list `(<= 1 (fabs ,x)))]
+            [`(fmod ,x ,y) (list `(== ,y 0))]
+            [`(lgamma ,x) (list `(and (<= ,x 0) (integer? ,x)))]
+            [`(log ,x) (list `(<= ,x 0))]
+            [`(log10 ,x) (list `(<= ,x 0))]
+            [`(log2 ,x) (list `(<= ,x 0))]
+            [`(logb ,x) (list `(== ,x 0))]
+            [`(remainder ,x ,y) (list `(== ,y 0))]
+            [`(sqrt ,x) (list `(< ,x 0))]
+            [`(tan ,x) (list `(== (cos ,x) 0))]
+            [`(tgamma ,x) (list `(and (<= ,x 0) (integer? ,x)))]
+            [`(pow ,a ,b) (list `(and (< ,a 0) (even-fraction? ,b)) `(and (== ,a 0) (< ,b 0)))]
+            [`(/ ,a ,b) (list `(== ,b 0))]
+            [else '()])
+          (if (list? x)
+              (append-map validity-conditions (cdr x))
+              '())))
 
 (define (simplify-conditions xs)
   (define simple1
-    (apply append
-           (for/list ([x (remove-duplicates xs)])
-             (match x
-               [`(== ,(? number? a) ,(? number? b))
-                (if (= a b) '((TRUE)) '())]
-               [`(< ,(? number? a) ,(? number? b))
-                (if (< a b) '((TRUE)) '())]
-               [`(> ,(? number? a) ,(? number? b))
-                (if (> a b) '((TRUE)) '())]
-               [`(<= (/ 1 ,a) 0) (list `(<= ,a 0))]
-               [`(,(or '== '<= '<) (exp ,a) 0) '()]
-               [`(== (PI) 0) '()]
-               [`(== (* 2 (PI)) 0) '()]
-               [`(== (cbrt ,a) 0) (list `(== ,a 0))]
-               [`(== (sqrt ,a) 0) (list `(== ,a 0))]
-               [`(== (neg ,a) 0) (list `(== ,a 0))]
-               [`(== (- 1 ,a) 0) (list `(== ,a 1))]
-               [`(== (fabs ,a) 0) (list `(== ,a 0))]
-               [`(== (fabs ,a) 1) (list `(== ,a 1) `(== ,a -1))]
-               [`(== (pow ,a 3) 0) (list `(== ,a 0))]
-               [`(== (* ,a ,b) 0) (list `(== ,a 0) `(== ,b 0))]
-               [`(== (cos (neg ,a)) 0) (list `(== (cos ,a) 0))]
-               [`(== (cos (neg ,a)) -1) (list `(== (cos ,a) -1))]
-               [`(== (cos (+ ,a (PI))) 0) (list `(== (cos ,a) 0))]
-               [`(== ,(? number? a) ,b) `((== ,b ,a))] ; canonicalize
-               [`(,(or '== '<= '<) (+ 1 (* ,a ,a)) 0) '()]
-               [`(,(or '== '<= '<) (+ (* ,a ,a) 1) 0) '()]
-               [`(< (* ,a ,a) 0) '()]
-               [`(< (sqrt ,a) 0) '()]
-               [`(< (neg ,a) 0) (list `(> ,a 0))]
-               [`(== (pow ,a ,b) 0) (list `(and (== ,a 0) (> ,b 0)))]
-               [`(< (* 2 ,a) 0) (list `(< ,a 0))]
-               [`(<= ,a ,b) (list `(< ,a ,b) `(== ,a ,b))]
-               [`(== (* ,a ,a) 1) (list `(== (fabs ,a) 1))]
-               [`(< (- 1 (* ,a ,a)) 0) (list `(< 1 (fabs ,a)))]
-               [`(< (- (* ,a ,a) 1) 0) (list `(< (fabs ,a) 1))]
-               [`(== (+ (* ,a ,a) (,(or '- '+) (* ,b ,b) (* ,a ,b))) 0)
-                (list `(and (== ,a 0) (== ,b 0)))]
-               [`(< 1 (fabs (neg x))) (list `(< 1 (fabs x)))]
-               [`(== (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
-               [`(== (+ ,x (sqrt (- (* ,x ,x) 1))) 0) '()]
-               [`(< (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
-               [`(< 1 (fabs (,(or 'cos 'sin) x))) '()]
-               [`(< (+ ,x (sqrt (- (* ,x ,x) 1))) 0) (list `(<= x -1))]
-               [`(== (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(== ,x -1))]
-               [`(< (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(< 1 (fabs x)))]
-               [`(,(or '< '== '<=) (fabs ,a) ,(? (conjoin number? negative?) b)) '()]
-               [`(== (/ ,a ,b) 0) (list `(== ,a 0))]
+    (apply
+     append
+     (for/list ([x (remove-duplicates xs)])
+       (match x
+         [`(== ,(? number? a) ,(? number? b))
+          (if (= a b)
+              '((TRUE))
+              '())]
+         [`(< ,(? number? a) ,(? number? b))
+          (if (< a b)
+              '((TRUE))
+              '())]
+         [`(> ,(? number? a) ,(? number? b))
+          (if (> a b)
+              '((TRUE))
+              '())]
+         [`(<= (/ 1 ,a) 0) (list `(<= ,a 0))]
+         [`(,(or '== '<= '<) (exp ,a) 0) '()]
+         [`(== (PI) 0) '()]
+         [`(== (* 2 (PI)) 0) '()]
+         [`(== (cbrt ,a) 0) (list `(== ,a 0))]
+         [`(== (sqrt ,a) 0) (list `(== ,a 0))]
+         [`(== (neg ,a) 0) (list `(== ,a 0))]
+         [`(== (- 1 ,a) 0) (list `(== ,a 1))]
+         [`(== (fabs ,a) 0) (list `(== ,a 0))]
+         [`(== (fabs ,a) 1) (list `(== ,a 1) `(== ,a -1))]
+         [`(== (pow ,a 3) 0) (list `(== ,a 0))]
+         [`(== (* ,a ,b) 0) (list `(== ,a 0) `(== ,b 0))]
+         [`(== (cos (neg ,a)) 0) (list `(== (cos ,a) 0))]
+         [`(== (cos (neg ,a)) -1) (list `(== (cos ,a) -1))]
+         [`(== (cos (+ ,a (PI))) 0) (list `(== (cos ,a) 0))]
+         [`(== ,(? number? a) ,b) `((== ,b ,a))] ; canonicalize
+         [`(,(or '== '<= '<) (+ 1 (* ,a ,a)) 0) '()]
+         [`(,(or '== '<= '<) (+ (* ,a ,a) 1) 0) '()]
+         [`(< (* ,a ,a) 0) '()]
+         [`(< (sqrt ,a) 0) '()]
+         [`(< (neg ,a) 0) (list `(> ,a 0))]
+         [`(== (pow ,a ,b) 0) (list `(and (== ,a 0) (> ,b 0)))]
+         [`(< (* 2 ,a) 0) (list `(< ,a 0))]
+         [`(<= ,a ,b) (list `(< ,a ,b) `(== ,a ,b))]
+         [`(== (* ,a ,a) 1) (list `(== (fabs ,a) 1))]
+         [`(< (- 1 (* ,a ,a)) 0) (list `(< 1 (fabs ,a)))]
+         [`(< (- (* ,a ,a) 1) 0) (list `(< (fabs ,a) 1))]
+         [`(== (+ (* ,a ,a) (,(or '- '+) (* ,b ,b) (* ,a ,b))) 0) (list `(and (== ,a 0) (== ,b 0)))]
+         [`(< 1 (fabs (neg x))) (list `(< 1 (fabs x)))]
+         [`(== (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
+         [`(== (+ ,x (sqrt (- (* ,x ,x) 1))) 0) '()]
+         [`(< (+ ,x (sqrt (+ (* ,x ,x) 1))) 0) '()]
+         [`(< 1 (fabs (,(or 'cos 'sin) x))) '()]
+         [`(< (+ ,x (sqrt (- (* ,x ,x) 1))) 0) (list `(<= x -1))]
+         [`(== (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(== ,x -1))]
+         [`(< (/ (+ 1 ,x) (- 1 ,x)) 0) (list `(< 1 (fabs x)))]
+         [`(,(or '< '== '<=) (fabs ,a) ,(? (conjoin number? negative?) b)) '()]
+         [`(== (/ ,a ,b) 0) (list `(== ,a 0))]
 
-               [`(< (/ ,x 2) 0) (list `(< ,x 0))]
-               [`(< (+ ,x 1) 0) (list `(< ,x -1))]
-               [`(== (+ ,x 1) 0) (list `(== ,x -1))]
-               [`(== (+ 1 ,x) 0) (list `(== ,x -1))]
-               [`(,(or '< '==) (cosh ,x) 0) '()]
-               [`(,(or '< '==) (cosh ,x) -1) '()]
-               [`(== (exp ,a) -1) '()]
-               [`(== (exp ,a) 0) '()]
-               [`(== (+ (exp ,a) (exp ,b)) 0) '()]
+         [`(< (/ ,x 2) 0) (list `(< ,x 0))]
+         [`(< (+ ,x 1) 0) (list `(< ,x -1))]
+         [`(== (+ ,x 1) 0) (list `(== ,x -1))]
+         [`(== (+ 1 ,x) 0) (list `(== ,x -1))]
+         [`(,(or '< '==) (cosh ,x) 0) '()]
+         [`(,(or '< '==) (cosh ,x) -1) '()]
+         [`(== (exp ,a) -1) '()]
+         [`(== (exp ,a) 0) '()]
+         [`(== (+ (exp ,a) (exp ,b)) 0) '()]
 
-               [`(== (* (tan ,x) (tan ,y)) 1) (list `(== (cos (+ ,x ,y)) 0))]
+         [`(== (* (tan ,x) (tan ,y)) 1) (list `(== (cos (+ ,x ,y)) 0))]
 
-               [`(== (+ (cos ,a) (cos ,b)) 0) (list `(== (cos (/ (+ ,a ,b) 2)) 0)
-                                                    `(== (cos (/ (- ,a ,b) 2)) 0))]
+         [`(== (+ (cos ,a) (cos ,b)) 0)
+          (list `(== (cos (/ (+ ,a ,b) 2)) 0) `(== (cos (/ (- ,a ,b) 2)) 0))]
 
-               [`(== (cos (* 2 ,a)) 0) (list `(== (tan ,a) 1)
-                                             `(== (tan ,a) -1))]
-               [`(== (cos (acos ,a)) 0) (list `(== ,a 0))]
-               [`(== (cos (asin ,a)) 0) (list `(== ,a 1) `(== ,a -1))]
+         [`(== (cos (* 2 ,a)) 0) (list `(== (tan ,a) 1) `(== (tan ,a) -1))]
+         [`(== (cos (acos ,a)) 0) (list `(== ,a 0))]
+         [`(== (cos (asin ,a)) 0) (list `(== ,a 1) `(== ,a -1))]
 
-               [`(even-fraction? (neg ,b)) (list `(even-fraction? ,b))]
-               [`(even-fraction? (+ ,b 1)) (list `(even-fraction? ,b))]
-               [`(even-fraction? ,(? rational? a))
-                (if (even? (denominator a))
-                    '((TRUE))
-                    '())]
+         [`(even-fraction? (neg ,b)) (list `(even-fraction? ,b))]
+         [`(even-fraction? (+ ,b 1)) (list `(even-fraction? ,b))]
+         [`(even-fraction? ,(? rational? a))
+          (if (even? (denominator a))
+              '((TRUE))
+              '())]
 
-               [`(or ,sub ...)
-                sub]
-               [`(and ,sub ...)
-                (define subs (map (compose simplify-conditions list) sub))
-                (define conjunctions (apply cartesian-product subs))
-                (for/list ([conj (in-list conjunctions)])
-                  (match (set-remove conj '(TRUE))
-                    ['() '(TRUE)]
-                    [(list a) a]
-                    [(list as ...) (cons 'and as)]))]
-               [x (list x)]))))
+         [`(or ,sub ...) sub]
+         [`(and ,sub ...)
+          (define subs (map (compose simplify-conditions list) sub))
+          (define conjunctions (apply cartesian-product subs))
+          (for/list ([conj (in-list conjunctions)])
+            (match (set-remove conj '(TRUE))
+              ['() '(TRUE)]
+              [(list a) a]
+              [(list as ...) (cons 'and as)]))]
+         [x (list x)]))))
   (if (equal? simple1 xs)
       xs
       (simplify-conditions simple1)))
 
 (define soundness-proofs
-  '((pow-plus
-     (implies (< b -1) (< b 0)))
-    (pow-sqr
-     (implies (even-fraction? (* 2 b)) (even-fraction? b)))
-    (hang-0p-tan
-     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
-    (hang-0p-tan-rev
-     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
-    (hang-0m-tan
-     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
-    (hang-0m-tan-rev
-     (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
-    (tanh-sum
-     (implies (== (* (tanh x) (tanh y)) -1) (FALSE)))
-    (acosh-def
-     (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
-     (rewrite (fabs (fabs x)) (fabs x)))
-    (acosh-def-rev
-     (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
-     (rewrite (fabs (fabs x)) (fabs x)))
-    (sqrt-undiv
-     (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
-    (sqrt-unprod
-     (implies (< (* x y) 0) (or (< x 0) (< y 0))))
-    (sum-log 
-     (implies (< (* x y) 0) (or (< x 0) (< y 0))))
-    (diff-log 
-     (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
-    (exp-to-pow
-     (implies (and a b) a))
-    (sinh-acosh
-     (implies (< (fabs x) 1) (< x 1)))
-    (tanh-acosh
-     (implies (< (fabs x) 1) (< x 1))
-     (implies (== x 0) (< x 1)))
-    (hang-p0-tan
-     (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
-    (hang-m0-tan
-     (implies (== (cos (/ a 2)) 0) (== (sin a) 0))
-     (rewrite (sin (neg a)) (neg (sin a))))
-    (sqrt-pow2
-     (implies (and a b) a))
-    (pow-div
-     (implies (< (- b c) 0) (or (< b 0) (> c 0)))
-     (implies (even-fraction? (- b c)) (or (even-fraction? b) (even-fraction? c))))
-    (pow-prod-up
-     (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
-     (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
-    (pow-prod-down
-     (implies (< (* b c) 0) (or (< b 0) (< c 0))))))
-
+  '((pow-plus (implies (< b -1) (< b 0)))
+    (pow-sqr (implies (even-fraction? (* 2 b)) (even-fraction? b)))
+    (hang-0p-tan (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0p-tan-rev (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0m-tan (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (hang-0m-tan-rev (implies (== (cos (/ a 2)) 0) (== (cos a) -1)))
+    (tanh-sum (implies (== (* (tanh x) (tanh y)) -1) (FALSE)))
+    (acosh-def (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
+               (rewrite (fabs (fabs x)) (fabs x)))
+    (acosh-def-rev (implies (< x 1) (or (< x -1) (== x -1) (< (fabs x) 1)))
+                   (rewrite (fabs (fabs x)) (fabs x)))
+    (sqrt-undiv (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
+    (sqrt-unprod (implies (< (* x y) 0) (or (< x 0) (< y 0))))
+    (sum-log (implies (< (* x y) 0) (or (< x 0) (< y 0))))
+    (diff-log (implies (< (/ x y) 0) (or (< x 0) (< y 0))))
+    (exp-to-pow (implies (and a b) a))
+    (sinh-acosh (implies (< (fabs x) 1) (< x 1)))
+    (tanh-acosh (implies (< (fabs x) 1) (< x 1)) (implies (== x 0) (< x 1)))
+    (hang-p0-tan (implies (== (cos (/ a 2)) 0) (== (sin a) 0)))
+    (hang-m0-tan (implies (== (cos (/ a 2)) 0) (== (sin a) 0)) (rewrite (sin (neg a)) (neg (sin a))))
+    (sqrt-pow2 (implies (and a b) a))
+    (pow-div (implies (< (- b c) 0) (or (< b 0) (> c 0)))
+             (implies (even-fraction? (- b c)) (or (even-fraction? b) (even-fraction? c))))
+    (pow-prod-up (implies (< (+ b c) 0) (or (< b 0) (< c 0)))
+                 (implies (even-fraction? (+ b c)) (or (even-fraction? b) (even-fraction? c))))
+    (pow-prod-down (implies (< (* b c) 0) (or (< b 0) (< c 0))))))
 
 (define (execute-proof-step step term)
   (match step
     [`(,(or 'implies 'rewrite) ,a ,b)
-     (define matches 
+     (define matches
        (for/list ([subexpr (in-list (all-subexpressions term))]
                   #:when (pattern-match a subexpr))
          (cons subexpr (pattern-substitute b (pattern-match a subexpr)))))
-     (for/fold ([term term])
-               ([(from to) (in-dict matches)])
+     (for/fold ([term term]) ([(from to) (in-dict matches)])
        (replace-expression term from to))]))
 
 (define (execute-proof proof terms)
-  (for/fold ([terms (simplify-conditions terms)])
-            ([step (in-list proof)])
+  (for/fold ([terms (simplify-conditions terms)]) ([step (in-list proof)])
     (simplify-conditions (map (curry execute-proof-step step) terms))))
 
 (define (potentially-unsound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -499,8 +499,7 @@
  (trigonometry sound)
  #:type ([x real])
  [acos-cos-rev (fabs (remainder x (* 2 (PI)))) (acos (cos x))]
- [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))]
-  )
+ [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))])
 
 (define-ruleset* trig-inverses-simplified
                  (trigonometry)
@@ -558,13 +557,14 @@
                  [sin-+PI-rev (neg (sin x)) (sin (+ x (PI)))]
                  [cos-+PI-rev (neg (cos x)) (cos (+ x (PI)))])
 
-(define-ruleset* trig-reduce
-                 (trigonometry)
-                 #:type ([a real] [b real] [x real])
-                 [neg-tan-+PI/2 (tan (+ x (/ (PI) 2))) (/ -1 (tan x))]
-                 [tan-+PI/2 (tan (+ (neg x) (/ (PI) 2))) (/ 1 (tan x))]
-                 [hang-m0-tan-rev (tan (/ (neg a) 2)) (/ (- 1 (cos a)) (neg (sin a)))] ; unsound @ a = 0
-                 [hang-p0-tan-rev (tan (/ a 2)) (/ (- 1 (cos a)) (sin a))]) ; unsound @ a = 0
+(define-ruleset*
+ trig-reduce
+ (trigonometry)
+ #:type ([a real] [b real] [x real])
+ [neg-tan-+PI/2 (tan (+ x (/ (PI) 2))) (/ -1 (tan x))]
+ [tan-+PI/2 (tan (+ (neg x) (/ (PI) 2))) (/ 1 (tan x))]
+ [hang-m0-tan-rev (tan (/ (neg a) 2)) (/ (- 1 (cos a)) (neg (sin a)))] ; unsound @ a = 0
+ [hang-p0-tan-rev (tan (/ a 2)) (/ (- 1 (cos a)) (sin a))]) ; unsound @ a = 0
 
 (define-ruleset* trig-reduce-rev
                  (trigonometry)
@@ -630,13 +630,14 @@
                  [sin-mult-rev (/ (- (cos (- x y)) (cos (+ x y))) 2) (* (sin x) (sin y))]
                  [sin-cos-mult-rev (/ (+ (sin (- x y)) (sin (+ x y))) 2) (* (sin x) (cos y))])
 
-(define-ruleset* trig-expand
-                 (trigonometry)
-                 #:type ([x real] [y real] [a real] [b real])
-                 [tan-sum (tan (+ x y)) (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y))))] ; unsound @ x = y = pi/2
-                 [tan-2 (tan (* 2 x)) (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x))))] ; unsound @ x = pi/2
-                 [tan-hang-p (tan (/ (+ a b) 2)) (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))]
-                 [tan-hang-m (tan (/ (- a b) 2)) (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))])
+(define-ruleset*
+ trig-expand
+ (trigonometry)
+ #:type ([x real] [y real] [a real] [b real])
+ [tan-sum (tan (+ x y)) (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y))))] ; unsound @ x = y = pi/2
+ [tan-2 (tan (* 2 x)) (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x))))] ; unsound @ x = pi/2
+ [tan-hang-p (tan (/ (+ a b) 2)) (/ (+ (sin a) (sin b)) (+ (cos a) (cos b)))]
+ [tan-hang-m (tan (/ (- a b) 2)) (/ (- (sin a) (sin b)) (+ (cos a) (cos b)))])
 
 (define-ruleset* atrig-expand
                  (trigonometry sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -274,15 +274,15 @@
                  #:type ([x real] [y real])
                  [sqrt-pow2 (pow (sqrt x) y) (pow x (/ y 2))]
                  [sqrt-unprod (* (sqrt x) (sqrt y)) (sqrt (* x y))]
-                 [sqrt-undiv (/ (sqrt x) (sqrt y)) (sqrt (/ x y))]
-                 [sqrt-pow1 (sqrt (pow x y)) (pow x (/ y 2))])
+                 [sqrt-undiv (/ (sqrt x) (sqrt y)) (sqrt (/ x y))])
 
 (define-ruleset* squares-transform
                  (arithmetic)
                  #:type ([x real] [y real])
                  [sqrt-prod (sqrt (* x y)) (* (sqrt x) (sqrt y))] ; unsound @ x = y = -1
                  [sqrt-div (sqrt (/ x y)) (/ (sqrt x) (sqrt y))] ; unsound @ x = y = -1
-                 [add-sqr-sqrt x (* (sqrt x) (sqrt x))]) ; unsound @ x = -1
+                 [add-sqr-sqrt x (* (sqrt x) (sqrt x))] ; unsound @ x = -1
+                 [sqrt-pow1 (sqrt (pow x y)) (pow x (/ y 2))]) ; unsound @ x = -1, y = 2
 
 ; Cube root
 (define-ruleset* cubes-reduce
@@ -634,7 +634,6 @@
                  [sin-mult-rev (/ (- (cos (- x y)) (cos (+ x y))) 2) (* (sin x) (sin y))]
                  [sin-cos-mult-rev (/ (+ (sin (- x y)) (sin (+ x y))) 2) (* (sin x) (cos y))])
 
-;; TODO
 (define-ruleset*
  trig-expand
  (trigonometry)
@@ -753,8 +752,7 @@
 (define-ruleset* htrig-expand-unsound
                  (hyperbolic)
                  #:type ([x real] [y real])
-                 [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x))] ; unsound @ x = 0
-                 [tanh-1/2*-rev (/ (- (cosh x) 1) (sinh x)) (tanh (/ x 2))])
+                 [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x))]) ; unsound @ x = 0
 
 (define-ruleset* htrig-expand-fp-safe
                  (hyperbolic sound)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -6,7 +6,7 @@
          "../syntax/syntax.rkt")
 
 (provide *rules*
-         *simplify-rules*
+         *sound-rules*
          (struct-out rule))
 
 ;; A rule represents "find-and-replacing" `input` by `output`. Both
@@ -27,8 +27,8 @@
 (define (*rules*)
   (filter rule-enabled? *all-rules*))
 
-(define (*simplify-rules*)
-  (filter (conjoin rule-enabled? (has-tag? 'simplify)) *all-rules*))
+(define (*sound-rules*)
+  (filter (conjoin rule-enabled? (has-tag? 'sound)) *all-rules*))
 
 ;;
 ;;  Rule loading
@@ -61,14 +61,14 @@
 
 ; Commutativity
 (define-ruleset* commutativity
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real])
                  [+-commutative (+ a b) (+ b a)]
                  [*-commutative (* a b) (* b a)])
 
 ; Associativity
 (define-ruleset* associativity
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real] [c real])
                  [associate-+r+ (+ a (+ b c)) (+ (+ a b) c)]
                  [associate-+l+ (+ (+ a b) c) (+ a (+ b c))]
@@ -89,7 +89,7 @@
 
 ; Identity
 (define-ruleset* id-reduce
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real])
                  [remove-double-div (/ 1 (/ 1 a)) a]
                  [rgt-mult-inverse (* a (/ 1 a)) 1]
@@ -109,16 +109,16 @@
                  [/-rgt-identity (/ a 1) a]
                  [mul-1-neg (* -1 a) (neg a)])
 ; Counting
-(define-ruleset* counting (arithmetic simplify sound) #:type ([x real]) [count-2 (+ x x) (* 2 x)])
+(define-ruleset* counting (arithmetic sound) #:type ([x real]) [count-2 (+ x x) (* 2 x)])
 
 (define-ruleset* counting-rev
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [2-split 2 (+ 1 1)]
                  [count-2-rev (* 2 x) (+ x x)])
 ; Distributivity
 (define-ruleset* distributivity
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real] [c real])
                  [distribute-lft-in (* a (+ b c)) (+ (* a b) (* a c))]
                  [distribute-rgt-in (* a (+ b c)) (+ (* b a) (* c a))]
@@ -129,13 +129,13 @@
                  [distribute-lft1-in (+ (* b a) a) (* (+ b 1) a)]
                  [distribute-rgt1-in (+ a (* c a)) (* (+ c 1) a)])
 (define-ruleset* cancel-sign
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real] [c real])
                  [cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
                  [cancel-sign-sub-inv (- a (* b c)) (+ a (* (neg b) c))])
 ; Safe Distributiviity
 (define-ruleset* distributivity-fp-safe
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real])
                  [distribute-lft-neg-in (neg (* a b)) (* (neg a) b)]
                  [distribute-rgt-neg-in (neg (* a b)) (* a (neg b))]
@@ -149,20 +149,20 @@
                  [distribute-neg-frac2 (neg (/ a b)) (/ a (neg b))])
 
 (define-ruleset* cancel-sign-fp-safe
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real] [c real])
                  [fp-cancel-sign-sub (- a (* (neg b) c)) (+ a (* b c))]
                  [fp-cancel-sub-sign (+ a (* (neg b) c)) (- a (* b c))])
 
 (define-ruleset* cancel-sign-fp-safe-rev
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([a real] [b real] [c real])
                  [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
                  [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
 ; Difference of squares
 (define-ruleset* difference-of-squares-canonicalize
-                 (polynomials simplify sound)
+                 (polynomials sound)
                  #:type ([a real] [b real])
                  [swap-sqr (* (* a b) (* a b)) (* (* a a) (* b b))]
                  [unswap-sqr (* (* a a) (* b b)) (* (* a b) (* a b))]
@@ -172,7 +172,7 @@
                  [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))])
 
 (define-ruleset* difference-of-squares-canonicalize-rev
-                 (polynomials simplify sound)
+                 (polynomials sound)
                  #:type ([a real] [b real])
                  [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
                  [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
@@ -207,14 +207,14 @@
 
 ; Dealing with fractions
 (define-ruleset* fractions-distribute
-                 (fractions simplify sound)
+                 (fractions sound)
                  #:type ([a real] [b real] [c real] [d real])
                  [div-sub (/ (- a b) c) (- (/ a c) (/ b c))]
                  [times-frac (/ (* a b) (* c d)) (* (/ a c) (/ b d))]
                  [div-add (/ (+ a b) c) (+ (/ a c) (/ b c))])
 
 (define-ruleset* fractions-distribute-rev
-                 (fractions simplify sound)
+                 (fractions sound)
                  #:type ([a real] [b real] [c real] [d real])
                  [div-add-rev (+ (/ a c) (/ b c)) (/ (+ a b) c)])
 
@@ -234,26 +234,26 @@
 
 ; Square root
 (define-ruleset* squares-reduce
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [rem-square-sqrt (* (sqrt x) (sqrt x)) x]
                  [rem-sqrt-square (sqrt (* x x)) (fabs x)]
                  [rem-sqrt-square-rev (fabs x) (sqrt (* x x))])
 
 (define-ruleset* squares-reduce-fp-sound
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [sqr-neg (* (neg x) (neg x)) (* x x)]
                  [sqr-abs (* (fabs x) (fabs x)) (* x x)])
 
 (define-ruleset* squares-reduce-fp-sound-rev
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
                  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
 
 (define-ruleset* fabs-reduce
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real] [a real] [b real])
                  [fabs-fabs (fabs (fabs x)) (fabs x)]
                  [fabs-sub (fabs (- a b)) (fabs (- b a))]
@@ -286,7 +286,7 @@
 
 ; Cube root
 (define-ruleset* cubes-reduce
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [rem-cube-cbrt (pow (cbrt x) 3) x]
                  [rem-cbrt-cube (cbrt (pow x 3)) x]
@@ -296,7 +296,7 @@
                  [cube-neg-rev (neg (pow x 3)) (pow (neg x) 3)])
 
 (define-ruleset* cubes-distribute
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real] [y real])
                  [cube-prod (pow (* x y) 3) (* (pow x 3) (pow y 3))]
                  [cube-div (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
@@ -315,7 +315,7 @@
                  [add-cbrt-cube x (cbrt (* (* x x) x))])
 
 (define-ruleset* cubes-canonicalize
-                 (arithmetic simplify sound)
+                 (arithmetic sound)
                  #:type ([x real])
                  [cube-unmult (* x (* x x)) (pow x 3)])
 
@@ -325,27 +325,27 @@
 (define-ruleset* exp-expand (exponents) #:type ([x real]) [add-exp-log x (exp (log x))])
 
 (define-ruleset* exp-reduce
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([x real])
                  [rem-exp-log (exp (log x)) x]
                  [rem-log-exp (log (exp x)) x])
 
 (define-ruleset* exp-constants
-                 (exponents simplify sound)
+                 (exponents sound)
                  [exp-0 (exp 0) 1]
                  [exp-1-e (exp 1) (E)]
                  [1-exp 1 (exp 0)]
                  [e-exp-1 (E) (exp 1)])
 
 (define-ruleset* exp-distribute
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [exp-sum (exp (+ a b)) (* (exp a) (exp b))]
                  [exp-neg (exp (neg a)) (/ 1 (exp a))]
                  [exp-diff (exp (- a b)) (/ (exp a) (exp b))])
 
 (define-ruleset* exp-factor
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [prod-exp (* (exp a) (exp b)) (exp (+ a b))]
                  [rec-exp (/ 1 (exp a)) (exp (neg a))]
@@ -356,19 +356,19 @@
                  [exp-lft-sqr (exp (* a 2)) (* (exp a) (exp a))]
                  [exp-lft-cube (exp (* a 3)) (pow (exp a) 3)])
 (define-ruleset* exp-factor-rev
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [exp-cbrt-rev (cbrt (exp a)) (exp (/ a 3))]
                  [exp-lft-cube-rev (pow (exp a) 3) (exp (* a 3))]
                  [exp-sqrt-rev (sqrt (exp a)) (exp (/ a 2))]
                  [exp-lft-sqr-rev (* (exp a) (exp a)) (exp (* a 2))])
 ; Powers
-(define-ruleset* pow-reduce (exponents simplify sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])
+(define-ruleset* pow-reduce (exponents sound) #:type ([a real]) [unpow-1 (pow a -1) (/ 1 a)])
 
-(define-ruleset* pow-reduce-fp-safe (exponents simplify sound) #:type ([a real]) [unpow1 (pow a 1) a])
+(define-ruleset* pow-reduce-fp-safe (exponents sound) #:type ([a real]) [unpow1 (pow a 1) a])
 
 (define-ruleset* pow-reduce-fp-safe-nan
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real])
                  [unpow0 (pow a 0) 1]
                  [pow-base-1 (pow 1 a) 1])
@@ -376,7 +376,7 @@
 (define-ruleset* pow-expand-fp-safe (exponents sound) #:type ([a real]) [pow1 a (pow a 1)])
 
 (define-ruleset* pow-canonicalize
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [exp-to-pow (exp (* (log a) b)) (pow a b)]
                  [unpow1/2 (pow a 1/2) (sqrt a)]
@@ -386,7 +386,7 @@
                  [pow-plus (* (pow a b) a) (pow a (+ b 1))])
 
 (define-ruleset* pow-canonicalize-rev
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [pow-plus-rev (pow a (+ b 1)) (* (pow a b) a)])
 
@@ -419,7 +419,7 @@
                  [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a))])
 
 (define-ruleset* pow-transform-fp-safe-nan
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real])
                  [pow-base-0 (pow 0 a) 0])
 
@@ -429,7 +429,7 @@
                  [inv-pow (/ 1 a) (pow a -1)])
 
 (define-ruleset* log-distribute-sound
-                 (exponents simplify sound)
+                 (exponents sound)
                  #:type ([a real] [b real])
                  [log-rec (log (/ 1 a)) (neg (log a))]
                  [log-E (log (E)) 1])
@@ -456,20 +456,20 @@
 
 ; Trigonometry
 (define-ruleset* trig-reduce-fp-sound
-                 (trigonometry simplify sound)
+                 (trigonometry sound)
                  [sin-0 (sin 0) 0]
                  [cos-0 (cos 0) 1]
                  [tan-0 (tan 0) 0])
 
 (define-ruleset* trig-reduce-fp-sound-nan
-                 (trigonometry simplify sound)
+                 (trigonometry sound)
                  #:type ([x real])
                  [sin-neg (sin (neg x)) (neg (sin x))]
                  [cos-neg (cos (neg x)) (cos x)]
                  [tan-neg (tan (neg x)) (neg (tan x))])
 
 (define-ruleset* trig-reduce-fp-sound-nan-rev
-                 (trigonometry simplify sound)
+                 (trigonometry sound)
                  #:type ([x real])
                  [cos-neg-rev (cos x) (cos (neg x))]
                  [sin-neg-rev (neg (sin x)) (sin (neg x))]
@@ -510,7 +510,7 @@
                  [acos-cos-s (acos (cos x)) x])
 
 (define-ruleset* trig-reduce-expressions
-                 (trigonometry simplify sound)
+                 (trigonometry sound)
                  #:type ([a real] [b real] [x real])
                  [cos-sin-sum (+ (* (cos a) (cos a)) (* (sin a) (sin a))) 1]
                  [1-sub-cos (- 1 (* (cos a) (cos a))) (* (sin a) (sin a))]
@@ -546,7 +546,7 @@
                  [hang-m-tan (/ (- (sin a) (sin b)) (+ (cos a) (cos b))) (tan (/ (- a b) 2))])
 
 (define-ruleset* trig-reduce-expressions-rev
-                 (trigonometry simplify sound)
+                 (trigonometry sound)
                  #:type ([a real] [b real] [x real])
                  [1-sub-sin-rev (* (cos a) (cos a)) (- 1 (* (sin a) (sin a)))]
                  [hang-m0-tan-rev (tan (/ (neg a) 2)) (/ (- 1 (cos a)) (neg (sin a)))]
@@ -669,7 +669,7 @@
 
 ; Hyperbolic trigonometric functions
 (define-ruleset* htrig-reduce
-                 (hyperbolic simplify sound)
+                 (hyperbolic sound)
                  #:type ([x real])
                  [sinh-def (sinh x) (/ (- (exp x) (exp (neg x))) 2)]
                  [cosh-def (cosh x) (/ (+ (exp x) (exp (neg x))) 2)]
@@ -681,7 +681,7 @@
                  [sinh---cosh (- (cosh x) (sinh x)) (exp (neg x))])
 
 (define-ruleset* htrig-reduce-rev
-                 (hyperbolic simplify sound)
+                 (hyperbolic sound)
                  #:type ([x real])
                  [tanh-def-b-rev (/ (- (exp (* 2 x)) 1) (+ (exp (* 2 x)) 1)) (tanh x)]
                  [tanh-def-c-rev (/ (- 1 (exp (* -2 x))) (+ 1 (exp (* -2 x)))) (tanh x)]
@@ -798,7 +798,7 @@
 
 ;; Sound because it's about soundness over real numbers
 (define-ruleset* compare-reduce
-                 (bools simplify sound)
+                 (bools sound)
                  #:type ([x real] [y real])
                  [lt-same (< x x) (FALSE)]
                  [gt-same (> x x) (FALSE)]
@@ -810,7 +810,7 @@
                  [not-gte (not (>= x y)) (< x y)])
 
 (define-ruleset* branch-reduce
-                 (branches simplify sound)
+                 (branches sound)
                  #:type ([a bool] [b bool] [x real] [y real])
                  [if-true (if (TRUE) x y) x]
                  [if-false (if (FALSE) x y) y]


### PR DESCRIPTION
This PR adds `prove-rules.rkt`, a counterpart to `test-rules.rkt`, which proves that sound rules are actually sound. Recall our definition of soundness: a rewrite `a -> b` is sound if `a = b` when both `a` and `b` are defined, and furthermore that `b` is defined whenever `a` is. This slightly-strange asymmetric definition of soundness is just loose enough to allow valuable rewrites like `a / a -> 1` to be considered sound, while still guaranteeing no unsoundness in the egraph.

This PR accomplishes a few things. First, it reclassifies 12 rules from sound to unsound, because they were actually unsound. Second, it adds a little theorem prover to prove the remainder sound. This theorem prover works like so:

- The `validity-conditions` function traverses an expression and returns a list of cases where it is undefined. For a rewrite `a -> b` we now need to prove that the conditions on `b` are a subset of the conditions on `a`.
- The `simplify-conditions` function simplifies these conditions in an attempt to bring them to some kind of normal form so that the subset relation is trivial to test. There's kind of a mess in here because I just added cases whenever I wanted more rules to go through. Cleaning this up would be valuable. So would integrating either interval analysis or egraphs to make some of the proofs go through easier.
- The `execute-proof` and the `soundness-proofs` demonstrate a little proof language that allows manual rewrite steps to be added to make the proofs go through.

The intention is to require all rules going forward to either be:
- Sound, and verified such with the proof assistant
- Unsound, with a recorded counterexample

At the moment, we have 428 rules, of which 39 are unsound, 27 are manually proven sound, and the other 362 are automatically proven sound.