### PR TITLE
Drop invalid points from pareto curves

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -98,7 +98,7 @@
 (define (inject-candidate! expr)
   (define new-alts (list (make-alt expr)))
   (define-values (errss costs) (atab-eval-altns (^table^) new-alts (*context*)))
-  (^table^ (atab-add-altns (^table^) new-alts errss costs))
+  (^table^ (atab-add-altns (^table^) new-alts errss costs (*context*)))
   (void))
 
 ;; The rest of the file is various helper / glue functions used by
@@ -194,7 +194,7 @@
 
   (define-values (errss costs) (atab-eval-altns (^table^) new-alts (*context*)))
   (timeline-event! 'prune)
-  (^table^ (atab-add-altns (^table^) new-alts errss costs))
+  (^table^ (atab-add-altns (^table^) new-alts errss costs (*context*)))
   (define final-fresh-alts (atab-not-done-alts (^table^)))
   (define final-done-alts (set-subtract (atab-active-alts (^table^)) final-fresh-alts))
   (timeline-push! 'count


### PR DESCRIPTION
This PR fixes #1220. Basically, in a few rare cases we might construct an alt that is _invalid_ at a point and yet is still the cheapest alt at that point. So maybe you somehow create the alt `(sqrt.f64 #(literal -1 binary64))`. Then that is stuck in your alt table, because it's the cheapest (even though it's bad). And then that gets into later egraphs and messes them up.

So this PR just never puts invalid points in the egraph.