### PR TITLE
Don't reduce sqrt terms

### DIFF
--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -206,11 +206,9 @@
   (for ([rule (in-list (*sound-rules*))])
     (test-case (~a (rule-name rule))
       (define proof (dict-ref soundness-proofs (rule-name rule) '()))
-      (define-values (lhs-bad rhs-bad)
-        (rewrite-unsound? (rule-input rule) (rule-output rule) proof))
+      (define-values (lhs-bad rhs-bad) (rewrite-unsound? (rule-input rule) (rule-output rule) proof))
       (when rhs-bad
-        (with-check-info (['lhs-bad lhs-bad])
-          (check-false rhs-bad))))))
+        (with-check-info (['lhs-bad lhs-bad]) (check-false rhs-bad))))))
 
 (module+ test
   (potentially-unsound))

--- a/src/core/prove-rules.rkt
+++ b/src/core/prove-rules.rkt
@@ -6,6 +6,8 @@
          "programs.rkt"
          "rules.rkt")
 
+(provide rewrite-unsound?)
+
 (define (undefined-conditions x)
   (reap [sow]
         (for ([subexpr (in-list (all-subexpressions x))])
@@ -57,7 +59,8 @@
         '[(cos (acos a)) . a]
         '[(cos (asin a)) . (sqrt (- 1 (* a a)))]
         '[(fabs (neg a)) . (fabs a)]
-        '[(fabs (fabs a)) . (fabs a)]))
+        '[(fabs (fabs a)) . (fabs a)]
+        '[(pow x 2) . (* x x)]))
 
 (define (simplify-expression expr)
   (for/fold ([expr expr]) ([(a b) (in-dict simplify-patterns)])
@@ -95,7 +98,10 @@
     [`(,(or '< '==) (fabs ,a) ,(? (conjoin number? (curryr < 0)))) '(FALSE)]
 
     [`(< (/ 1 ,a) 0) `(< ,a 0)]
+    [`(> (/ 1 ,a) 0) `(> ,a 0)]
+    [`(< (/ -1 ,a) 0) `(> ,a 0)]
     [`(< (neg ,a) 0) `(> ,a 0)]
+    [`(> (neg ,a) 0) `(< ,a 0)]
     [`(< (* 2 ,a) ,(? number? b)) `(< ,a ,(/ b 2))]
     [`(< (+ 1 ,a) 0) `(< ,a -1)]
     [`(< (/ ,x 2) 0) `(< ,x 0)]
@@ -187,15 +193,24 @@
     (match step
       [`(implies ,a ,b) (simplify-conditions (map (curryr rewrite-all a b) terms))])))
 
+(define (rewrite-unsound? lhs rhs [proof '()])
+  (define lhs-bad (execute-proof proof (undefined-conditions lhs)))
+  (define rhs-bad (execute-proof proof (undefined-conditions rhs)))
+  (define extra (set-remove (set-subtract rhs-bad lhs-bad) '(FALSE)))
+  (if (empty? extra)
+      (values #f #f)
+      (values lhs-bad extra)))
+
 (define (potentially-unsound)
   (define num 0)
   (for ([rule (in-list (*sound-rules*))])
     (test-case (~a (rule-name rule))
       (define proof (dict-ref soundness-proofs (rule-name rule) '()))
-      (define lhs-bad (execute-proof proof (undefined-conditions (rule-input rule))))
-      (define rhs-bad (execute-proof proof (undefined-conditions (rule-output rule))))
-      (define extra (set-remove (set-subtract rhs-bad lhs-bad) '(FALSE)))
-      (with-check-info (('lhs-bad lhs-bad)) (check-equal? empty extra)))))
+      (define-values (lhs-bad rhs-bad)
+        (rewrite-unsound? (rule-input rule) (rule-output rule) proof))
+      (when rhs-bad
+        (with-check-info (['lhs-bad lhs-bad])
+          (check-false rhs-bad))))))
 
 (module+ test
   (potentially-unsound))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -27,6 +27,7 @@
        [(and (zero? b) (not (zero? a))) 1]
        [(and (zero? a) (positive? b)) 0]
        [(and (not (zero? a)) (integer? b)) (expt a b)]
+       [(= a 1) 1]
        [else #f])]
     [(list 'sqrt (? exact-value? a))
      (define s1 (sqrt (numerator a)))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -27,6 +27,7 @@
        [(and (zero? b) (not (zero? a))) 1]
        [(and (zero? a) (positive? b)) 0]
        [(and (not (zero? a)) (integer? b)) (expt a b)]
+       [(= a -1) (if (even? (numerator b)) 1 -1)]
        [(= a 1) 1]
        [else #f])]
     [(list 'sqrt (? exact-value? a))
@@ -34,13 +35,13 @@
      (define s2 (sqrt (denominator a)))
      (and (real? s1) (real? s2) (exact? s1) (exact? s2) (/ s1 s2))]
     [(list 'cbrt (? exact-value? a))
-     (define inexact-num (inexact->exact (expt (numerator a) 1/3)))
-     (define inexact-den (inexact->exact (expt (denominator a) 1/3)))
+     (define inexact-num (inexact->exact (expt (abs (numerator a)) 1/3)))
+     (define inexact-den (inexact->exact (expt (abs (denominator a)) 1/3)))
      (and (real? inexact-num)
           (real? inexact-den)
-          (= (expt inexact-num 3) (numerator a))
-          (= (expt inexact-den 3) (denominator a))
-          (/ inexact-num inexact-den))]
+          (= (expt inexact-num 3) (abs (numerator a)))
+          (= (expt inexact-den 3) (abs (denominator a)))
+          (* (sgn a) (/ inexact-num inexact-den)))]
     [(list 'fabs (? exact-value? a)) (abs a)]
     [(list 'floor (? exact-value? a)) (floor a)]
     [(list 'ceil (? exact-value? a)) (ceiling a)]
@@ -67,10 +68,6 @@
   (match expr
     [(? number?) expr]
     [(? symbol?) expr]
-    [`(,(and (or '+ '- '*) op) ,args ...) ; v-ary
-     (define args* (map reduce args))
-     (define val (apply eval-application op args*))
-     (or val (reduce-node (list* op args*)))]
     [`(,op ,args ...)
      (define args* (map reduce args))
      (define val (apply eval-application op args*))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -478,7 +478,11 @@
   (match-define (cons shift coeffs) (normalize-series arg))
   (define hash (make-hash))
   (define negate? (and (number? (coeffs 0)) (not (positive? (coeffs 0)))))
-  (hash-set! hash 0 (reduce (if negate? `(log (neg ,(coeffs 0))) `(log ,(coeffs 0)))))
+  (define (maybe-negate x)
+    (if negate?
+        `(neg ,x)
+        x))
+  (hash-set! hash 0 (reduce `(log ,(maybe-negate (coeffs 0)))))
 
   (define (series n)
     (hash-ref! hash
@@ -493,13 +497,13 @@
                                                   (if (= p 0)
                                                       1
                                                       `(pow (* ,(factorial i) ,(coeffs i)) ,p))))
-                                           (pow ,(coeffs 0) ,(- k))))))
+                                           (exp (* ,(- k) ,(series 0)))))))
                              ,(factorial n))))))
 
   (cons 0
         (λ (n)
           (if (and (= n 0) (not (zero? shift)))
-              (reduce `(+ (* (neg ,shift) (log ,(if negate? `(neg ,var) var))) ,(series 0)))
+              (reduce `(+ (* (neg ,shift) (log ,(maybe-negate var))) ,(series 0)))
               (series n)))))
 
 (module+ test

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -477,7 +477,8 @@
 (define (taylor-log var arg)
   (match-define (cons shift coeffs) (normalize-series arg))
   (define hash (make-hash))
-  (hash-set! hash 0 (reduce `(log ,(coeffs 0))))
+  (define negate? (and (number? (coeffs 0)) (not (positive? (coeffs 0)))))
+  (hash-set! hash 0 (reduce (if negate? `(log (neg ,(coeffs 0))) `(log ,(coeffs 0)))))
 
   (define (series n)
     (hash-ref! hash
@@ -498,7 +499,7 @@
   (cons 0
         (λ (n)
           (if (and (= n 0) (not (zero? shift)))
-              (reduce `(+ (* (neg ,shift) (log ,var)) ,(series 0)))
+              (reduce `(+ (* (neg ,shift) (log ,(if negate? `(neg ,var) var))) ,(series 0)))
               (series n)))))
 
 (module+ test

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -522,4 +522,4 @@
   (check-equal? (coeffs '(cbrt (+ 1 x))) '(1 1/3 -1/9 5/81 -10/243 22/729 -154/6561))
   (check-equal? (coeffs '(sqrt x)) '((sqrt x) 0 0 0 0 0 0))
   (check-equal? (coeffs '(cbrt x)) '((cbrt x) 0 0 0 0 0 0))
-  (check-equal? (coeffs '(cbrt (* x x))) '((cbrt (pow x 2)) 0 0 0 0 0 0)))
+  (check-equal? (coeffs '(cbrt (* x x))) '((pow x 2/3) 0 0 0 0 0 0)))


### PR DESCRIPTION
This PR removes the `reduce.rkt` simplifier's handling of `sqrt`, because such handling was often unsound. This fixes #1220 and is part of a broader project to fix unsoundness throughout Herbie, because we've started to see it as a bottleneck on further improvement.