### PR TITLE
Simplify batch compression logging

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -187,7 +187,7 @@
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (atab-eval-altns atab altns ctx)
-  (define batch (progs->batch (map alt-expr altns) #:timeline-push #t #:vars (context-vars ctx)))
+  (define batch (progs->batch (map alt-expr altns) #:vars (context-vars ctx)))
   (define errss (batch-errors batch (alt-table-pcontext atab) ctx))
   (define costs (alt-batch-cost batch (context-repr ctx)))
   (values errss costs))

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -75,22 +75,17 @@
   (match-define (batchref b idx) x)
   (batch-ref b idx))
 
-(define (progs->batch exprs #:timeline-push [timeline-push #f] #:vars [vars '()])
-
+(define (progs->batch exprs #:vars [vars '()])
   (define out (make-mutable-batch))
 
   (for ([var (in-list vars)])
     (mutable-batch-push! out var))
-
   (define roots
     (for/vector #:length (length exprs)
                 ([expr (in-list exprs)])
       (mutable-batch-munge! out expr)))
 
-  (define final (mutable-batch->batch out roots))
-  (when timeline-push
-    (timeline-push! 'compiler (batch-tree-size final) (batch-length final)))
-  final)
+  (mutable-batch->batch out roots))
 
 (define (batch-tree-size b)
   (define len (vector-length (batch-nodes b)))

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require "../utils/timeline.rkt"
-         "../syntax/syntax.rkt")
+(require "../syntax/syntax.rkt")
 
 (provide progs->batch ; (Listof Expr) -> Batch
          batch->progs ; Batch -> ?(or (Listof Root) (Vectorof Root)) -> (Listof Expr)
@@ -9,6 +8,7 @@
          (struct-out batchref) ; temporarily for patch.rkt
          (struct-out mutable-batch) ; temporarily for patch.rkt
          batch-length ; Batch -> Integer
+         batch-tree-size ; Batch -> Integer
          batch-ref ; Batch -> Idx -> Expr
          deref ; Batchref -> Expr
          batch-replace ; Batch -> (Expr<Batchref> -> Expr<Batchref>) -> Batch

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -3,6 +3,7 @@
 (require "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "../utils/float.rkt"
+         "../utils/timeline.rkt"
          "batch.rkt")
 
 (provide compile-progs

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -65,7 +65,9 @@
   (define batch
     (if (batch? exprs)
         exprs
-        (progs->batch exprs #:timeline-push #t #:vars vars)))
+        (progs->batch exprs #:vars vars)))
+
+  (timeline-push! 'compiler (batch-tree-size batch) (batch-length batch))
 
   ; Here we need to keep vars even though no roots refer to the vars
   (define batch* (batch-remove-zombie (batch-remove-approx batch) #:keep-vars #t))


### PR DESCRIPTION
There's a timeline field called "Compiler" that tells you how much batches deduplicated the expression tree. There were two problems with it:

1. I introduced a cache in #1195 which means we were logging the wrong number anyway
2. The logging code actually makes `progs->batch` unable to use `mutable-batch-munge!` and in general imposes a kind of ugly API

This PR fixes this all by introducing the `batch-tree-size` API, which gives the size of a batch if it were a tree. Critically, it doesn't actually build a tree, it just does math. Then this API lets us unify `progs->batch` and `mutable-batch-munge!`; along the way, I add the cache from #1195 to `mutable-batch-munge!`, which I think might speed up a few benchmarks.

Long-term, I think it would be good to remove the `timeline-push` argument from `progs->batch` since the caller is now able to do it themselves. Might be this PR might be another one.