### PR TITLE
Clean up server.rkt a bit

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -32,6 +32,7 @@
 (define *demo?* (make-parameter false))
 (define *demo-prefix* (make-parameter "/"))
 (define *demo-log* (make-parameter false))
+(define *demo-output* (make-parameter false))
 
 (define (add-prefix url)
   (string-replace (string-append (*demo-prefix*) url) "//" "/"))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -163,7 +163,7 @@
         " | "
         (a ([id "use-fpcore"]) "Use FPCore"))
     (cond
-      [(is-server-up)
+      [(server-up?)
        `(form
          ([action ,(url improve)] [method "post"] [id "formula"] [data-progress ,(url improve-start)])
          (textarea ([name "formula"] [autofocus "true"]
@@ -363,8 +363,8 @@
                      (fprintf out "Doing ~a\n" (hash-ref entry 'type))))))]))
 
 (define (check-up req)
-  (response/full (if (is-server-up) 200 500)
-                 (if (is-server-up) #"Up" #"Down")
+  (response/full (if (server-up?) 200 500)
+                 (if (server-up?) #"Up" #"Down")
                  (current-seconds)
                  #"text/plain"
                  (list (header #"X-Job-Count" (string->bytes/utf-8 (~a (job-count))))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -110,7 +110,11 @@
     [(and (*demo-output*) (file-exists? (build-path (*demo-output*) "results.json")))
      (next-dispatcher)]
     [else
-     (define info (make-report-info (get-improve-table-data) #:seed (get-seed)))
+     (define improve-results (get-improve-results))
+     (define table-data
+       (for/list ([result (get-improve-results)])
+         (get-table-data-from-hash result (hash-ref result 'path))))
+     (define info (make-report-info table-data #:seed (get-seed)))
      (response 200
                #"OK"
                (current-seconds)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -474,27 +474,25 @@
                              (define result (core->mathjs (syntax->datum formula)))
                              (hasheq 'mathjs result))))
 
+(define (get-converter target-lang)
+  (case target-lang
+    [("python") core->python]
+    [("c") core->c]
+    [("fortran") core->fortran]
+    [("java") core->java]
+    [("julia") core->julia]
+    [("matlab") core->matlab]
+    [("wls") core->wls]
+    [("tex") core->tex]
+    [("js") core->js]
+    [else (error "Unsupported target language:" target-lang)]))
+
 (define translate-endpoint
   (post-with-json-response (lambda (post-data)
                              ; FPCore formula and target language
                              (define formula (read (open-input-string (hash-ref post-data 'formula))))
                              (define target-lang (hash-ref post-data 'language))
-                             ; Select the appropriate conversion function
-                             (define lang-converter
-                               (case target-lang
-                                 [("python") core->python]
-                                 [("c") core->c]
-                                 [("fortran") core->fortran]
-                                 [("java") core->java]
-                                 [("julia") core->julia]
-                                 [("matlab") core->matlab]
-                                 [("wls") core->wls]
-                                 [("tex") core->tex]
-                                 [("js") core->js]
-                                 [else (error "Unsupported target language:" target-lang)]))
-
-                             ; convert the expression
-                             (define converted (lang-converter formula "expr"))
+                             (define converted ((get-converter target-lang) formula "expr"))
                              (hasheq 'result converted 'language target-lang))))
 
 (define (run-demo #:quiet [quiet? #f]

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -313,13 +313,7 @@
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
        (define test (parse-test formula))
-       (define job-id
-         (start-job 'improve
-                    test
-                    #:seed (get-seed)
-                    #:pcontext #f
-                    #:profile? #f
-                    #:timeline-disabled? #f))
+       (define job-id (start-job 'improve test #:seed (get-seed) #:profile? #f #:timeline? #t))
        (body job-id))]
     [_
      (response/error "Demo Error"
@@ -443,47 +437,34 @@
 (define-api-endpoint ("sample" post-data)
   (define test (get-test post-data))
   (define seed (parse-seed post-data))
-  (start-job 'sample test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #t))
+  (start-job 'sample test #:seed seed))
 
 (define-api-endpoint ("explanations" post-data)
   (start-job 'explanations
              (get-test post-data)
              #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)
-             #:profile? #f
-             #:timeline-disabled? #t))
+             #:pcontext (get-pcontext post-data)))
 
 (define-api-endpoint ("analyze" post-data)
   (start-job 'errors
              (get-test post-data)
              #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)
-             #:profile? #f
-             #:timeline-disabled? #t))
+             #:pcontext (get-pcontext post-data)))
 
 (define-api-endpoint ("localerror" post-data)
   (start-job 'local-error
              (get-test post-data)
              #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)
-             #:profile? #f
-             #:timeline-disabled? #t))
+             #:pcontext (get-pcontext post-data)))
 
 (define-api-endpoint ("alternatives" post-data)
   (start-job 'alternatives
              (get-test post-data)
              #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)
-             #:profile? #f
-             #:timeline-disabled? #t))
+             #:pcontext (get-pcontext post-data)))
 
 (define-api-endpoint ("cost" post-data)
-  (start-job 'cost
-             (get-test post-data)
-             #:seed #f
-             #:pcontext #f
-             #:profile? #f
-             #:timeline-disabled? #f))
+  (start-job 'cost (get-test post-data) #:seed #f))
 
 (define ->mathjs-endpoint
   (post-with-json-response (lambda (post-data)

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -426,7 +426,7 @@
   (parse-test formula))
 
 ; The name get-seed is taken.
-(define (parse-seed post-data)
+(define (get-seed post-data)
   (hash-ref post-data 'seed #f))
 
 (define (get-pcontext post-data)
@@ -436,30 +436,30 @@
 
 (define-api-endpoint ("sample" post-data)
   (define test (get-test post-data))
-  (define seed (parse-seed post-data))
+  (define seed (get-seed post-data))
   (start-job 'sample test #:seed seed))
 
 (define-api-endpoint ("explanations" post-data)
   (define test (get-test post-data))
-  (define seed (parse-seed post-data))
+  (define seed (get-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'explanations test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("analyze" post-data)
   (define test (get-test post-data))
-  (define seed (parse-seed post-data))
+  (define seed (get-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'errors test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("localerror" post-data)
   (define test (get-test post-data))
-  (define seed (parse-seed post-data))
+  (define seed (get-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'local-error test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("alternatives" post-data)
   (define test (get-test post-data))
-  (define seed (parse-seed post-data))
+  (define seed (get-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'alternatives test #:seed seed #:pcontext pcontext))
 

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -440,28 +440,28 @@
   (start-job 'sample test #:seed seed))
 
 (define-api-endpoint ("explanations" post-data)
-  (start-job 'explanations
-             (get-test post-data)
-             #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)))
+  (define test (get-test post-data))
+  (define seed (parse-seed post-data))
+  (define pcontext (get-pcontext post-data))
+  (start-job 'explanations test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("analyze" post-data)
-  (start-job 'errors
-             (get-test post-data)
-             #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)))
+  (define test (get-test post-data))
+  (define seed (parse-seed post-data))
+  (define pcontext (get-pcontext post-data))
+  (start-job 'errors test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("localerror" post-data)
-  (start-job 'local-error
-             (get-test post-data)
-             #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)))
+  (define test (get-test post-data))
+  (define seed (parse-seed post-data))
+  (define pcontext (get-pcontext post-data))
+  (start-job 'local-error test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("alternatives" post-data)
-  (start-job 'alternatives
-             (get-test post-data)
-             #:seed (parse-seed post-data)
-             #:pcontext (get-pcontext post-data)))
+  (define test (get-test post-data))
+  (define seed (parse-seed post-data))
+  (define pcontext (get-pcontext post-data))
+  (start-job 'alternatives test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("cost" post-data)
   (start-job 'cost (get-test post-data) #:seed #f))

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -426,7 +426,7 @@
   (parse-test formula))
 
 ; The name get-seed is taken.
-(define (get-seed post-data)
+(define (parse-seed post-data)
   (hash-ref post-data 'seed #f))
 
 (define (get-pcontext post-data)
@@ -436,30 +436,30 @@
 
 (define-api-endpoint ("sample" post-data)
   (define test (get-test post-data))
-  (define seed (get-seed post-data))
+  (define seed (parse-seed post-data))
   (start-job 'sample test #:seed seed))
 
 (define-api-endpoint ("explanations" post-data)
   (define test (get-test post-data))
-  (define seed (get-seed post-data))
+  (define seed (parse-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'explanations test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("analyze" post-data)
   (define test (get-test post-data))
-  (define seed (get-seed post-data))
+  (define seed (parse-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'errors test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("localerror" post-data)
   (define test (get-test post-data))
-  (define seed (get-seed post-data))
+  (define seed (parse-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'local-error test #:seed seed #:pcontext pcontext))
 
 (define-api-endpoint ("alternatives" post-data)
   (define test (get-test post-data))
-  (define seed (get-seed post-data))
+  (define seed (parse-seed post-data))
   (define pcontext (get-pcontext post-data))
   (start-job 'alternatives test #:seed seed #:pcontext pcontext))
 

--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -42,8 +42,7 @@
  (λ (x)
    (and (not (and (*demo-output*) ; If we've already saved to disk, skip this job
                   (directory-exists? (build-path (*demo-output*) x))))
-        (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
-          (and m (job-status (second m))))))
+        (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)]) (and m (job-status (second m))))))
  (λ (x)
    (let ([m (regexp-match #rx"^([0-9a-f]+)\\.[0-9a-f.]+" x)])
      (job-status (if m

--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -84,17 +84,17 @@
   (unless (directory-exists? dir)
     (make-directory dir))
 
-  (start-job-server threads)
+  (server-start threads)
   (define job-ids
     (for/list ([test (in-list tests)])
-      (start-job 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline-disabled? #f)))
+      (job-start 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline? #t)))
 
   (define total-tests (length tests))
   (define job-results
     (for/list ([job-id (in-list job-ids)]
                [test (in-list tests)]
                [test-number (in-naturals)])
-      (define result (wait-for-job job-id))
+      (define result (job-wait job-id))
       (print-test-result (+ test-number 1) total-tests test result)
       result))
   (define results

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -158,12 +158,12 @@
                     #:seed [seed #f]
                     #:pcontext [pcontext #f]
                     #:profile? [profile? #f]
-                    #:timeline-disabled? [timeline-disabled? #f])
+                    #:timeline? [timeline? #f])
   (define timeline #f)
   (define profile #f)
 
   (define (on-exception start-time e)
-    (parameterize ([*timeline-disabled* timeline-disabled?])
+    (parameterize ([*timeline-disabled* (not timeline?)])
       (timeline-event! 'end)
       (define time (- (current-inexact-milliseconds) start-time))
       (match command
@@ -171,7 +171,7 @@
         [_ (raise e)])))
 
   (define (on-timeout)
-    (parameterize ([*timeline-disabled* timeline-disabled?])
+    (parameterize ([*timeline-disabled* (not timeline?)])
       (timeline-load! timeline)
       (timeline-event! 'end)
       (match command
@@ -180,7 +180,7 @@
         [_ (error 'run-herbie "command ~a timed out" command)])))
 
   (define (compute-result)
-    (parameterize ([*timeline-disabled* timeline-disabled?])
+    (parameterize ([*timeline-disabled* (not timeline?)])
       (define start-time (current-inexact-milliseconds))
       (reset!)
       (*context* (test-context test))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -3,22 +3,22 @@
 (require openssl/sha1)
 (require (only-in xml write-xexpr))
 
-(require "../core/points.rkt"
-         "../reports/history.rkt"
-         "../reports/plot.rkt"
-         "../reports/common.rkt"
-         "../syntax/types.rkt"
+(require "../syntax/load-plugin.rkt"
          "../syntax/read.rkt"
-         "../syntax/load-plugin.rkt"
          "../syntax/sugar.rkt"
+         "../syntax/syntax.rkt"
+         "../syntax/types.rkt"
          "../utils/alternative.rkt"
          "../utils/common.rkt"
          "../utils/errors.rkt"
          "../utils/float.rkt"
+         "../core/points.rkt"
+         "../reports/common.rkt"
+         "../reports/history.rkt"
          "../reports/pages.rkt"
-         "sandbox.rkt"
+         "../reports/plot.rkt"
          "datafile.rkt"
-         "../syntax/syntax.rkt"
+         "sandbox.rkt"
          (submod "../utils/timeline.rkt" debug))
 
 (provide job-path

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -45,7 +45,7 @@
     (apply eprintf msg args)))
 
 ;; Job object, What herbie excepts as input for a new job.
-(struct herbie-command (command test seed pcontext profile? timeline-disabled?) #:prefab)
+(struct herbie-command (command test seed pcontext profile? timeline?) #:prefab)
 
 ; computes the path used for server URLs
 (define (make-path id)
@@ -81,8 +81,8 @@
                    #:seed [seed #f]
                    #:pcontext [pcontext #f]
                    #:profile? [profile? #f]
-                   #:timeline-disabled? [timeline-disabled? #f])
-  (define job (herbie-command command test seed pcontext profile? timeline-disabled?))
+                   #:timeline? [timeline? #f])
+  (define job (herbie-command command test seed pcontext profile? timeline?))
   (define job-id (compute-job-id job))
   (manager-tell 'start manager job job-id)
   (log "Job ~a, Qed up for program: ~a\n" job-id (test-name test))
@@ -194,7 +194,7 @@
                       #:seed (herbie-command-seed cmd)
                       #:pcontext (herbie-command-pcontext cmd)
                       #:profile? (herbie-command-profile? cmd)
-                      #:timeline-disabled? (herbie-command-timeline-disabled? cmd))
+                      #:timeline? (herbie-command-timeline? cmd))
     (log "Completed ~a job (~a)\n" (herbie-command-command cmd) job-id)))
 
 (define-syntax (place/context* stx)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -30,8 +30,7 @@
          start-job
          wait-for-job
          server-up?
-         start-job-server
-         alt->fpcore)
+         start-job-server)
 
 (define log-level #f)
 (define (log msg . args)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -32,9 +32,8 @@
          server-count
          server-up?)
 
-(define log-level #f)
 (define (log msg . args)
-  (when log-level
+  (when false
     (apply eprintf msg args)))
 
 ;; Job object, What herbie excepts as input for a new job.
@@ -77,15 +76,9 @@
   finished-result)
 
 ;; Start the job server
-;; worker-cap: `false` or `no` to not use Racket `place` best used for
-;; debugging, specific yes to use the number of cores on your system as the
-;; worker cap or specif the number of workers you would like to use
-;; logging: Set to #f as default. Set to #t to print what the server is doing
-;; to standard error.
-(define (server-start worker-cap #:logging [set-logging #f])
-  (set! log-level set-logging)
-  (when worker-cap
-    (set! manager (make-manager worker-cap))))
+(define (server-start threads)
+  (when threads
+    (set! manager (make-manager threads))))
 
 (define (server-improve-results)
   (log "Getting improve results.\n")

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -22,7 +22,7 @@
          (submod "../utils/timeline.rkt" debug))
 
 (provide make-path
-         get-improve-table-data
+         get-improve-results
          server-check-on
          get-results-for
          get-timeline-for
@@ -65,7 +65,7 @@
   (log "Checking on: ~a.\n" job-id)
   (manager-ask 'check job-id))
 
-(define (get-improve-table-data)
+(define (get-improve-results)
   (log "Getting improve results.\n")
   (manager-ask 'improve))
 
@@ -119,7 +119,7 @@
         [(list 'improve)
          (for/list ([(job-id result) (in-hash completed-jobs)]
                     #:when (equal? (hash-ref result 'command) "improve"))
-           (get-table-data-from-hash result (make-path job-id)))])))
+           result)])))
 
 (define (get-json-converter command)
   (match (herbie-command-command command)
@@ -309,7 +309,7 @@
         (define improved-list
           (for/list ([(job-id result) (in-hash completed-jobs)]
                      #:when (equal? (hash-ref result 'command) "improve"))
-            (get-table-data-from-hash result (make-path job-id))))
+            result))
         (place-channel-put handler improved-list)]))))
 
 (define (make-worker worker-id)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -31,7 +31,6 @@
          start-job
          wait-for-job
          start-job-server
-         *demo-output*
          alt->fpcore)
 
 (define (warn-single-threaded-mpfr)
@@ -39,8 +38,6 @@
   (local-require math/private/bigfloat/mpfr)
   (unless ((get-ffi-obj 'mpfr_buildopt_tls_p mpfr-lib (_fun -> _bool)))
     (warn 'mpfr-threads "Your MPFR is single-threaded. Herbie will work but be slower than normal.")))
-
-(define *demo-output* (make-parameter false))
 
 (define log-level #f)
 (define (log msg . args)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -105,11 +105,12 @@
 
 (define (manager-ask-basic msg . args)
   (match (list* msg args) ; public commands
-    [(list 'start hash-false command)
-     (define job-id (compute-job-id command))
-     (hash-set! queued-jobs job-id command)
+    [(list 'start 'basic command test seed pcontext profile? timeline?)
+     (define job (herbie-command command test seed pcontext profile? timeline?))
+     (define job-id (compute-job-id job))
+     (hash-set! queued-jobs job-id job)
      job-id]
-    [(list 'wait hash-false job-id)
+    [(list 'wait 'basic job-id)
      (define command (hash-ref queued-jobs job-id))
      (define result (herbie-do-server-job command job-id))
      (hash-set! completed-jobs job-id result)

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -85,9 +85,7 @@
 (define (server-start worker-cap #:logging [set-logging #f])
   (set! log-level set-logging)
   (when worker-cap
-    (define r (make-manager worker-cap))
-    (set! manager-dead-event (place-dead-evt r))
-    (set! manager r)))
+    (set! manager (make-manager worker-cap))))
 
 (define (server-improve-results)
   (log "Getting improve results.\n")
@@ -100,7 +98,7 @@
 
 (define (server-up?)
   (if manager
-      (not (sync/timeout 0 manager-dead-event))
+      (not (sync/timeout 0 (place-dead-evt manager)))
       #t))
 
 ;; Implementation of the two manager types (threaded and basic)
@@ -146,7 +144,6 @@
     (warn 'mpfr-threads "Your MPFR is single-threaded. Herbie will work but be slower than normal.")))
 
 (define manager #f)
-(define manager-dead-event #f)
 
 (define (compute-job-id job-info)
   (sha1 (open-input-string (~s job-info))))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -41,13 +41,13 @@
 (define (run-improve input output #:threads [threads #f])
   (define seed (get-seed))
   (define tests (load-tests input))
-  (start-job-server threads)
+  (server-start threads)
   (define ids
     (for/list ([test (in-list tests)])
-      (start-job 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f)))
+      (job-start 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f)))
   (define results
     (for/list ([id ids])
-      (wait-for-job id)))
+      (job-wait id)))
 
   (if (equal? output "-")
       (print-improve-outputs tests results (current-output-port) #:seed seed)
@@ -62,11 +62,11 @@
            (match (system-type 'os)
              ['windows "Ctrl-Z Enter"]
              [_ "Ctrl-D"]))
-  (start-job-server #f)
+  (server-start #f)
   (with-handlers ([exn:break? (λ (e) (exit 0))])
     (for ([test (in-producer get-shell-input eof-object?)]
           [idx (in-naturals)])
-      (define result (wait-for-job (start-job 'improve test #:seed seed)))
+      (define result (job-wait (job-start 'improve test #:seed seed)))
       (match (hash-ref result 'status)
         ["success" (pretty-print (job-result->fpcore result) (current-output-port) 1)]
         ["failure"

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -44,7 +44,7 @@
   (server-start threads)
   (define ids
     (for/list ([test (in-list tests)])
-      (job-start 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline-disabled? #f)))
+      (job-start 'improve test #:seed seed #:pcontext #f #:profile? #f #:timeline? #f)))
   (define results
     (for/list ([id ids])
       (job-wait id)))

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -57,7 +57,7 @@
 
 (define (run-shell)
   (define seed (get-seed))
-  (start-job-server #f)
+  (server-start #f)
   (eprintf "Find help on https://herbie.uwplse.org/, exit with ~a\n"
            (match (system-type 'os)
              ['windows "Ctrl-Z Enter"]


### PR DESCRIPTION
This PR reorganizes and renames server.rkt methods, and maybe cleans up some of the control flow a bit.