### PR TITLE
Speed up duplicative printing in taylor-alts

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -29,6 +29,7 @@
 
 (define (taylor-alts starting-exprs altns global-batch)
   (define specs (map prog->spec starting-exprs))
+  (define spec-string (~a specs)) ; TODO: make output more useful somehow
   (define free-vars (map free-variables specs))
   (define vars (context-vars (*context*)))
 
@@ -37,7 +38,7 @@
         (for* ([var (in-list vars)]
                [transform-type transforms-to-try])
           (match-define (list name f finv) transform-type)
-          (define timeline-stop! (timeline-start! 'series (~a specs) (~a var) (~a name)))
+          (define timeline-stop! (timeline-start! 'series spec-string (~a var) (~a name)))
           (define genexprs (approximate specs var #:transform (cons f finv)))
           (for ([genexpr (in-list genexprs)]
                 [spec (in-list specs)]


### PR DESCRIPTION
This is super minor and dumb and a mis-feature already but this PR makes colonnade way faster without any significant code change, just by caching a string.