### PR TITLE
Compute critical subexpressions using batches

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -98,12 +98,12 @@
         [_
          #:when (equal? i except-index)
          (set)]
-        [(? symbol?) (set n)]
-        [(? number?) (set)]
-        [(? literal?) (set)]
+        [(? symbol?) (list n)]
+        [(? number?) (list)]
+        [(? literal?) (list)]
         [(approx _ impl) (vector-ref out impl)]
-        [(hole _ _) (set)]
-        [(list op args ...) (apply set-union (set) (map (curry vector-ref out) args))]))
+        [(hole _ _) (list)]
+        [(list op args ...) (apply set-union (list) (map (curry vector-ref out) args))]))
     (vector-set! out i fv))
   out)
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -111,14 +111,14 @@
   (define start-root (vector-ref (batch-roots b) 0))
   (reap [sow]
         (for ([i (in-naturals)]
-              [n (in-vector (batch-nodes b))])
+              [n (in-vector (batch-nodes b))]
+              #:unless (set-empty? (vector-ref basic-fv i)))
           (define cut-fv (batch-free-vars b #:except i))
           (define critical?
             ;; We can only binary search if the branch expression is
             ;; critical for some of the alts and also for the start
             ;; program.
-            (and (not (set-empty? (vector-ref basic-fv i)))
-                 (set-disjoint? (vector-ref basic-fv i) (vector-ref cut-fv start-root))
+            (and (set-disjoint? (vector-ref basic-fv i) (vector-ref cut-fv start-root))
                  (for/or ([root (in-vector (batch-roots b) 1)])
                    (set-disjoint? (vector-ref basic-fv i) (vector-ref cut-fv start-root)))))
           (when critical?

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -97,7 +97,7 @@
       (match n
         [_
          #:when (equal? i except-index)
-         (set)]
+         (list)]
         [(? symbol?) (list n)]
         [(? number?) (list)]
         [(? literal?) (list)]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -95,14 +95,15 @@
         [n (in-vector (batch-nodes b))])
     (define fv
       (match n
-        [_ #:when (equal? i except-index) (set)]
+        [_
+         #:when (equal? i except-index)
+         (set)]
         [(? symbol?) (set n)]
         [(? number?) (set)]
         [(? literal?) (set)]
         [(approx _ impl) (vector-ref out impl)]
         [(hole _ _) (set)]
-        [(list op args ...)
-         (apply set-union (set) (map (curry vector-ref out) args))]))
+        [(list op args ...) (apply set-union (set) (map (curry vector-ref out) args))]))
     (vector-set! out i fv))
   out)
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -102,7 +102,7 @@
         [(approx _ impl) (vector-ref out impl)]
         [(hole _ _) (set)]
         [(list op args ...)
-         (apply set-union (map (curry vector-ref out) args))]))
+         (apply set-union (set) (map (curry vector-ref out) args))]))
     (vector-set! out i fv))
   out)
 

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -442,10 +442,9 @@
                                 `(tr (td ,(~a key) (td ,(~a val)))))))))
 
 (define (render-phase-counts alts)
-  `((dt "Counts")
-    ,@(for/list ([rec (in-list alts)])
-        (match-define (list inputs outputs) rec)
-        `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
+  `((dt "Counts") ,@(for/list ([rec (in-list alts)])
+                      (match-define (list inputs outputs) rec)
+                      `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
 
 (define (render-phase-alts alts)
   `((dt "Alt Table")

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -442,8 +442,10 @@
                                 `(tr (td ,(~a key) (td ,(~a val)))))))))
 
 (define (render-phase-counts alts)
-  (match-define (list (list inputs outputs)) alts)
-  `((dt "Counts") (dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " "))))
+  `((dt "Counts")
+    ,@(for/list ([rec (in-list alts)])
+        (match-define (list inputs outputs) rec)
+        `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
 
 (define (render-phase-alts alts)
   `((dt "Alt Table")


### PR DESCRIPTION
Critical subexpressions is a (small) part of regimes. This PR switches the critical-subexpression computation from using expression trees to using a batch, which is slightly faster, especially on benchmarks like `colonnade` that have a lot of shared subexpressions.

It also reclassifies critical subexpression computation from `prune` to `regimes`, just a small oversight!