### PR TITLE
Refactor pcontext to embed context

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -439,7 +439,7 @@
                (unless (and (list? pt) (= (length pt) (length var-reprs)))
                  (error 'json->pcontext "Invalid point ~a" pt))
                (values (list->vector (map json->value pt var-reprs)) (json->value ex output-repr))))
-  (mk-pcontext pts exs))
+  (mk-pcontext pts exs ctx))
 
 (define (get-pcontext post-data)
   (define test (get-test post-data))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -72,7 +72,7 @@
   ;; compute error/cost for input expression
   (define start-expr (test-input test))
   (define start-alt (make-alt-preprocessing start-expr (test-preprocess test)))
-  (define start-errs (errors start-expr test-pcontext* (*context*)))
+  (define start-errs (errors start-expr test-pcontext*))
   (define start-alt-data (alt-analysis start-alt start-errs))
 
   ;; optionally compute error/cost for input expression
@@ -81,12 +81,12 @@
     (for/list ([(expr is-valid?) (in-dict (test-output test))]
                #:when is-valid?)
       (define target-expr (fpcore->prog expr (*context*)))
-      (define target-errs (errors target-expr test-pcontext* (*context*)))
+      (define target-errs (errors target-expr test-pcontext*))
       (alt-analysis (make-alt target-expr) target-errs)))
 
   ;; compute error/cost for output expression
   ;; and sort alternatives by accuracy + cost on testing subset
-  (define test-errs* (batch-errors (map alt-expr alternatives) test-pcontext* (*context*)))
+  (define test-errs* (batch-errors (map alt-expr alternatives) test-pcontext*))
   (define sorted-end-exprs (sort-alts alternatives test-errs*))
   (define end-exprs (map (compose alt-expr car) sorted-end-exprs))
   (define end-errs (map cdr sorted-end-exprs))
@@ -108,7 +108,7 @@
     (error 'get-errors "cannnot run without a pcontext"))
 
   (define-values (_ test-pcontext) (partition-pcontext pcontext))
-  (define errs (errors (test-input test) test-pcontext (*context*)))
+  (define errs (errors (test-input test) test-pcontext))
   (for/list ([(pt _) (in-pcontext test-pcontext)]
              [err (in-list errs)])
     (cons pt err)))
@@ -147,7 +147,7 @@
   (define sample
     (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
       (sample-points precondition (list specification) (list (*context*)))))
-  (apply mk-pcontext sample))
+  (apply mk-pcontext (append sample (list (*context*)))))
 
 ;;
 ;;  Public interface

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -402,7 +402,7 @@
                       (improve-result-target backend)
                       (improve-result-end backend))))
        (define exprs (append-map collect-expressions all-alts))
-       (make-hash (map cons exprs (batch-errors exprs pcontext ctx)))]
+       (make-hash (map cons exprs (batch-errors exprs pcontext)))]
       [else #f]))
 
   (define test-fpcore

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -51,7 +51,7 @@
 
 (define (make-alt-table pcontext initial-alt ctx)
   (define cost (alt-cost initial-alt (context-repr ctx)))
-  (define errs (errors (alt-expr initial-alt) pcontext ctx))
+  (define errs (errors (alt-expr initial-alt) pcontext))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-list errs)])
                (list (pareto-point cost err (list initial-alt))))
@@ -188,7 +188,7 @@
 
 (define (atab-eval-altns atab altns ctx)
   (define batch (progs->batch (map alt-expr altns) #:vars (context-vars ctx)))
-  (define errss (batch-errors batch (alt-table-pcontext atab) ctx))
+  (define errss (batch-errors batch (alt-table-pcontext atab)))
   (define costs (alt-batch-cost batch (context-repr ctx)))
   (values errss costs))
 

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -104,7 +104,7 @@
   (define (new-sampler)
     (values (vector-append (vector val) (random-ref pts)) #f))
   (define-values (results _) (batch-prepare-points evaluator new-sampler))
-  (apply mk-pcontext results))
+  (apply mk-pcontext (append results (list (pcontext-ctx pcontext)))))
 
 (define/reset *prepend-arguement-cache* (make-hash))
 (define (cache-get-prepend v expr macro)

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -106,7 +106,7 @@
 ;; and timeline data.
 
 (define (score-alt alt)
-  (errors-score (errors (alt-expr alt) (*pcontext*) (*context*))))
+  (errors-score (errors (alt-expr alt) (*pcontext*))))
 
 ; Pareto mode alt picking
 (define (choose-mult-alts altns)
@@ -253,7 +253,7 @@
      (add-derivations alts)]
     [else alts]))
 
-(define (sort-alts alts [errss (batch-errors (map alt-expr alts) (*pcontext*) (*context*))])
+(define (sort-alts alts [errss (batch-errors (map alt-expr alts) (*pcontext*))])
   ;; sort everything by error + cost
   (define repr (context-repr (*context*)))
   (define alts-to-be-sorted (map cons alts errss))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -27,7 +27,7 @@
 
 (define (pareto-regimes sorted ctx)
   (timeline-event! 'regimes)
-  (define err-lsts (batch-errors (map alt-expr sorted) (*pcontext*) ctx))
+  (define err-lsts (batch-errors (map alt-expr sorted) (*pcontext*)))
   (define branches
     (if (null? sorted)
         '()
@@ -152,7 +152,7 @@
 (module+ test
   (define ctx (make-debug-context '(x)))
   (parameterize ([*start-prog* (literal 1 'binary64)]
-                 [*pcontext* (mk-pcontext '(#(0.5) #(4.0)) '(1.0 1.0))])
+                 [*pcontext* (mk-pcontext '(#(0.5) #(4.0)) '(1.0 1.0) ctx)])
     (define alts (map make-alt (list '(fmin.f64 x 1) '(fmax.f64 x 1))))
     (define err-lsts `((,(expt 2.0 53) 1.0) (1.0 ,(expt 2.0 53))))
 


### PR DESCRIPTION
## Summary
- store the `context` inside `pcontext`
- default to the embedded context in `errors` and `batch-errors`
- update sampling and json helpers to construct `pcontext` with a context
- use embedded context in various callers so only the pcontext is needed

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp` *(fails: CRASH)*
- `raco test src/` *(fails: egglog executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f551cf7c8331868cf32cac1b4167