### PR TITLE
Move startup message to `start-job-server`

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -503,10 +503,6 @@
   (*demo-log* log)
   (start-job-server threads)
 
-  (unless quiet?
-    (eprintf "Herbie ~a with seed ~a\n" *herbie-version* (get-seed))
-    (eprintf "Find help on https://herbie.uwplse.org/, exit with Ctrl-C\n"))
-
   (serve/servlet dispatch
                  #:listen-ip (if public #f "127.0.0.1")
                  #:port port

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -201,9 +201,11 @@
   (set! log-level set-logging)
   (cond
     [worker-cap
-     (eprintf "Starting Herbie ~a with ~a workers and seed ~a...\n" *herbie-version* worker-cap (get-seed))]
-    [else
-     (eprintf "Starting Herbie ~a with seed ~a...\n" *herbie-version* (get-seed))])
+     (eprintf "Starting Herbie ~a with ~a workers and seed ~a...\n"
+              *herbie-version*
+              worker-cap
+              (get-seed))]
+    [else (eprintf "Starting Herbie ~a with seed ~a...\n" *herbie-version* (get-seed))])
   (when worker-cap
     (define r (make-manager worker-cap))
     (set! manager-dead-event (place-dead-evt r))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -199,6 +199,11 @@
 ;; to standard error.
 (define (start-job-server worker-cap #:logging [set-logging #f])
   (set! log-level set-logging)
+  (cond
+    [worker-cap
+     (eprintf "Starting Herbie ~a with ~a workers and seed ~a...\n" *herbie-version* worker-cap (get-seed))]
+    [else
+     (eprintf "Starting Herbie ~a with seed ~a...\n" *herbie-version* (get-seed))])
   (when worker-cap
     (define r (make-manager worker-cap))
     (set! manager-dead-event (place-dead-evt r))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -57,12 +57,11 @@
 
 (define (run-shell)
   (define seed (get-seed))
-  (eprintf "Herbie ~a with seed ~a\n" *herbie-version* seed)
+  (start-job-server #f)
   (eprintf "Find help on https://herbie.uwplse.org/, exit with ~a\n"
            (match (system-type 'os)
              ['windows "Ctrl-Z Enter"]
              [_ "Ctrl-D"]))
-  (start-job-server #f)
   (with-handlers ([exn:break? (λ (e) (exit 0))])
     (for ([test (in-producer get-shell-input eof-object?)]
           [idx (in-naturals)])


### PR DESCRIPTION
This way we always print the startup message in a uniform way and include relevant information (like the seed).