### PR TITLE
Run reports on main thread while other benchmarks run

### DIFF
--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -90,19 +90,13 @@
       (job-start 'improve test #:seed seed #:pcontext #f #:profile? #t #:timeline? #t)))
 
   (define total-tests (length tests))
-  (define job-results
+  (define results
     (for/list ([job-id (in-list job-ids)]
                [test (in-list tests)]
                [test-number (in-naturals)])
       (define result (job-wait job-id))
       (print-test-result (+ test-number 1) total-tests test result)
-      result))
-  (define results
-    (for/list ([job-id (in-list job-ids)]
-               [job-result (in-list job-results)]
-               [test (in-list tests)]
-               [test-number (in-naturals)])
-      (generate-bench-report job-result (test-name test) test-number dir (length tests))))
+      (generate-bench-report result (test-name test) test-number dir total-tests)))
 
   (define info (make-report-info results #:seed seed))
   (write-datafile (build-path dir "results.json") info)


### PR DESCRIPTION
This PR lets multithreaded reports by running benchmarks on the main thread while worker threads do benchmark runs. It should make nightlies slightly faster.