### PR TITLE
Fix attribution of `exprs-to-branch-on`

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -26,6 +26,7 @@
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
 (define (pareto-regimes sorted ctx)
+  (timeline-event! 'regimes)
   (define err-lsts (batch-errors (map alt-expr sorted) (*pcontext*) ctx))
   (define branches
     (if (null? sorted)
@@ -51,7 +52,6 @@
 ;; can insert a timeline break between them.
 
 (define (infer-splitpoints branch-exprs alts err-lsts* #:errs [cerrs (hash)] ctx)
-  (timeline-event! 'regimes)
   (timeline-push! 'inputs (map (compose ~a alt-expr) alts))
   (define sorted-bexprs
     (sort branch-exprs (lambda (x y) (< (hash-ref cerrs x -1) (hash-ref cerrs y -1)))))

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -442,10 +442,9 @@
                                 `(tr (td ,(~a key) (td ,(~a val)))))))))
 
 (define (render-phase-counts alts)
-  `((dt "Counts")
-    ,@(for/list ([rec (in-list alts)])
-        (match-define (list inputs outputs) alts)
-        `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
+  `((dt "Counts") ,@(for/list ([rec (in-list alts)])
+                      (match-define (list inputs outputs) alts)
+                      `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
 
 (define (render-phase-alts alts)
   `((dt "Alt Table")

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -442,8 +442,10 @@
                                 `(tr (td ,(~a key) (td ,(~a val)))))))))
 
 (define (render-phase-counts alts)
-  (match-define (list (list inputs outputs)) alts)
-  `((dt "Counts") (dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " "))))
+  `((dt "Counts")
+    ,@(for/list ([rec (in-list alts)])
+        (match-define (list inputs outputs) alts)
+        `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
 
 (define (render-phase-alts alts)
   `((dt "Alt Table")


### PR DESCRIPTION
Basically this was showing up as prune time, whereas it is actually regimes time. Fixing this required a little bit of futzing with timeline printing.