### PR TITLE
Further optimizations to JSONify

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -424,7 +424,7 @@
       [else (values '() #f)]))
 
   (define exprs
-    (append-map (curryr collect-expressions pcontext ctx)
+    (append-map collect-expressions
                 (if (equal? (job-result-status herbie-result) 'success)
                     (map alt-analysis-alt
                          (append (list (improve-result-start backend))
@@ -432,17 +432,8 @@
                                  (improve-result-end backend)))
                     '())))
 
-  (define pctx->exprs
-    (for/hash ([group (in-list (group-by cdr exprs))])
-      (values (cdar group) (map car group))))
-
   (define errcache
-    (for/hash ([(pctx exprs) (in-hash pctx->exprs)])
-      (define scores (map errors-score (batch-errors exprs pctx ctx)))
-      (values pctx
-              (for/hash ([expr (in-list exprs)]
-                         [score (in-list scores)])
-                (values expr score)))))
+    (make-hash (map cons exprs (batch-errors exprs pcontext ctx))))
 
   (define test-fpcore
     (alt->fpcore test (make-alt-preprocessing (test-input test) (test-preprocess test))))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -423,17 +423,17 @@
        (values altns pcontext)]
       [else (values '() #f)]))
 
-  (define exprs
-    (append-map collect-expressions
-                (if (equal? (job-result-status herbie-result) 'success)
-                    (map alt-analysis-alt
-                         (append (list (improve-result-start backend))
-                                 (improve-result-target backend)
-                                 (improve-result-end backend)))
-                    '())))
-
   (define errcache
-    (make-hash (map cons exprs (batch-errors exprs pcontext ctx))))
+    (cond
+      [(equal? (job-result-status herbie-result) 'success)
+       (define all-alts 
+         (map alt-analysis-alt
+              (append (list (improve-result-start backend))
+                      (improve-result-target backend)
+                      (improve-result-end backend))))
+       (define exprs (append-map collect-expressions all-alts))
+       (make-hash (map cons exprs (batch-errors exprs pcontext ctx)))]
+      [else #f]))
 
   (define test-fpcore
     (alt->fpcore test (make-alt-preprocessing (test-input test) (test-preprocess test))))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -426,7 +426,7 @@
   (define errcache
     (cond
       [(equal? (job-result-status herbie-result) 'success)
-       (define all-alts 
+       (define all-alts
          (map alt-analysis-alt
               (append (list (improve-result-start backend))
                       (improve-result-target backend)

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -191,12 +191,11 @@
   (define ctx* (struct-copy context ctx [repr (repr-of bexpr ctx)]))
   (define prog (compile-prog bexpr ctx*))
 
-  (flip-lists
-   (for/list ([(pt ex) (in-pcontext pcontext)])
-     (define val (prog pt))
-     (define alt-id
-       (for/first ([right (in-list splitpoints)]
-                  #:when (or (equal? (sp-point right) +nan.0)
-                             (<=/total val (sp-point right) (context-repr ctx*))))
-        (sp-cidx right)))
-     (build-list num-alts (curry = alt-id)))))
+  (flip-lists (for/list ([(pt ex) (in-pcontext pcontext)])
+                (define val (prog pt))
+                (define alt-id
+                  (for/first ([right (in-list splitpoints)]
+                              #:when (or (equal? (sp-point right) +nan.0)
+                                         (<=/total val (sp-point right) (context-repr ctx*))))
+                    (sp-cidx right)))
+                (build-list num-alts (curry = alt-id)))))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -4,6 +4,7 @@
          racket/random)
 (require "../config.rkt"
          "../utils/alternative.rkt"
+         "../utils/common.rkt"
          "../utils/timeline.rkt"
          "../utils/errors.rkt"
          "../utils/float.rkt"
@@ -20,7 +21,7 @@
 
 (provide combine-alts
          (struct-out sp)
-         regimes-split-pcontext)
+         regimes-pcontext-masks)
 
 (module+ test
   (require rackunit
@@ -184,26 +185,18 @@
             (sp (si-cidx si1) expr split-at))
           (list (sp (si-cidx (last sindices)) expr +nan.0))))
 
-(define (regimes-split-pcontext pcontext splitpoints alts ctx)
+(define (regimes-pcontext-masks pcontext splitpoints alts ctx)
+  (define num-alts (length alts))
   (define bexpr (sp-bexpr (car splitpoints)))
   (define ctx* (struct-copy context ctx [repr (repr-of bexpr ctx)]))
   (define prog (compile-prog bexpr ctx*))
 
-  (define pts-vector (make-vector (length alts) '()))
-  (define exs-vector (make-vector (length alts) '()))
-
-  (for ([(pt ex) (in-pcontext pcontext)])
-    (define val (prog pt))
-    (for/first ([right (in-list splitpoints)]
-                #:when (or (equal? (sp-point right) +nan.0)
-                           (<=/total val (sp-point right) (context-repr ctx*))))
-      ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
-      (vector-set! pts-vector (sp-cidx right) (cons pt (vector-ref pts-vector (sp-cidx right))))
-      (vector-set! exs-vector (sp-cidx right) (cons ex (vector-ref exs-vector (sp-cidx right))))))
-
-  (for/list ([sp (in-list splitpoints)])
-    (define pts (reverse (vector-ref pts-vector (sp-cidx sp))))
-    (define exs (reverse (vector-ref exs-vector (sp-cidx sp))))
-    (if (null? pts)
-        pcontext
-        (mk-pcontext pts exs))))
+  (flip-lists
+   (for/list ([(pt ex) (in-pcontext pcontext)])
+     (define val (prog pt))
+     (define alt-id
+       (for/first ([right (in-list splitpoints)]
+                  #:when (or (equal? (sp-point right) +nan.0)
+                             (<=/total val (sp-point right) (context-repr ctx*))))
+        (sp-cidx right)))
+     (build-list num-alts (curry = alt-id)))))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -107,7 +107,8 @@
             [(alt prog 'add-preprocessing `(,prev) _) (loop prev)]
             [(alt _ `(regimes ,splitpoints) prevs _) (for-each loop prevs)]
             [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _) (loop prev)]
-            [(alt prog `(rr ,loc ,input ,proof) `(,prev) _) (loop prev)
+            [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
+             (loop prev)
              (when proof
                (for ([step proof])
                  (define-values (dir rule loc expr) (splice-proof-step step))
@@ -170,14 +171,13 @@
                 ""))
        (li (p "Applied rewrites" (span ((class "error")) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(program->tex prog ctx #:loc loc) "\\]")))]))
-  
+
 (define (errors-score-masked errs mask)
   (if (ormap identity mask)
-      (errors-score
-       (for/list ([err (in-list errs)]
-                  [use? (in-list mask)]
-                  #:when use?)
-         err))
+      (errors-score (for/list ([err (in-list errs)]
+                               [use? (in-list mask)]
+                               #:when use?)
+                      err))
       (errors-score errs)))
 
 (define (render-proof proof pcontext ctx errcache mask)
@@ -230,11 +230,10 @@
                              (define entry-ivals
                                (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx)) intervals))
                              (map (curryr interval->string repr) entry-ivals)))
-            (prevs .
-                   ,(for/list ([entry prevs]
-                               [new-mask (regimes-pcontext-masks pcontext splitpoints prevs ctx)])
-                      (define mask* (map and-fn mask new-mask))
-                      (render-json entry pcontext ctx errcache mask*))))]
+            (prevs . ,(for/list ([entry prevs]
+                                 [new-mask (regimes-pcontext-masks pcontext splitpoints prevs ctx)])
+                        (define mask* (map and-fn mask new-mask))
+                        (render-json entry pcontext ctx errcache mask*))))]
 
     [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _)
      `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))


### PR DESCRIPTION
The JSONify phase is kind of a confusing, poorly-factored phase, but the main thing this phase does is compute derivations, and most of _that_ time is spent evaluating intermediate expressions. At the moment (since #1205) this involves one batch evaluation per pcontext. There are multiple pcontexts because regimes splits the pcontext into pieces.

This PR refactors things so that there's only ever one pcontext; instead of splitting pcontexts, regimes involves creating masks. This means that we only need to do one batch evaluation, which ends up being faster, possibly quite a bit faster if there are many different alts each of which have different regime splits. There's another possible effect—with #1205 I noticed that GC pressure on the rest of Herbie increased by a noticable amount. I'm not really sure why that happened, but maybe this helps? Who knows.

Ideally we would rewrite how all this crappy code works and jsonify would stop being a thing and maybe would just make more sense overall, but until then, this helps, and should save maybe as much a minute.