### PR TITLE
Simplify job count

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -88,8 +88,7 @@
   (manager-ask 'improve))
 
 (define (server-count)
-  (define job-list (manager-ask 'count))
-  (apply + job-list))
+  (manager-ask 'count))
 
 (define (server-up?)
   (match manager
@@ -126,7 +125,7 @@
     [(list 'result job-id) (hash-ref completed-jobs job-id #f)]
     [(list 'timeline job-id) (hash-ref completed-jobs job-id #f)]
     [(list 'check job-id) (and (hash-ref completed-jobs job-id #f) job-id)]
-    [(list 'count) (list 0 0)]
+    [(list 'count) 0]
     [(list 'improve)
      (for/list ([(job-id result) (in-hash completed-jobs)]
                 #:when (equal? (hash-ref result 'command) "improve"))
@@ -252,9 +251,9 @@
         (place-channel-put handler (and (hash-has-key? completed-jobs job-id) job-id))]
        ; Returns the current count of working workers.
        [(list 'count handler)
-        (define counts (list (hash-count busy-workers) (hash-count queued-jobs)))
-        (log "Currently ~a jobs in progress, ~a jobs in queue.\n" (first counts) (second counts))
-        (place-channel-put handler counts)]
+        (define total (+ (hash-count busy-workers) (hash-count queued-jobs)))
+        (log "Currently ~a jobs total.\n" total)
+        (place-channel-put handler total)]
        ; Retreive the improve results for results.json
        [(list 'improve handler)
         (define improved-list


### PR DESCRIPTION
## Summary
- streamline job count to return totals directly
- log total job count in the threaded manager

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`
- `raco test src/` *(fails: egglog executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477806533c833188ef7327e1216ef3