### PR TITLE
Skip egglog tests if egglog not found

### DIFF
--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -296,10 +296,11 @@
            "../syntax/load-plugin.rkt"
            "egglog-herbie.rkt")
 
-  (load-herbie-builtins)
-  (populate-e->id-tables)
-  (test-e1->expr)
-  (test-e2->expr))
+  (when (find-executable-path "egglog")
+    (load-herbie-builtins)
+    (populate-e->id-tables)
+    (test-e1->expr)
+    (test-e2->expr)))
 
 ;; run-sample-egglog
 (module+ test
@@ -374,4 +375,5 @@
       (,rules . ((node . ,(*node-limit*)) (scheduler . simple)))
       (lower . ((iteration . 1) (scheduler . simple)))))
 
-  (run-egglog-multi-extractor (egglog-runner batch roots reprs schedule ctx) batch))
+  (when (find-executable-path "egglog")
+    (run-egglog-multi-extractor (egglog-runner batch roots reprs schedule ctx) batch)))


### PR DESCRIPTION
This PR changes the egglog tests to only run if egglog is installed. We don't require it yet, so it'd be good for tests to pass without.

https://chatgpt.com/codex/tasks/task_e_6847113af4e083318545417db3d65ad8