### PR TITLE
Taylor rewrite in separate paths

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -87,7 +87,7 @@
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
         (run-egglog-multi-extractor runner global-batch)
-        (egraph-variations runner global-batch)))
+        (egraph-best runner global-batch)))
 
   ; apply changelists
   (define rewritten

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -62,11 +62,42 @@
     (approx-impl (vector-ref (batch-nodes global-batch) approx-pt)))
 
   (define approxs (remove-duplicates (taylor-alts starting-exprs altns global-batch) #:key key))
+  (define approxs* (run-lowering approxs global-batch))
 
-  (timeline-push! 'outputs (map ~a (map (compose debatchref alt-expr) approxs)))
-  (timeline-push! 'count (length altns) (length approxs))
+  (timeline-push! 'outputs (map ~a (map (compose debatchref alt-expr) approxs*)))
+  (timeline-push! 'count (length altns) (length approxs*))
 
-  approxs)
+  approxs*)
+
+(define (run-lowering altns global-batch)
+  (define schedule `((lower . ((iteration . 1) (scheduler . simple)))))
+
+  ; run egg
+  (define exprs (map (compose debatchref alt-expr) altns))
+  (define input-batch (progs->batch exprs))
+
+  (define roots (list->vector (map (compose batchref-idx alt-expr) altns)))
+  (define reprs (map (curryr repr-of (*context*)) exprs))
+
+  (define runner
+    (if (flag-set? 'generate 'egglog)
+        (make-egglog-runner input-batch (batch-roots input-batch) reprs schedule)
+        (make-egraph global-batch roots reprs schedule)))
+
+  (define batchrefss
+    (if (flag-set? 'generate 'egglog)
+        (run-egglog-multi-extractor runner global-batch)
+        (egraph-variations runner global-batch)))
+
+  ; apply changelists
+  (define rewritten
+    (reap [sow]
+          (for ([batchrefs (in-list batchrefss)]
+                [altn (in-list altns)])
+            (for ([batchref* (in-list batchrefs)])
+              (sow (alt batchref* (list 'rr runner #f) (list altn) '()))))))
+
+  rewritten)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -138,7 +169,7 @@
   ; Recursive rewrite
   (define rewritten
     (if (flag-set? 'generate 'rr)
-        (run-rr (append start-altns approximations) global-batch)
+        (run-rr start-altns global-batch)
         '()))
 
-  (remove-duplicates rewritten #:key (λ (x) (batchref-idx (alt-expr x)))))
+  (remove-duplicates (append rewritten approximations) #:key (λ (x) (batchref-idx (alt-expr x)))))

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -228,8 +228,8 @@
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
   [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
   [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
-  [fabs-lhs-div (/ (fabs x) x) (copysign 1 x) #;(/ x (fabs x))]
-  [fabs-rhs-div (/ x (fabs x)) (copysign 1 x) #;(/ (fabs x) x)]
+  [fabs-lhs-div (/ (fabs x) x) (copysign 1 x)]
+  [fabs-rhs-div (/ x (fabs x)) (copysign 1 x)]
   [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
   [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
@@ -273,8 +273,8 @@
   [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
   [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
   [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
-  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (copysign 1 x) #;(/ x (fabs x))]
-  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (copysign 1 x) #;(/ (fabs x) x)])
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (copysign 1 x)]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (copysign 1 x)])
 
 ; Exponentials
 (define-rules exponents

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -199,9 +199,7 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
-  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))] ; can be reached in 4 steps
-  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))]) ; can be reached in 4 steps
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
 
 ; Absolute value
 (define-rules arithmetic
@@ -266,8 +264,7 @@
   [add-log-exp x (log (exp x))]
   [add-exp-log x (exp (log x)) #:unsound] ; unsound @ x = 0
   [rem-exp-log (exp (log x)) x]
-  [rem-log-exp (log (exp x)) x]
-  [log-fabs (log x) (log (fabs x))]) ; range widening
+  [rem-log-exp (log (exp x)) x])
 
 (define-rules exponents
   [exp-0 (exp 0) 1]

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -130,6 +130,22 @@
   [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
   [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
+; Add/sub flips
+(define-rules arithmetic
+  [sub-flip (- a b) (+ a (neg b))]
+  [sub-flip-reverse (+ a (neg b)) (- a b)]
+  [sub-negate (neg (- b a)) (- a b)]
+  [sub-negate-rev (- a b) (neg (- b a))]
+  [add-flip (+ a b) (- a (neg b))]
+  [add-flip-rev (- a (neg b)) (+ a b)]
+  [add-negate (neg (+ a b)) (- (neg a) b)]
+  [add-negate-rev (- (neg a) b) (neg (+ a b))])
+
+; Mul/div flip
+(define-rules arithmetic
+  [mult-flip (/ a b) (* a (/ 1 b))]
+  [mult-flip-rev (* a (/ 1 b)) (/ a b)])
+
 ; Difference of squares
 (define-rules polynomials
   [swap-sqr (* (* a b) (* a b)) (* (* a a) (* b b))]
@@ -138,6 +154,10 @@
   [difference-of-sqr-1 (- (* a a) 1) (* (+ a 1) (- a 1))]
   [difference-of-sqr--1 (+ (* a a) -1) (* (+ a 1) (- a 1))]
   [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))]
+  [sum-square-pow (pow (+ a b) 2) (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2))]
+  [sub-square-pow (pow (- a b) 2) (+ (- (pow a 2) (* 2 (* a b))) (pow b 2))]
+  [sum-square-reverse (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
+  [sub-square-reverse (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
   [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
   [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
   [difference-of-squares-rev (* (+ a b) (- a b)) (- (* a a) (* b b))])

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -228,8 +228,8 @@
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
   [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
   [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
-  [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
-  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)]
+  [fabs-lhs-div (/ (fabs x) x) (copysign 1 x) #;(/ x (fabs x))]
+  [fabs-rhs-div (/ x (fabs x)) (copysign 1 x) #;(/ (fabs x) x)]
   [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
   [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
@@ -273,8 +273,8 @@
   [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
   [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
   [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
-  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (/ x (fabs x))]
-  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (/ (fabs x) x)])
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (copysign 1 x) #;(/ x (fabs x))]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (copysign 1 x) #;(/ (fabs x) x)])
 
 ; Exponentials
 (define-rules exponents

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -199,19 +199,24 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
+  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))] ; can be reached in 4 steps
+  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))]) ; can be reached in 4 steps
 
 ; Absolute value
 (define-rules arithmetic
   [fabs-fabs (fabs (fabs x)) (fabs x)]
   [fabs-sub (fabs (- a b)) (fabs (- b a))]
+  [fabs-add (fabs (+ (fabs a) (fabs b))) (+ (fabs a) (fabs b))]
   [fabs-neg (fabs (neg x)) (fabs x)]
   [fabs-sqr (fabs (* x x)) (* x x)]
   [fabs-mul (fabs (* a b)) (* (fabs a) (fabs b))]
   [fabs-div (fabs (/ a b)) (/ (fabs a) (fabs b))]
   [neg-fabs (fabs x) (fabs (neg x))]
   [mul-fabs (* (fabs a) (fabs b)) (fabs (* a b))]
-  [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))])
+  [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
+  [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
+  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)])
 
 ; Square root
 (define-rules arithmetic
@@ -248,20 +253,29 @@
   [cbrt-pow (cbrt (pow x y)) (pow x (/ y 3))]
   [add-cube-cbrt x (* (* (cbrt x) (cbrt x)) (cbrt x))]
   [add-cbrt-cube x (cbrt (* (* x x) x))]
-  [cube-unmult (* x (* x x)) (pow x 3)])
+  [cube-unmult (* x (* x x)) (pow x 3)]
+  [cbrt-neg (cbrt (neg x)) (neg (cbrt x))]
+  [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
+  [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
+  [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (/ x (fabs x))]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (/ (fabs x) x)])
 
 ; Exponentials
 (define-rules exponents
   [add-log-exp x (log (exp x))]
   [add-exp-log x (exp (log x)) #:unsound] ; unsound @ x = 0
   [rem-exp-log (exp (log x)) x]
-  [rem-log-exp (log (exp x)) x])
+  [rem-log-exp (log (exp x)) x]
+  [log-fabs (log x) (log (fabs x))]) ; range widening
 
 (define-rules exponents
   [exp-0 (exp 0) 1]
   [exp-1-e (exp 1) (E)]
   [1-exp 1 (exp 0)]
-  [e-exp-1 (E) (exp 1)])
+  [e-exp-1 (E) (exp 1)]
+  [exp-fabs (exp x) (fabs (exp x))]
+  [fabs-exp (fabs (exp x)) (exp x)])
 
 (define-rules exponents
   [exp-sum (exp (+ a b)) (* (exp a) (exp b))]
@@ -344,8 +358,10 @@
 (define-rules trigonometry
   [sin-neg (sin (neg x)) (neg (sin x))]
   [cos-neg (cos (neg x)) (cos x)]
+  [cos-fabs (cos (fabs x)) (cos x)]
   [tan-neg (tan (neg x)) (neg (tan x))]
   [cos-neg-rev (cos x) (cos (neg x))]
+  [cos-fabs-rev (cos x) (cos (fabs x))]
   [sin-neg-rev (neg (sin x)) (sin (neg x))]
   [tan-neg-rev (neg (tan x)) (tan (neg x))])
 

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -228,8 +228,8 @@
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
   [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
   [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
-  [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
-  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)]
+  [fabs-lhs-div (/ (fabs x) x) (copysign 1 x)]
+  [fabs-rhs-div (/ x (fabs x)) (copysign 1 x)]
   [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
   [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
@@ -273,8 +273,8 @@
   [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
   [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
   [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
-  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (/ x (fabs x))]
-  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (/ (fabs x) x)])
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (copysign 1 x)]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (copysign 1 x)])
 
 ; Exponentials
 (define-rules exponents

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -228,8 +228,8 @@
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
   [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
   [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
-  [fabs-lhs-div (/ (fabs x) x) (copysign 1 x)]
-  [fabs-rhs-div (/ x (fabs x)) (copysign 1 x)]
+  [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
+  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)]
   [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
   [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
@@ -273,8 +273,8 @@
   [cbrt-neg-rev (neg (cbrt x)) (cbrt (neg x))]
   [cbrt-fabs (cbrt (fabs x)) (fabs (cbrt x))]
   [cbrt-fabs-rev (fabs (cbrt x)) (cbrt (fabs x))]
-  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (copysign 1 x)]
-  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (copysign 1 x)])
+  [cbrt-div-cbrt (/ (cbrt x) (fabs (cbrt x))) (/ x (fabs x))]
+  [cbrt-div-cbrt2 (/ (fabs (cbrt x)) (cbrt x)) (/ (fabs x) x)])
 
 ; Exponentials
 (define-rules exponents

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -130,21 +130,13 @@
   [fp-cancel-sign-sub-inv (+ a (* b c)) (- a (* (neg b) c))]
   [fp-cancel-sub-sign-inv (- a (* b c)) (+ a (* (neg b) c))])
 
-; Add/sub flips
 (define-rules arithmetic
   [sub-flip (- a b) (+ a (neg b))]
   [sub-flip-reverse (+ a (neg b)) (- a b)]
   [sub-negate (neg (- b a)) (- a b)]
   [sub-negate-rev (- a b) (neg (- b a))]
   [add-flip (+ a b) (- a (neg b))]
-  [add-flip-rev (- a (neg b)) (+ a b)]
-  [add-negate (neg (+ a b)) (- (neg a) b)]
-  [add-negate-rev (- (neg a) b) (neg (+ a b))])
-
-; Mul/div flip
-(define-rules arithmetic
-  [mult-flip (/ a b) (* a (/ 1 b))]
-  [mult-flip-rev (* a (/ 1 b)) (/ a b)])
+  [add-flip-rev (- a (neg b)) (+ a b)])
 
 ; Difference of squares
 (define-rules polynomials
@@ -156,11 +148,29 @@
   [pow-sqr (* (pow a b) (pow a b)) (pow a (* 2 b))]
   [sum-square-pow (pow (+ a b) 2) (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2))]
   [sub-square-pow (pow (- a b) 2) (+ (- (pow a 2) (* 2 (* a b))) (pow b 2))]
-  [sum-square-reverse (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
-  [sub-square-reverse (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
+  [sum-square-pow-rev (+ (+ (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (+ a b) 2)]
+  [sub-square-pow-rev (+ (- (pow a 2) (* 2 (* a b))) (pow b 2)) (pow (- a b) 2)]
   [difference-of-sqr-1-rev (* (+ a 1) (- a 1)) (- (* a a) 1)]
   [difference-of-sqr--1-rev (* (+ a 1) (- a 1)) (+ (* a a) -1)]
   [difference-of-squares-rev (* (+ a b) (- a b)) (- (* a a) (* b b))])
+
+; Mul/div flip
+(define-rules arithmetic
+  [mult-flip (/ a b) (* a (/ 1 b))]
+  [mult-flip-rev (* a (/ 1 b)) (/ a b)]
+  [div-flip (/ a b) (/ 1 (/ b a)) #:unsound] ; unsound @ a = 0, b != 0
+  [div-flip-rev (/ 1 (/ b a)) (/ a b)])
+
+(define-rules arithmetic
+  [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound]
+  [sum-to-mult-rev (* (+ 1 (/ b a)) a) (+ a b)]
+  [sub-to-mult (- a b) (* (- 1 (/ b a)) a) #:unsound]
+  [sub-to-mult-rev (* (- 1 (/ b a)) a) (- a b)]
+  [add-to-fraction (+ c (/ b a)) (/ (+ (* c a) b) a)]
+  [add-to-fraction-rev (/ (+ (* c a) b) a) (+ c (/ b a))]
+  [sub-to-fraction (- c (/ b a)) (/ (- (* c a) b) a)]
+  [sub-to-fraction-rev (/ (- (* c a) b) a) (- c (/ b a))]
+  [common-denominator (+ (/ a b) (/ c d)) (/ (+ (* a d) (* c b)) (* b d))])
 
 (define-rules polynomials
   [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1
@@ -199,7 +209,9 @@
   [sqr-neg (* (neg x) (neg x)) (* x x)]
   [sqr-abs (* (fabs x) (fabs x)) (* x x)]
   [sqr-abs-rev (* x x) (* (fabs x) (fabs x))]
-  [sqr-neg-rev (* x x) (* (neg x) (neg x))])
+  [sqr-neg-rev (* x x) (* (neg x) (neg x))]
+  [sqrt-cbrt (sqrt (cbrt x)) (cbrt (sqrt x))]
+  [cbrt-sqrt (cbrt (sqrt x)) (sqrt (cbrt x))])
 
 ; Absolute value
 (define-rules arithmetic
@@ -213,8 +225,12 @@
   [neg-fabs (fabs x) (fabs (neg x))]
   [mul-fabs (* (fabs a) (fabs b)) (fabs (* a b))]
   [div-fabs (/ (fabs a) (fabs b)) (fabs (/ a b))]
+  [sqrt-fabs (fabs (sqrt a)) (sqrt a)]
+  [sqrt-fabs-rev (sqrt a) (fabs (sqrt a))]
   [fabs-lhs-div (/ (fabs x) x) (/ x (fabs x))]
-  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)])
+  [fabs-rhs-div (/ x (fabs x)) (/ (fabs x) x)]
+  [fabs-cbrt (fabs (/ (cbrt a) a)) (/ (cbrt a) a)]
+  [fabs-cbrt-rev (/ (cbrt a) a) (fabs (/ (cbrt a) a))])
 
 ; Square root
 (define-rules arithmetic


### PR DESCRIPTION
This PR is built on top of #1226.
It introduces updates to `generate-candidates`. Particularly speaking, currently, we _lower_ our approximations and rewrite them in the same e-graph that we use for general rewrites.
But that actually slightly wrong.
The reasons behind are:
Taylor expansions do not guarantee to produce any good results - it can, and in most of the cases does, but in general, taylor expansions can be just a nonsense.
When we rewrite a potential nonsense with meaningful expressions that we actually sure about - we just occupy our vital space in egg and hit the node limit faster.
And we likely do not need to do that - taylor expansions should go to a separate egg for lowering and do not interact with the general rewrites as they actually can produce something good and more nodes are essentially needed.
As a result - expressions that we are sure about can be rewritten with way more nodes - which eventually will result in better accuracy.

From nightly reports we can see, that the idea works, 0.4% overall accuracy improvement is observed.
[`main`](https://nightly.cs.washington.edu/reports/herbie/1747760482:main:0e5c6bc4/) vs [`taylor-rewrite-in-separate-paths`](https://nightly.cs.washington.edu/reports/herbie/1747796398:taylor-rewrite-in-separate-paths:026a4f72/)