### PR TITLE
Remove "conditional" rules

### DIFF
--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -93,9 +93,10 @@
 
     [`(< (/ 1 ,a) 0) (list `(< ,a 0))]
     [`(< (neg ,a) 0) (list `(> ,a 0))]
+    [`(< (cbrt ,a) 0) (list `(< ,a 0))]
     [`(< (* 2 ,a) ,(? number? b)) (list `(< ,a ,(/ b 2)))]
     [`(< (+ 1 ,a) 0) (list `(< ,a -1))]
-    [`(< (/ ,x 2) 0) (list `(< ,x 0))]
+    [`(< (/ ,x ,(? (conjoin number? positive?))) 0) (list `(< ,x 0))]
     [`(< (+ ,x 1) 0) (list `(< ,x -1))]
     [`(< (- ,a 1) ,(? number? b)) (list `(< ,a ,(+ b 1)))]
     [`(< (- 1 ,x) 0) (list `(< 1 ,x))]
@@ -119,6 +120,7 @@
 
     [`(even-denominator? (neg ,b)) (list `(even-denominator? ,b))]
     [`(even-denominator? (+ ,b 1)) (list `(even-denominator? ,b))]
+    [`(even-denominator? (/ ,b 3)) (list `(even-denominator? ,b))]
     [`(even-denominator? ,(? rational? a))
      (if (even? (denominator a))
          '((TRUE))

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -227,6 +227,8 @@
   [cbrt-div (cbrt (/ x y)) (/ (cbrt x) (cbrt y))]
   [cbrt-unprod (* (cbrt x) (cbrt y)) (cbrt (* x y))]
   [cbrt-undiv (/ (cbrt x) (cbrt y)) (cbrt (/ x y))]
+  [pow-cbrt (pow (cbrt x) y) (pow x (/ y 3))]
+  [cbrt-pow (cbrt (pow x y)) (pow x (/ y 3))]
   [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
   [add-cbrt-cube x (cbrt (* (* x x) x))]
   [cube-unmult (* x (* x x)) (pow x 3)])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -205,7 +205,7 @@
   [sqrt-prod (sqrt (* x y)) (* (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
   [sqrt-div (sqrt (/ x y)) (/ (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
   [add-sqr-sqrt x (* (sqrt x) (sqrt x)) #:unsound] ; unsound @ x = -1
-  [sqrt-pow1 (sqrt (pow x y)) (pow x (/ y 2)) #:unsound]) ; unsound @ x = -1, y = 2
+  #;[sqrt-pow1 (sqrt (pow x y)) (pow x (/ y 2)) #:unsound]) ; unsound @ x = -1, y = 2
 
 ; Cubing
 (define-rules arithmetic
@@ -298,8 +298,8 @@
   [pow-to-exp (pow a b) (exp (* (log a) b)) #:unsound] ; unsound @ a = -1, b = 1
   [pow-add (pow a (+ b c)) (* (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
   [pow-sub (pow a (- b c)) (/ (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
-  [pow-pow (pow (pow a b) c) (pow a (* b c)) #:unsound] ; unsound @ a = -1, b = 2, c = 1/4
-  [pow-unpow (pow a (* b c)) (pow (pow a b) c) #:unsound] ; unsound @ a = -1, b = 1/2, c = 2
+  #;[pow-pow (pow (pow a b) c) (pow a (* b c)) #:unsound] ; unsound @ a = -1, b = 2, c = 1/4
+  #;[pow-unpow (pow a (* b c)) (pow (pow a b) c) #:unsound] ; unsound @ a = -1, b = 1/2, c = 2
   [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a)) #:unsound]) ; unsound @ a = 1/2, b = c = -1
 
 ; Logarithms
@@ -349,9 +349,9 @@
   [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))])
 
 (define-rules trigonometry
-  [atan-tan-s (atan (tan x)) x #:unsound] ; unsound @ x = pi
-  [asin-sin-s (asin (sin x)) x #:unsound] ; unsound @ x = pi
-  [acos-cos-s (acos (cos x)) x #:unsound] ; unsound @ x = 2pi
+  #;[atan-tan-s (atan (tan x)) x #:unsound] ; unsound @ x = pi
+  #;[asin-sin-s (asin (sin x)) x #:unsound] ; unsound @ x = pi
+  #;[acos-cos-s (acos (cos x)) x #:unsound] ; unsound @ x = 2pi
   [atan-tan-rev (remainder x (PI)) (atan (tan x)) #:unsound]) ; unsound @ x = pi/2
 
 (define-rules trigonometry
@@ -589,5 +589,5 @@
   [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x)) #:unsound] ; unsound @ x = 0
   [sinh-acosh-rev (sqrt (- (* x x) 1)) (sinh (acosh x)) #:unsound] ; unsound @ x = -1
   [tanh-acosh-rev (/ (sqrt (- (* x x) 1)) x) (tanh (acosh x)) #:unsound] ; unsound @ x = -1
-  [asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x)) #:unsound] ; unsound @ x = -1
+  #;[asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x)) #:unsound] ; unsound @ x = -1
   [acosh-2 (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x)) #:unsound]) ; unsound @ x = -1

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -577,6 +577,7 @@
   [cosh-asinh-rev (sqrt (+ (* x x) 1)) (cosh (asinh x))]
   [sinh-atanh-rev (/ x (sqrt (- 1 (* x x)))) (sinh (atanh x))]
   [cosh-atanh-rev (/ 1 (sqrt (- 1 (* x x)))) (cosh (atanh x))]
+  [asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh (fabs x)))]
   [acosh-2-rev (* 2 (acosh x)) (acosh (- (* 2 (* x x)) 1))])
 
 (define-rules hyperbolic

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -204,8 +204,7 @@
 (define-rules arithmetic
   [sqrt-prod (sqrt (* x y)) (* (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
   [sqrt-div (sqrt (/ x y)) (/ (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
-  [add-sqr-sqrt x (* (sqrt x) (sqrt x)) #:unsound] ; unsound @ x = -1
-  #;[sqrt-pow1 (sqrt (pow x y)) (pow x (/ y 2)) #:unsound]) ; unsound @ x = -1, y = 2
+  [add-sqr-sqrt x (* (sqrt x) (sqrt x)) #:unsound]) ; unsound @ x = -1
 
 ; Cubing
 (define-rules arithmetic
@@ -300,8 +299,6 @@
   [pow-to-exp (pow a b) (exp (* (log a) b)) #:unsound] ; unsound @ a = -1, b = 1
   [pow-add (pow a (+ b c)) (* (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
   [pow-sub (pow a (- b c)) (/ (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
-  #;[pow-pow (pow (pow a b) c) (pow a (* b c)) #:unsound] ; unsound @ a = -1, b = 2, c = 1/4
-  #;[pow-unpow (pow a (* b c)) (pow (pow a b) c) #:unsound] ; unsound @ a = -1, b = 1/2, c = 2
   [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a)) #:unsound]) ; unsound @ a = 1/2, b = c = -1
 
 ; Logarithms
@@ -351,9 +348,6 @@
   [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))])
 
 (define-rules trigonometry
-  #;[atan-tan-s (atan (tan x)) x #:unsound] ; unsound @ x = pi
-  #;[asin-sin-s (asin (sin x)) x #:unsound] ; unsound @ x = pi
-  #;[acos-cos-s (acos (cos x)) x #:unsound] ; unsound @ x = 2pi
   [atan-tan-rev (remainder x (PI)) (atan (tan x)) #:unsound]) ; unsound @ x = pi/2
 
 (define-rules trigonometry
@@ -591,5 +585,4 @@
   [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x)) #:unsound] ; unsound @ x = 0
   [sinh-acosh-rev (sqrt (- (* x x) 1)) (sinh (acosh x)) #:unsound] ; unsound @ x = -1
   [tanh-acosh-rev (/ (sqrt (- (* x x) 1)) x) (tanh (acosh x)) #:unsound] ; unsound @ x = -1
-  #;[asinh-2 (acosh (+ (* 2 (* x x)) 1)) (* 2 (asinh x)) #:unsound] ; unsound @ x = -1
   [acosh-2 (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x)) #:unsound]) ; unsound @ x = -1

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -13,16 +13,6 @@
 (load-herbie-builtins)
 
 (define num-test-points (make-parameter 100))
-
-(define *conditions*
-  (list '[asinh-2 . (>= x 0)]
-        '[pow-unpow . (>= a 0)]
-        '[pow-pow . (>= a 0)]
-        '[sqrt-pow1 . (>= x 0)]
-        '[asin-sin-s . (<= (fabs x) (/ (PI) 2))]
-        '[acos-cos-s . (and (<= 0 x) (<= x (PI)))]
-        '[atan-tan-s . (<= (fabs x) (/ (PI) 2))]))
-
 (define double-repr (get-representation 'binary64))
 
 (define (env->ctx p1 p2)
@@ -33,14 +23,10 @@
   (match-define (rule name p1 p2 _ _ _) test-rule)
   (define ctx (env->ctx p1 p2))
 
-  (define pre (dict-ref *conditions* name '(TRUE)))
-  (unless (equal? pre '(TRUE))
-    (check-false (set-member? (rule-tags test-rule) 'sound) "Sound rules cannot have conditions"))
-
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (sample-points pre (list p1 p2) (list ctx ctx))))
+      (sample-points '(TRUE) (list p1 p2) (list ctx ctx))))
 
   (for ([pt (in-list pts)]
         [v1 (in-list exs1)]


### PR DESCRIPTION
We have seven "conditional" rules, where the lhs and rhs aren't equal over the whole domain but only over a subset of the domain. Conceptually this is I guess fine, just another kind of unsoundness, but the actual rules aren't used much so why not remove them? Well, it turned out one of the rules (`pow-pow`) was useful for reasoning about cube roots, so this PR adds a sound replacement for just that one case, and then removes all of the conditional rules.