### PR TITLE
Fix the server in "no-threads" mode

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -119,13 +119,24 @@
      (hash-set! queued-jobs job-id job)
      job-id]
     [(list 'wait 'basic job-id)
-     (define command (hash-ref queued-jobs job-id))
-     (define result (herbie-do-server-job command job-id))
-     (hash-set! completed-jobs job-id result)
+     (define command (hash-ref queued-jobs job-id #f))
+     (define result (and command (herbie-do-server-job command job-id)))
+     (when command
+       (hash-set! completed-jobs job-id result))
      result]
     [(list 'result job-id) (hash-ref completed-jobs job-id #f)]
-    [(list 'timeline job-id) (hash-ref completed-jobs job-id #f)]
-    [(list 'check job-id) (and (hash-ref completed-jobs job-id #f) job-id)]
+    [(list 'timeline job-id)
+     (define command (hash-ref queued-jobs job-id #f))
+     (define result (and command (herbie-do-server-job command job-id)))
+     (when command
+       (hash-set! completed-jobs job-id result))
+     result]
+    [(list 'check job-id)
+     (define command (hash-ref queued-jobs job-id #f))
+     (define result (and command (herbie-do-server-job command job-id)))
+     (when command
+       (hash-set! completed-jobs job-id result))
+     job-id]
     [(list 'count) (list 0 0)]
     [(list 'improve)
      (for/list ([(job-id result) (in-hash completed-jobs)]


### PR DESCRIPTION
In "no-threads" mode (the default!) the normal Herbie server doesn't work. That's because the normal Herbie server was only actually _doing_ the work when you asked for the results; if you asked it the status it would always say "job in progress". But that lead to a kind of livelock, where the web server was constantly asking "are you done yet" and then Herbie was saying "nope, still in progress". The fix is easy: also do the job if someone asks for its status, which (annoyingly) there are several ways to do.