### PR TITLE
New rules

### DIFF
--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -199,9 +199,7 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
-  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))] ; can be reached in 4 steps
-  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))]) ; can be reached in 4 steps
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
 
 ; Absolute value
 (define-rules arithmetic
@@ -266,8 +264,7 @@
   [add-log-exp x (log (exp x))]
   [add-exp-log x (exp (log x)) #:unsound] ; unsound @ x = 0
   [rem-exp-log (exp (log x)) x]
-  [rem-log-exp (log (exp x)) x]
-  [log-fabs (log x) (log (fabs x))]) ; range widening
+  [rem-log-exp (log (exp x)) x])
 
 (define-rules exponents
   [exp-0 (exp 0) 1]

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -130,6 +130,22 @@
   [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
   [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
+; Add/sub flips
+(define-rules arithmetic
+  [sub-flip (- a b) (+ a (neg b))]
+  [sub-flip-reverse (+ a (neg b)) (- a b)]
+  [sub-negate (neg (- b a)) (- a b)]
+  [sub-negate-rev (- a b) (neg (- b a))]
+  [add-flip (+ a b) (- a (neg b))]
+  [add-flip-rev (- a (neg b)) (+ a b)]
+  [add-negate (neg (+ a b)) (- (neg a) b)]
+  [add-negate-rev (- (neg a) b) (neg (+ a b))])
+
+; Mul/div flip
+(define-rules arithmetic
+  [mult-flip (/ a b) (* a (/ 1 b))]
+  [mult-flip-rev (* a (/ 1 b)) (/ a b)])
+
 ; Difference of squares
 (define-rules polynomials
   [swap-sqr (* (* a b) (* a b)) (* (* a a) (* b b))]
@@ -138,6 +154,10 @@
   [difference-of-sqr-1 (- (* a a) 1) (* (+ a 1) (- a 1))]
   [difference-of-sqr--1 (+ (* a a) -1) (* (+ a 1) (- a 1))]
   [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))]
+  [sum-square-pow (pow (+ a b) 2) (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2))]
+  [sub-square-pow (pow (- a b) 2) (+ (- (pow a 2) (* 2 (* a b))) (pow b 2))]
+  [sum-square-reverse (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
+  [sub-square-reverse (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
   [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
   [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
   [difference-of-squares-rev (* (+ a b) (- a b)) (- (* a a) (* b b))])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -199,19 +199,24 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
+  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))] ; can be reached in 4 steps
+  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))]) ; can be reached in 4 steps
 
 ; Absolute value
 (define-rules arithmetic
   [fabs-fabs (fabs (fabs x)) (fabs x)]
   [fabs-sub (fabs (- a b)) (fabs (- b a))]
+  [fabs-add (fabs (+ (fabs a) (fabs b))) (+ (fabs a) (fabs b))]
   [fabs-neg (fabs (neg x)) (fabs x)]
   [fabs-sqr (fabs (* x x)) (* x x)]
   [fabs-mul (fabs (* a b)) (* (fabs a) (fabs b))]
   [fabs-div (fabs (/ a b)) (/ (fabs a) (fabs b))]
   [neg-fabs (fabs x) (fabs (neg x))]
   [mul-fabs (* (fabs a) (fabs b)) (fabs (* a b))]
-  [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))])
+  [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
+  [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
+  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)])
 
 ; Square root
 (define-rules arithmetic
@@ -248,20 +253,29 @@
   [cbrt-pow (cbrt (pow x y)) (pow x (/ y 3))]
   [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
   [add-cbrt-cube x (cbrt (* (* x x) x))]
-  [cube-unmult (* x (* x x)) (pow x 3)])
+  [cube-unmult (* x (* x x)) (pow x 3)]
+  [cbrt-neg (cbrt (neg x)) (neg (cbrt x))]
+  [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
+  [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
+  [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (/ x (fabs x))]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (/ (fabs x) x)])
 
 ; Exponentials
 (define-rules exponents
   [add-log-exp x (log (exp x))]
   [add-exp-log x (exp (log x)) #:unsound] ; unsound @ x = 0
   [rem-exp-log (exp (log x)) x]
-  [rem-log-exp (log (exp x)) x])
+  [rem-log-exp (log (exp x)) x]
+  [log-fabs (log x) (log (fabs x))]) ; range widening
 
 (define-rules exponents
   [exp-0 (exp 0) 1]
   [exp-1-e (exp 1) (E)]
   [1-exp 1 (exp 0)]
-  [e-exp-1 (E) (exp 1)])
+  [e-exp-1 (E) (exp 1)]
+  [exp-fabs (exp x) (fabs (exp x))]
+  [fabs-exp (fabs (exp x)) (exp x)])
 
 (define-rules exponents
   [exp-sum (exp (+ a b)) (* (exp a) (exp b))]
@@ -344,8 +358,10 @@
 (define-rules trigonometry
   [sin-neg (sin (neg x)) (neg (sin x))]
   [cos-neg (cos (neg x)) (cos x)]
+  [cos-fabs (cos (fabs x)) (cos x)]
   [tan-neg (tan (neg x)) (neg (tan x))]
   [cos-neg-rev (cos x) (cos (neg x))]
+  [cos-fabs-rev (cos x) (cos (fabs x))]
   [sin-neg-rev (neg (sin x)) (sin (neg x))]
   [tan-neg-rev (neg (tan x)) (tan (neg x))])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -173,12 +173,6 @@
   [sub-to-fraction-rev (/ (- (* c a) b) a) (- c (/ b a))]
   [common-denominator (+ (/ a b) (/ c d)) (/ (+ (* a d) (* c b)) (* b d))])
 
-(define-rules arithmetic
-  [fake-sub (+ a b) (+ (- a b) (* 2 b))]
-  [fake-add (- a b) (- (+ a b) (* 2 b))]
-  [fake-div (* a b) (* (/ a b) (pow b 2)) #:unsound] ; unsound @ b = 0, a = 1
-  [fake-mult (/ a b) (/ (* a b) (pow b 2))])
-
 (define-rules polynomials
   [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1
   [flip-+ (+ a b) (/ (- (* a a) (* b b)) (- a b)) #:unsound] ; unsound @ a = b = 1

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -163,9 +163,9 @@
 
 ; Fractions
 (define-rules arithmetic
-  [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound]
+  [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
   [sum-to-mult-rev (* (+ 1 (/ b a)) a) (+ a b)]
-  [sub-to-mult (- a b) (* (- 1 (/ b a)) a) #:unsound]
+  [sub-to-mult (- a b) (* (- 1 (/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
   [sub-to-mult-rev (* (- 1 (/ b a)) a) (- a b)]
   [add-to-fraction (+ c (/ b a)) (/ (+ (* c a) b) a)]
   [add-to-fraction-rev (/ (+ (* c a) b) a) (+ c (/ b a))]
@@ -176,8 +176,8 @@
 (define-rules arithmetic
   [fake-sub (+ a b) (+ (- a b) (* 2 b))]
   [fake-add (- a b) (- (+ a b) (* 2 a))]
-  [fake-div (* a b) (* (/ a b) (pow b 2)) #:unsound]
-  [fake-mult (/ a b) (/ (* a b) (pow b 2)) #:unsound])
+  [fake-div (* a b) (* (/ a b) (pow b 2)) #:unsound] ; unsound @ b = 0, a = 1
+  [fake-mult (/ a b) (/ (* a b) (pow b 2))])
 
 (define-rules polynomials
   [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -130,21 +130,13 @@
   [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
   [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
-; Add/sub flips
 (define-rules arithmetic
   [sub-flip (- a b) (+ a (neg b))]
   [sub-flip-reverse (+ a (neg b)) (- a b)]
   [sub-negate (neg (- b a)) (- a b)]
   [sub-negate-rev (- a b) (neg (- b a))]
   [add-flip (+ a b) (- a (neg b))]
-  [add-flip-rev (- a (neg b)) (+ a b)]
-  [add-negate (neg (+ a b)) (- (neg a) b)]
-  [add-negate-rev (- (neg a) b) (neg (+ a b))])
-
-; Mul/div flip
-(define-rules arithmetic
-  [mult-flip (/ a b) (* a (/ 1 b))]
-  [mult-flip-rev (* a (/ 1 b)) (/ a b)])
+  [add-flip-rev (- a (neg b)) (+ a b)])
 
 ; Difference of squares
 (define-rules polynomials
@@ -156,11 +148,29 @@
   [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))]
   [sum-square-pow (pow (+ a b) 2) (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2))]
   [sub-square-pow (pow (- a b) 2) (+ (- (pow a 2) (* 2 (* a b))) (pow b 2))]
-  [sum-square-reverse (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
-  [sub-square-reverse (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
+  [sum-square-pow-rev (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
+  [sub-square-pow-rev (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
   [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
   [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
   [difference-of-squares-rev (* (+ a b) (- a b)) (- (* a a) (* b b))])
+
+; Mul/div flip
+(define-rules arithmetic
+  [mult-flip (/ a b) (* a (/ 1 b))]
+  [mult-flip-rev (* a (/ 1 b)) (/ a b)]
+  [div-flip (/ a b) (/ 1 (/ b a)) #:unsound] ; unsound @ a = 0, b != 0
+  [div-flip-rev (/ 1 (/ b a)) (/ a b)])
+
+(define-rules arithmetic
+  [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound]
+  [sum-to-mult-rev (* (+ 1 (/ b a)) a) (+ a b)]
+  [sub-to-mult (- a b) (* (- 1 (/ b a)) a) #:unsound]
+  [sub-to-mult-rev (* (- 1 (/ b a)) a) (- a b)]
+  [add-to-fraction (+ c (/ b a)) (/ (+ (* c a) b) a)]
+  [add-to-fraction-rev (/ (+ (* c a) b) a) (+ c (/ b a))]
+  [sub-to-fraction (- c (/ b a)) (/ (- (* c a) b) a)]
+  [sub-to-fraction-rev (/ (- (* c a) b) a) (- c (/ b a))]
+  [common-denominator (+ (/ a b) (/ c d)) (/ (+ (* a d) (* c b)) (* b d))])
 
 (define-rules polynomials
   [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1
@@ -199,7 +209,9 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
+  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))]
+  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))])
 
 ; Absolute value
 (define-rules arithmetic
@@ -213,8 +225,12 @@
   [neg-fabs (fabs x) (fabs (neg x))]
   [mul-fabs (* (fabs a) (fabs b)) (fabs (* a b))]
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
+  [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
+  [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
   [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
-  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)])
+  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)]
+  [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
+  [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
 ; Square root
 (define-rules arithmetic

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -175,7 +175,7 @@
 
 (define-rules arithmetic
   [fake-sub (+ a b) (+ (- a b) (* 2 b))]
-  [fake-add (- a b) (- (+ a b) (* 2 a))]
+  [fake-add (- a b) (- (+ a b) (* 2 b))]
   [fake-div (* a b) (* (/ a b) (pow b 2)) #:unsound] ; unsound @ b = 0, a = 1
   [fake-mult (/ a b) (/ (* a b) (pow b 2))])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -161,6 +161,7 @@
   [div-flip (/ a b) (/ 1 (/ b a)) #:unsound] ; unsound @ a = 0, b != 0
   [div-flip-rev (/ 1 (/ b a)) (/ a b)])
 
+; Fractions
 (define-rules arithmetic
   [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound]
   [sum-to-mult-rev (* (+ 1 (/ b a)) a) (+ a b)]
@@ -171,6 +172,12 @@
   [sub-to-fraction (- c (/ b a)) (/ (- (* c a) b) a)]
   [sub-to-fraction-rev (/ (- (* c a) b) a) (- c (/ b a))]
   [common-denominator (+ (/ a b) (/ c d)) (/ (+ (* a d) (* c b)) (* b d))])
+
+(define-rules arithmetic
+  [fake-sub (+ a b) (+ (- a b) (* 2 b))]
+  [fake-add (- a b) (- (+ a b) (* 2 a))]
+  [fake-div (* a b) (* (/ a b) (pow b 2)) #:unsound]
+  [fake-mult (/ a b) (/ (* a b) (pow b 2)) #:unsound])
 
 (define-rules polynomials
   [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1


### PR DESCRIPTION
This PR introduces new rules for rewrites.
Most of the introduced rules can not be achieved using other rewrites, except
`[sqrt-fabs (fabs (sqrt a)) (sqrt a)]` which can be achieved in 4 steps (still, probably, worth adding), and
`[sub-negate (neg (- b a)) (- a b)]` - which can be achieved in 5 steps.

All other rules require 10+ rewrites in the best case, while the majority can not be achieved at all.

The impact of the new rule set is prominent. For fair comparison how rules work - Taylor expanions were turned off for `main` and `new-rules` branch.
The results are quite impressive, `new-rules` produce better accuracy on 1% over the nightly run when comparing with `main`.
[`new-rules-taylor-last-iter`](https://nightly.cs.washington.edu/reports/herbie/1747773824:new-rules-taylor-LAST:cd6c75cb/) vs [ `main-taylor-last-iter`](https://nightly.cs.washington.edu/reports/herbie/1747772605:main-taylor-last:6201f6b0/).

However, when taylor expansions are included, `new-rules` branch is somewhat close to `main` accuracy-wise.
Probably, the reasons are that taylor expansions can come up with all the missing rewrites on its own.
It is not quite good and, of course, we do want to have a more strong rule-set rather than relying on taylor expansions.
[`main`](https://nightly.cs.washington.edu/reports/herbie/1747760482:main:0e5c6bc4/) vs [`new-rules`](https://nightly.cs.washington.edu/reports/herbie/1747776467:new-rules:d84e2243/)