### PR TITLE
Sound rules fuzzer

### DIFF
--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -191,12 +191,16 @@
 ; Difference of cubes
 (define-ruleset*
  difference-of-cubes
- (polynomials) ; unsound @ a = b = 0
+ (polynomials sound)
  #:type ([a real] [b real])
  [sum-cubes (+ (pow a 3) (pow b 3)) (* (+ (* a a) (- (* b b) (* a b))) (+ a b))]
- [difference-cubes (- (pow a 3) (pow b 3)) (* (+ (* a a) (+ (* b b) (* a b))) (- a b))]
- [flip3-+ (+ a b) (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
- [flip3-- (- a b) (/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b))))])
+ [difference-cubes (- (pow a 3) (pow b 3)) (* (+ (* a a) (+ (* b b) (* a b))) (- a b))])
+
+(define-ruleset* difference-of-cubes-unsound
+                 (polynomials) ; unsound @ a = b = 0
+                 #:type ([a real] [b real])
+                 [flip3-+ (+ a b) (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b))))]
+                 [flip3-- (- a b) (/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b))))])
 
 (define-ruleset*
  difference-of-cubes-rev
@@ -408,8 +412,11 @@
                  #:type ([a real])
                  [pow1/2 (sqrt a) (pow a 1/2)]
                  [pow2 (* a a) (pow a 2)]
-                 [pow1/3 (cbrt a) (pow a 1/3)]
                  [pow3 (* (* a a) a) (pow a 3)])
+(define-ruleset* pow-specialize-unsound
+                 (exponents)
+                 #:type ([a real])
+                 [pow1/3 (cbrt a) (pow a 1/3)]) ; unsound @ a = -3
 
 (define-ruleset*
  pow-transform
@@ -800,7 +807,7 @@
 (define-ruleset* ahtrig-expand
                  (hyperbolic sound)
                  #:type ([x real])
-                 [asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x))])
+                 [asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh (fabs x)))])
 
 (define-ruleset* ahtrig-expand-unsound
                  (hyperbolic)

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -411,12 +411,9 @@
                  (exponents sound)
                  #:type ([a real])
                  [pow1/2 (sqrt a) (pow a 1/2)]
+                 [pow1/3 (cbrt a) (pow a 1/3)]
                  [pow2 (* a a) (pow a 2)]
                  [pow3 (* (* a a) a) (pow a 3)])
-(define-ruleset* pow-specialize-unsound
-                 (exponents)
-                 #:type ([a real])
-                 [pow1/3 (cbrt a) (pow a 1/3)]) ; unsound @ a = -3
 
 (define-ruleset*
  pow-transform

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -74,7 +74,6 @@
                     (and (not (equal? v1 v2))
                          (and (not (equal? v1 0.0)) (not (equal? v2 -0.0)))
                          (and (not (equal? v1 -0.0)) (not (equal? v2 0.0))))))
-       (unsound-rules (cons (rule-name test-rule) (unsound-rules)))
        (fail "Rule is unsound, LHS is valid, RHS is invalid"))))
   cnt)
 
@@ -98,7 +97,6 @@
                                       ['lhs-err? (ival-hi res1)]
                                       ['lhs-err! (ival-lo res1)])
                    (when (and (or rhs-err? rhs-err!) (not (or lhs-err? lhs-err!)))
-                     (unsound-rules (cons (rule-name test-rule) (unsound-rules)))
                      (fail "Rule is unsound, LHS is error free, RHS contains error"))))
 
 (define (arguments-are-real? ctx)
@@ -157,8 +155,7 @@
   (define pre (dict-ref *conditions* name '(TRUE)))
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
-                   [*max-find-range-depth* 0]
-                   [*rival-use-shorthands* #f])
+                   [*max-find-range-depth* 0])
       (sample-points pre (list p1 p2) (list ctx ctx))))
 
   (for ([pt (in-list pts)]
@@ -170,10 +167,9 @@
                                          (check-eq? (ulp-difference v1 v2 (context-repr ctx)) 1))))))
 
 (define (check-rule rule)
-  ;(check-rule-correct rule)
-  (check-rule-sound rule)
-  #;(when (set-member? (rule-tags rule) 'sound)
-      (check-rule-sound rule)))
+  (check-rule-correct rule)
+  (when (set-member? (rule-tags rule) 'sound)
+    (check-rule-sound rule)))
 
 (module+ main
   (num-test-points (* 100 (num-test-points)))
@@ -184,9 +180,7 @@
                     (first (filter (λ (x) (equal? (~a (rule-name x)) name)) (*rules*))))
                   (check-rule test-rule))))
 
-(define unsound-rules (make-parameter '()))
 (module+ test
   (for* ([rule (in-list (*rules*))])
     (test-case (~a (rule-name rule))
-      (check-rule rule)))
-  (println (unsound-rules)))
+      (check-rule rule))))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -44,6 +44,7 @@
     [(list v*) v*]
     [_ (error "Uknown Rival's result")]))
 
+; Check whether expression contains trigonometric operations
 (define (contains-trig? expr)
   (define trig-set '(sin cos tan asin acos atan atan2 sinh cosh tanh asinh acosh atanh))
   (let loop ([expr expr])
@@ -51,6 +52,9 @@
       [(list op args ...) (or (set-member? trig-set op) (map loop args))]
       [_ #f])))
 
+; Function evaluates a point to a correct rounding for both compilers and check results
+; Fails if results of compiler1 are valid and results of compiler2 are invalid
+; or fails when results are valid and not equal
 (define (eval-check-sound compiler1 compiler2 pt test-rule)
   (define cnt 0)
   (when (or (> (vector-count boolean? pt) 0)
@@ -74,6 +78,9 @@
        (fail "Rule is unsound, LHS is valid, RHS is invalid"))))
   cnt)
 
+; Function analyzes an interval with 1ulp distance made out of pt for both compilers and check results
+; Fails if LHS is error free and RHS has some errors
+; This test helps with PI, PI/2 and etc as they can not be represented exactly
 (define (analyze-check-sound compiler1 compiler2 pt test-rule)
   (define pt*
     (parameterize ([bf-precision 53])
@@ -97,6 +104,7 @@
 (define (arguments-are-real? ctx)
   (andmap (λ (x) (not (equal? 'bool (representation-name x)))) (context-var-reprs ctx)))
 
+; get all possible permutations of testing-range with varc length
 (define (get-pts-combinations testing-range varc)
   (apply cartesian-product (map (const testing-range) (range varc))))
 
@@ -104,7 +112,7 @@
   (define cnt 0)
   (match-define (rule name p1 p2 env out tags) test-rule)
 
-  ; Context
+  ; Custom context
   (define vars (remove-duplicates (append (free-variables p1) (free-variables p2))))
   (define out-repr (type->repr out))
   (define input-reprs (map (λ (var) (type->repr (dict-ref env var))) vars))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -119,12 +119,8 @@
 
   ; Compilers + random sampler
   (define-values (sampler) (λ () (vector-map random-generate (list->vector (context-var-reprs ctx)))))
-  (define compiler1
-    (parameterize ([*rival-use-shorthands* #f])
-      (make-real-compiler (list p1) (list ctx))))
-  (define compiler2
-    (parameterize ([*rival-use-shorthands* #f])
-      (make-real-compiler (list p2) (list ctx))))
+  (define compiler1 (make-real-compiler (list p1) (list ctx)))
+  (define compiler2 (make-real-compiler (list p2) (list ctx)))
 
   ; -------------------- Soundness using common inputs --------------------------------------------
   (when (arguments-are-real? ctx)


### PR DESCRIPTION
This PR introduces a fuzzer for rules.
Particularly speaking, the fuzzer searches for unsoundness in the rules using either: `rival-apply` if the fuzzing point can be represented in double precision, or `rival-analyze` if the point can not be represented in double precision (`PI`, `PI/2`, etc...).
`rival-apply` part simply checks that LHS is valid and RHS is valid, if RHS is invalid and LHS is valid - rule is unsound.
`rival-analyze` part check that LHS and RHS are both error free, if RHS has errors that LHS does not - rule is unsound.

Fuzzing is done over different ranges: 
For rules that do not have trigonometric functions: `(range -3 3 0.5)` + some random points
For rules that do have trigonometric functions I rely on `rival-analyze` at points `(map degrees->radians (range 0 361 0.15))` as they can not be represented as doubles + some random points