### PR TITLE
Soundness in rules

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -136,7 +136,7 @@
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph
-(define *node-limit* (make-parameter 8000))
+(define *node-limit* (make-parameter 4000))
 (define *proof-max-length* (make-parameter 200))
 (define *proof-max-string-length* (make-parameter 10000))
 

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -578,15 +578,9 @@
               (get-representation 'bool)
               'bool))
         (list 'if (lookup cond cond-type) (lookup ift type) (lookup iff type))]
-       [(and (string-contains? (~a f) "special") (equal? (u32vector-length ids) 1))
-        (define a (u32vector-ref ids 0))
+       [(string-contains? (~a f) "special")
         (define op (string->symbol (string-replace (symbol->string f) "special-" "")))
-        (list op (lookup a 'real))]
-       [(and (string-contains? (~a f) "special") (equal? (u32vector-length ids) 2))
-        (define a (u32vector-ref ids 0))
-        (define b (u32vector-ref ids 1))
-        (define op (string->symbol (string-replace (symbol->string f) "special-" "")))
-        (list op (lookup a 'real) (lookup b 'real))]
+        (list* op (map (λ (x) (lookup (u32vector-ref ids x) 'real)) (range (u32vector-length ids))))]
        [else
         (define itypes
           (if (impl-exists? f)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -316,6 +316,27 @@
            (list 'if (loop cond (get-representation 'bool)) (loop ift type) (loop iff type))
            (list 'if (loop cond 'bool) (loop ift type) (loop iff type)))]
       [(list (? impl-exists? impl) args ...) (cons impl (map loop args (impl-info impl 'itype)))]
+      [(list (or 'special-sqrt
+                 'special-log
+                 'special-exp
+                 'special-pow
+                 'special-+
+                 'special--
+                 'special-/
+                 'special-*
+                 'special-tan
+                 'special-atan
+                 'special-cos
+                 'special-cosh
+                 'special-sin
+                 'special-neg
+                 'special-sinh
+                 'special-acosh
+                 'special-asinh
+                 'special-tanh)
+             args ...)
+       (define op (string->symbol (string-replace (symbol->string (car expr)) "special-" "")))
+       (cons op (map loop args (map (const 'real) args)))]
       [(list op args ...) (cons op (map loop args (operator-info op 'itype)))])))
 
 ;; Parses a string from egg into a single S-expr.
@@ -551,6 +572,25 @@
      (cond
        [(eq? f '$approx) (platform-reprs (*active-platform*))]
        [(eq? f 'if) (all-reprs/types)]
+       [(or (eq? f 'special-tan)
+            (eq? f 'special-atan)
+            (eq? f 'special-cos)
+            (eq? f 'special-cosh)
+            (eq? f 'special-sin)
+            (eq? f 'special-neg)
+            (eq? f 'special-sinh)
+            (eq? f 'special-acosh)
+            (eq? f 'special-asinh)
+            (eq? f 'special-tanh)
+            (eq? f 'special-sqrt)
+            (eq? f 'special-log)
+            (eq? f 'special-exp)
+            (eq? f 'special-pow)
+            (eq? f 'special-+)
+            (eq? f 'special--)
+            (eq? f 'special-/)
+            (eq? f 'special-*))
+        (list 'real)]
        [(impl-exists? f) (list (impl-info f 'otype))]
        [else (list (operator-info f 'otype))])]))
 
@@ -574,6 +614,31 @@
               (get-representation 'bool)
               'bool))
         (list 'if (lookup cond cond-type) (lookup ift type) (lookup iff type))]
+       [(or (eq? f 'special-atan)
+            (eq? f 'special-tan)
+            (eq? f 'special-cos)
+            (eq? f 'special-cosh)
+            (eq? f 'special-sin)
+            (eq? f 'special-neg)
+            (eq? f 'special-sinh)
+            (eq? f 'special-acosh)
+            (eq? f 'special-asinh)
+            (eq? f 'special-tanh)
+            (eq? f 'special-sqrt)
+            (eq? f 'special-log)
+            (eq? f 'special-exp))
+        (define a (u32vector-ref ids 0))
+        (define op (string->symbol (string-replace (symbol->string f) "special-" "")))
+        (list op (lookup a 'real))]
+       [(or (eq? f 'special-pow)
+            (eq? f 'special-+)
+            (eq? f 'special--)
+            (eq? f 'special-/)
+            (eq? f 'special-*))
+        (define a (u32vector-ref ids 0))
+        (define b (u32vector-ref ids 1))
+        (define op (string->symbol (string-replace (symbol->string f) "special-" "")))
+        (list op (lookup a 'real) (lookup b 'real))]
        [else
         (define itypes
           (if (impl-exists? f)

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1229,7 +1229,6 @@
     (timeline-push! 'stop (~a (egraph-stop-reason egg-graph)) 1)
     (cond
       [(egraph-is-unsound-detected egg-graph)
-       (println "unsound")
        ; unsoundness means run again with less iterations
        (define num-iters (length iteration-data))
        (if (<= num-iters 1) ; nothing to fall back on

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -316,8 +316,8 @@
            (list 'if (loop cond (get-representation 'bool)) (loop ift type) (loop iff type))
            (list 'if (loop cond 'bool) (loop ift type) (loop iff type)))]
       [(list (? impl-exists? impl) args ...) (cons impl (map loop args (impl-info impl 'itype)))]
-      [(list (? (λ (x) (string-contains? (~a x) "special")) op) args ...)
-       (define op* (string->symbol (string-replace (symbol->string (car expr)) "special-" "")))
+      [(list (? (λ (x) (string-contains? (~a x) "unsound")) op) args ...)
+       (define op* (string->symbol (string-replace (symbol->string (car expr)) "unsound-" "")))
        (cons op* (map loop args (map (const 'real) args)))]
       [(list op args ...) (cons op (map loop args (operator-info op 'itype)))])))
 
@@ -554,7 +554,7 @@
      (cond
        [(eq? f '$approx) (platform-reprs (*active-platform*))]
        [(eq? f 'if) (all-reprs/types)]
-       [(string-contains? (~a f) "special") (list 'real)]
+       [(string-contains? (~a f) "unsound") (list 'real)]
        [(impl-exists? f) (list (impl-info f 'otype))]
        [else (list (operator-info f 'otype))])]))
 
@@ -578,8 +578,8 @@
               (get-representation 'bool)
               'bool))
         (list 'if (lookup cond cond-type) (lookup ift type) (lookup iff type))]
-       [(string-contains? (~a f) "special")
-        (define op (string->symbol (string-replace (symbol->string f) "special-" "")))
+       [(string-contains? (~a f) "unsound")
+        (define op (string->symbol (string-replace (symbol->string f) "unsound-" "")))
         (list* op (map (λ (x) (lookup (u32vector-ref ids x) 'real)) (range (u32vector-length ids))))]
        [else
         (define itypes

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -8,7 +8,8 @@
          "../config.rkt"
          "../syntax/load-plugin.rkt"
          "batch.rkt"
-         "egglog-program.rkt")
+         "egglog-program.rkt"
+         "../utils/common.rkt")
 
 (provide (struct-out egglog-runner)
          prelude
@@ -128,7 +129,8 @@
 ;; Runs egglog using an egglog runner by extracting multiple variants
 (define (run-egglog-multi-extractor runner output-batch) ; multi expression extraction
 
-  (define insert-batch (batch-remove-zombie (egglog-runner-batch runner)))
+  (define insert-batch
+    (batch-remove-zombie (egglog-runner-batch runner) (egglog-runner-roots runner)))
   (define curr-program (make-egglog-program))
 
   ;; 1. Add the Prelude
@@ -370,14 +372,24 @@
     (rewrite (Round (Num x)) (Num (round x)) :ruleset const-fold)))
 
 (define (platform-spec-nodes)
-  (for/list ([op (in-list (all-operators))])
-    (hash-set! (id->e1) op (serialize-op op))
-    (hash-set! (e1->id) (serialize-op op) op)
-    (define arity (length (operator-info op 'itype)))
-    `(,(serialize-op op) ,@(for/list ([i (in-range arity)])
-                             'M)
-                         :cost
-                         4294967295)))
+  (append* (for/list ([op (in-list (all-operators))])
+             (hash-set! (id->e1) op (serialize-op op))
+             (hash-set! (e1->id) (serialize-op op) op)
+
+             ; Unsound versions of operations
+             (define unsound-op (sym-append "unsound-" op))
+             (hash-set! (id->e1) unsound-op (serialize-op unsound-op))
+             (hash-set! (e1->id) (serialize-op unsound-op) unsound-op)
+
+             (define arity (length (operator-info op 'itype)))
+             (list `(,(serialize-op op) ,@(for/list ([i (in-range arity)])
+                                            'M)
+                                        :cost
+                                        4294967295)
+                   `(,(serialize-op unsound-op) ,@(for/list ([i (in-range arity)])
+                                                    'M)
+                                                :cost
+                                                4294967295)))))
 
 (define (platform-impl-nodes pform min-cost)
   (for/list ([impl (in-list (platform-impls pform))])

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -112,7 +112,7 @@
   ; egg schedule (3-phases for mathematical rewrites and implementation selection)
   (define schedule
     `((lift . ((iteration . 1) (scheduler . simple))) (,rules . ((node . ,(*node-limit*))))
-                                                      (lower . ((iteration . 2) (scheduler .
+                                                      (lower . ((iteration . 1) (scheduler .
                                                                                            simple)))))
 
   ; run egg

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -112,7 +112,7 @@
   ; egg schedule (3-phases for mathematical rewrites and implementation selection)
   (define schedule
     `((lift . ((iteration . 1) (scheduler . simple))) (,rules . ((node . ,(*node-limit*))))
-                                                      (lower . ((iteration . 1) (scheduler .
+                                                      (lower . ((iteration . 2) (scheduler .
                                                                                            simple)))))
 
   ; run egg

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -106,8 +106,6 @@
 
   ; generate required rules
   (define rules (*rules*))
-  (define lifting-rules (platform-lifting-rules))
-  (define lowering-rules (platform-lowering-rules))
 
   ; egg schedule (3-phases for mathematical rewrites and implementation selection)
   (define schedule

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -8,7 +8,8 @@
 
 (provide *rules*
          *sound-rules*
-         (struct-out rule))
+         (struct-out rule)
+         add-unsound)
 
 ;; A rule represents "find-and-replacing" `input` by `output`. Both
 ;; are patterns, meaning that symbols represent pattern variables.
@@ -36,11 +37,9 @@
 (define (make-rule-context input output)
   (map (curryr cons 'real) (set-union (free-variables input) (free-variables output))))
 
-(define (add-special expr)
+(define (add-unsound expr)
   (match expr
-    [(list op args ...)
-     (define op* (string->symbol (string-append "special-" (symbol->string op))))
-     (cons op* (map add-special args))]
+    [(list op args ...) (cons (sym-append "unsound-" op) (map add-unsound args))]
     [_ expr]))
 
 (define-syntax define-rule
@@ -53,7 +52,7 @@
      (set!
       *all-rules*
       (cons
-       (rule 'rname 'input (add-special 'output) (make-rule-context 'input 'output) 'real '(group))
+       (rule 'rname 'input (add-unsound 'output) (make-rule-context 'input 'output) 'real '(group))
        *all-rules*))]))
 
 (define-syntax-rule (define-rules group

--- a/src/core/rules.rkt
+++ b/src/core/rules.rkt
@@ -158,14 +158,14 @@
 (define-rules arithmetic
   [mult-flip (/ a b) (* a (/ 1 b))]
   [mult-flip-rev (* a (/ 1 b)) (/ a b)]
-  [div-flip (/ a b) (/ 1 (/ b a)) #:unsound] ; unsound @ a = 0, b != 0
+  [div-flip (/ a b) (/ 1 (special-/ b a)) #:unsound] ; unsound @ a = 0, b != 0
   [div-flip-rev (/ 1 (/ b a)) (/ a b)])
 
 ; Fractions
 (define-rules arithmetic
-  [sum-to-mult (+ a b) (* (+ 1 (/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
+  [sum-to-mult (+ a b) (* (+ 1 (special-/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
   [sum-to-mult-rev (* (+ 1 (/ b a)) a) (+ a b)]
-  [sub-to-mult (- a b) (* (- 1 (/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
+  [sub-to-mult (- a b) (special-* (- 1 (special-/ b a)) a) #:unsound] ; unsound @ a = 0, b = 1
   [sub-to-mult-rev (* (- 1 (/ b a)) a) (- a b)]
   [add-to-fraction (+ c (/ b a)) (/ (+ (* c a) b) a)]
   [add-to-fraction-rev (/ (+ (* c a) b) a) (+ c (/ b a))]
@@ -174,9 +174,12 @@
   [common-denominator (+ (/ a b) (/ c d)) (/ (+ (* a d) (* c b)) (* b d))])
 
 (define-rules polynomials
-  [sqr-pow (pow a b) (* (pow a (/ b 2)) (pow a (/ b 2))) #:unsound] ; unsound @ a = -1, b = 1
-  [flip-+ (+ a b) (/ (- (* a a) (* b b)) (- a b)) #:unsound] ; unsound @ a = b = 1
-  [flip-- (- a b) (/ (- (* a a) (* b b)) (+ a b)) #:unsound]) ; unsound @ a = -1, b = 1
+  [sqr-pow
+   (pow a b)
+   (* (special-pow a (/ b 2)) (special-pow a (/ b 2)))
+   #:unsound] ; unsound @ a = -1, b = 1
+  [flip-+ (+ a b) (special-/ (- (* a a) (* b b)) (- a b)) #:unsound] ; unsound @ a = b = 1
+  [flip-- (- a b) (special-/ (- (* a a) (* b b)) (+ a b)) #:unsound]) ; unsound @ a = -1, b = 1
 
 ; Difference of cubes
 (define-rules polynomials
@@ -186,8 +189,8 @@
   [sum-cubes-rev (* (+ (* a a) (- (* b b) (* a b))) (+ a b)) (+ (pow a 3) (pow b 3))])
 
 (define-rules polynomials ; unsound @ a = b = 0
-  [flip3-+ (+ a b) (/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b)))) #:unsound]
-  [flip3-- (- a b) (/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b)))) #:unsound])
+  [flip3-+ (+ a b) (special-/ (+ (pow a 3) (pow b 3)) (+ (* a a) (- (* b b) (* a b)))) #:unsound]
+  [flip3-- (- a b) (special-/ (- (pow a 3) (pow b 3)) (+ (* a a) (+ (* b b) (* a b)))) #:unsound])
 
 ; Dealing with fractions
 (define-rules fractions
@@ -240,9 +243,12 @@
   [sqrt-undiv (/ (sqrt x) (sqrt y)) (sqrt (/ x y))])
 
 (define-rules arithmetic
-  [sqrt-prod (sqrt (* x y)) (* (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
-  [sqrt-div (sqrt (/ x y)) (/ (sqrt x) (sqrt y)) #:unsound] ; unsound @ x = y = -1
-  [add-sqr-sqrt x (* (sqrt x) (sqrt x)) #:unsound]) ; unsound @ x = -1
+  [sqrt-prod (sqrt (* x y)) (* (special-sqrt x) (special-sqrt y)) #:unsound] ; unsound @ x = y = -1
+  [sqrt-div
+   (sqrt (/ x y))
+   (special-/ (special-sqrt x) (special-sqrt y))
+   #:unsound] ; unsound @ x = y = -1
+  [add-sqr-sqrt x (* (special-sqrt x) (special-sqrt x)) #:unsound]) ; unsound @ x = -1
 
 ; Cubing
 (define-rules arithmetic
@@ -279,7 +285,7 @@
 ; Exponentials
 (define-rules exponents
   [add-log-exp x (log (exp x))]
-  [add-exp-log x (exp (log x)) #:unsound] ; unsound @ x = 0
+  [add-exp-log x (exp (special-log x)) #:unsound] ; unsound @ x = 0
   [rem-exp-log (exp (log x)) x]
   [rem-log-exp (log (exp x)) x])
 
@@ -338,14 +344,23 @@
   [pow-div (/ (pow a b) (pow a c)) (pow a (- b c))])
 
 (define-rules exponents
-  [pow-plus-rev (pow a (+ b 1)) (* (pow a b) a) #:unsound] ; unsound @ a = 0, b = -1/2
-  [pow-neg (pow a (neg b)) (/ 1 (pow a b)) #:unsound]) ; unsound @ a = 0, b = -1
+  [pow-plus-rev (pow a (+ b 1)) (special-* (special-pow a b) a) #:unsound] ; unsound @ a = 0, b = -1/2
+  [pow-neg (pow a (neg b)) (special-/ 1 (pow a b)) #:unsound]) ; unsound @ a = 0, b = -1
 
 (define-rules exponents
-  [pow-to-exp (pow a b) (exp (* (log a) b)) #:unsound] ; unsound @ a = -1, b = 1
-  [pow-add (pow a (+ b c)) (* (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
-  [pow-sub (pow a (- b c)) (/ (pow a b) (pow a c)) #:unsound] ; unsound @ a = -1, b = c = 1/2
-  [unpow-prod-down (pow (* b c) a) (* (pow b a) (pow c a)) #:unsound]) ; unsound @ a = 1/2, b = c = -1
+  [pow-to-exp (pow a b) (exp (special-* (special-log a) b)) #:unsound] ; unsound @ a = -1, b = 1
+  [pow-add
+   (pow a (+ b c))
+   (* (special-pow a b) (special-pow a c))
+   #:unsound] ; unsound @ a = -1, b = c = 1/2
+  [pow-sub
+   (pow a (- b c))
+   (special-/ (special-pow a b) (special-pow a c))
+   #:unsound] ; unsound @ a = -1, b = c = 1/2
+  [unpow-prod-down
+   (pow (* b c) a)
+   (* (special-pow b a) (special-pow c a))
+   #:unsound]) ; unsound @ a = 1/2, b = c = -1
 
 ; Logarithms
 (define-rules exponents
@@ -354,9 +369,9 @@
   [log-pow-rev (* b (log a)) (log (pow a b))])
 
 (define-rules exponents
-  [log-prod (log (* a b)) (+ (log a) (log b)) #:unsound] ; unsound @ a = b = -1
-  [log-div (log (/ a b)) (- (log a) (log b)) #:unsound] ; unsound @ a = b = -1
-  [log-pow (log (pow a b)) (* b (log a)) #:unsound]) ; unsound @ a = -1, b = 2
+  [log-prod (log (* a b)) (+ (special-log a) (special-log b)) #:unsound] ; unsound @ a = b = -1
+  [log-div (log (/ a b)) (- (special-log a) (special-log b)) #:unsound] ; unsound @ a = b = -1
+  [log-pow (log (pow a b)) (special-* b (special-log a)) #:unsound]) ; unsound @ a = -1, b = 2
 
 (define-rules exponents
   [sum-log (+ (log a) (log b)) (log (* a b))]
@@ -396,7 +411,7 @@
   [asin-sin-rev (- (fabs (remainder (+ x (/ (PI) 2)) (* 2 (PI)))) (/ (PI) 2)) (asin (sin x))])
 
 (define-rules trigonometry
-  [atan-tan-rev (remainder x (PI)) (atan (tan x)) #:unsound]) ; unsound @ x = pi/2
+  [atan-tan-rev (remainder x (PI)) (special-atan (tan x)) #:unsound]) ; unsound @ x = pi/2
 
 (define-rules trigonometry
   [cos-sin-sum (+ (* (cos a) (cos a)) (* (sin a) (sin a))) 1]
@@ -445,10 +460,13 @@
   [tan-+PI/2-rev (/ 1 (tan x)) (tan (+ (neg x) (/ (PI) 2)))])
 
 (define-rules trigonometry
-  [neg-tan-+PI/2 (tan (+ x (/ (PI) 2))) (/ -1 (tan x)) #:unsound] ; unsound @ x = pi/2
-  [tan-+PI/2 (tan (+ (neg x) (/ (PI) 2))) (/ 1 (tan x)) #:unsound] ; unsound @ x = pi/2
-  [hang-m0-tan-rev (tan (/ (neg a) 2)) (/ (- 1 (cos a)) (neg (sin a))) #:unsound] ; unsound @ a = 0
-  [hang-p0-tan-rev (tan (/ a 2)) (/ (- 1 (cos a)) (sin a)) #:unsound]) ; unsound @ a = 0
+  [neg-tan-+PI/2 (tan (+ x (/ (PI) 2))) (special-/ -1 (tan x)) #:unsound] ; unsound @ x = pi/2
+  [tan-+PI/2 (tan (+ (neg x) (/ (PI) 2))) (special-/ 1 (tan x)) #:unsound] ; unsound @ x = pi/2
+  [hang-m0-tan-rev
+   (tan (/ (neg a) 2))
+   (special-/ (- 1 (cos a)) (neg (sin a)))
+   #:unsound] ; unsound @ a = 0
+  [hang-p0-tan-rev (tan (/ a 2)) (special-/ (- 1 (cos a)) (sin a)) #:unsound]) ; unsound @ a = 0
 
 (define-rules trigonometry
   [sin-sum (sin (+ x y)) (+ (* (sin x) (cos y)) (* (cos x) (sin y)))]
@@ -502,13 +520,13 @@
 
 (define-rules trigonometry
   ; unsound @ x = y = pi/2
-  [tan-sum (tan (+ x y)) (/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y)))) #:unsound]
+  [tan-sum (tan (+ x y)) (special-/ (+ (tan x) (tan y)) (- 1 (* (tan x) (tan y)))) #:unsound]
   ; unsound @ x = pi/2
-  [tan-2 (tan (* 2 x)) (/ (* 2 (tan x)) (- 1 (* (tan x) (tan x)))) #:unsound]
+  [tan-2 (tan (* 2 x)) (special-/ (* 2 (tan x)) (- 1 (* (tan x) (tan x)))) #:unsound]
   ; unsound @ a = pi/2 b = -pi/2
-  [tan-hang-p (tan (/ (+ a b) 2)) (/ (+ (sin a) (sin b)) (+ (cos a) (cos b))) #:unsound]
+  [tan-hang-p (tan (/ (+ a b) 2)) (special-/ (+ (sin a) (sin b)) (+ (cos a) (cos b))) #:unsound]
   ; unsound @ a = b = pi/2
-  [tan-hang-m (tan (/ (- a b) 2)) (/ (- (sin a) (sin b)) (+ (cos a) (cos b))) #:unsound])
+  [tan-hang-m (tan (/ (- a b) 2)) (special-/ (- (sin a) (sin b)) (+ (cos a) (cos b))) #:unsound])
 
 (define-rules trigonometry
   [cos-asin (cos (asin x)) (sqrt (- 1 (* x x)))]
@@ -631,7 +649,7 @@
   [acosh-2-rev (* 2 (acosh x)) (acosh (- (* 2 (* x x)) 1))])
 
 (define-rules hyperbolic
-  [tanh-1/2* (tanh (/ x 2)) (/ (- (cosh x) 1) (sinh x)) #:unsound] ; unsound @ x = 0
-  [sinh-acosh-rev (sqrt (- (* x x) 1)) (sinh (acosh x)) #:unsound] ; unsound @ x = -1
-  [tanh-acosh-rev (/ (sqrt (- (* x x) 1)) x) (tanh (acosh x)) #:unsound] ; unsound @ x = -1
-  [acosh-2 (acosh (- (* 2 (* x x)) 1)) (* 2 (acosh x)) #:unsound]) ; unsound @ x = -1
+  [tanh-1/2* (tanh (/ x 2)) (special-/ (- (cosh x) 1) (sinh x)) #:unsound] ; unsound @ x = 0
+  [sinh-acosh-rev (sqrt (- (* x x) 1)) (special-sinh (special-acosh x)) #:unsound] ; unsound @ x = -1
+  [tanh-acosh-rev (/ (sqrt (- (* x x) 1)) x) (tanh (special-acosh x)) #:unsound] ; unsound @ x = -1
+  [acosh-2 (acosh (- (* 2 (* x x)) 1)) (* 2 (special-acosh x)) #:unsound]) ; unsound @ x = -1

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -358,13 +358,6 @@
   ; (cons approx-rule impl-rules))
   impl-rules)
 
-(define (add-special expr)
-  (match expr
-    [(list op args ...)
-     (define op* (string->symbol (string-append "special-" (symbol->string op))))
-     (cons op* (map add-special args))]
-    [_ expr]))
-
 ;; Synthesizes lowering rules for a given platform.
 (define (platform-lowering-rules [pform (*active-platform*)])
   (define impls (platform-impls pform))
@@ -378,8 +371,8 @@
                 (define itypes (map representation-type (impl-info impl 'itype)))
                 (define otype (representation-type (impl-info impl 'otype)))
                 (list (rule name spec-expr impl-expr (map cons vars itypes) otype '(lowering))
-                      (rule (sym-append 'lower-special- impl)
-                            (add-special spec-expr)
+                      (rule (sym-append 'lower-unsound- impl)
+                            (add-unsound spec-expr)
                             impl-expr
                             (map cons vars itypes)
                             otype

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -358,18 +358,32 @@
   ; (cons approx-rule impl-rules))
   impl-rules)
 
+(define (add-special expr)
+  (match expr
+    [(list op args ...)
+     (define op* (string->symbol (string-append "special-" (symbol->string op))))
+     (cons op* (map add-special args))]
+    [_ expr]))
+
 ;; Synthesizes lowering rules for a given platform.
 (define (platform-lowering-rules [pform (*active-platform*)])
   (define impls (platform-impls pform))
-  (for/list ([impl (in-list impls)])
-    (hash-ref! (*lowering-rules*)
-               (cons impl pform)
-               (lambda ()
-                 (define name (sym-append 'lower- impl))
-                 (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
-                 (define itypes (map representation-type (impl-info impl 'itype)))
-                 (define otype (representation-type (impl-info impl 'otype)))
-                 (rule name spec-expr impl-expr (map cons vars itypes) otype '(lowering))))))
+  (append* (for/list ([impl (in-list impls)])
+             (hash-ref!
+              (*lowering-rules*)
+              (cons impl pform)
+              (lambda ()
+                (define name (sym-append 'lower- impl))
+                (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
+                (define itypes (map representation-type (impl-info impl 'itype)))
+                (define otype (representation-type (impl-info impl 'otype)))
+                (list (rule name spec-expr impl-expr (map cons vars itypes) otype '(lowering))
+                      (rule (sym-append 'lower-special- impl)
+                            (add-special spec-expr)
+                            impl-expr
+                            (map cons vars itypes)
+                            otype
+                            '(lowering))))))))
 
 ;; Extracts the `fpcore` field of an operator implementation
 ;; as a property dictionary and expression.


### PR DESCRIPTION
This PR introduces soundness for egg rewrites.
The problem was: Herbie used a lot of unsound rules which leaded egg to stop early.
Previous work #1207 has discovered unsound rules which was a cause of early stopping.

This PR elaborates on unsound rules and special case RHS of these rules with "unsound-" prefix.
As a result, once an unsound rewrite is applied it won't be matched anymore on any other rules - therefore, unsoundness won't be reached inside egg.

Additionally, it has been discovered that without unsoundness, node limit can be decreased to 4000 nodes instead of 8000 nodes as it was before. The reasons are - the number of nodes that get extracted triples as we introduce soundness which becomes expensive when using egg. 4000 node limit seem to introduce a comparable performance with `main` - which we believe can become a new standard of Herbie.
The node limit can be increased in future to achieve better results as extraction becomes faster.