### PR TITLE
Additional deduplcation at taylor

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -60,8 +60,7 @@
   (define (key x)
     (define approx-pt (batchref-idx (alt-expr x)))
     (define hole-pt (approx-impl (vector-ref (batch-nodes global-batch) approx-pt)))
-    (define expr-pt (hole-spec (vector-ref (batch-nodes global-batch) hole-pt)))
-    expr-pt)
+    hole-pt)
 
   (define approxs (remove-duplicates (taylor-alts starting-exprs altns global-batch) #:key key))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -57,9 +57,13 @@
   (timeline-event! 'series)
   (timeline-push! 'inputs (map ~a starting-exprs))
 
-  (define approxs
-    (remove-duplicates (taylor-alts starting-exprs altns global-batch)
-                       #:key (λ (x) (batchref-idx (alt-expr x)))))
+  (define (key x)
+    (define approx-pt (batchref-idx (alt-expr x)))
+    (define hole-pt (approx-impl (vector-ref (batch-nodes global-batch) approx-pt)))
+    (define expr-pt (hole-spec (vector-ref (batch-nodes global-batch) hole-pt)))
+    expr-pt)
+
+  (define approxs (remove-duplicates (taylor-alts starting-exprs altns global-batch) #:key key))
 
   (timeline-push! 'outputs (map ~a (map (compose debatchref alt-expr) approxs)))
   (timeline-push! 'count (length altns) (length approxs))


### PR DESCRIPTION
Recently I noticed that we deduplicate approximations by deduplicating `approx` nodes.
But the thing is, that `approx` node contains `spec` and `impl`.
So, for example if `spec`s do not match, but `impl`s are the same - we end up not deduplicating these approximations.
But in fact, we mostly do not care which exactly `spec` has been approximated - what we care is no equal `impl`s should be present.
Maybe that will help further and `egg` will receive less `approx` nodes - as a result more rewrites will be produced.

How much of additional deduplication happens:
I tried `quadp` benchmark and here how much we can reduce
1st expansion: 108 approximations -> 103 approximations
2nd expansion 213 approximations -> 109 approximations
3rd expansion 269 approximations -> 165 approximations
4th expansion 260 approximations -> 154 approximations