### PR TITLE
Evaluate real constants with the exception crash fixed

### DIFF
--- a/bench/mathematics/xkcd-expr.fpcore
+++ b/bench/mathematics/xkcd-expr.fpcore
@@ -1,0 +1,4 @@
+(FPCore ()
+  :name "xkcd217 (a numerical coincidence)"
+  :precision binary64
+  (- 20 (- (exp PI) PI)))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -8,7 +8,7 @@
   #hash([precision . (double fallback)]
         [setup . (simplify search)]
         [localize . (costs errors)]
-        [generate . (rr taylor simplify better-rr proofs egglog)]
+        [generate . (rr taylor simplify better-rr proofs egglog evaluate)]
         [reduce . (regimes avg-error binary-search branch-expressions simplify)]
         [rules
          . (arithmetic polynomials
@@ -26,7 +26,7 @@
   #hash([precision . ()]
         [setup . (search)]
         [localize . ()]
-        [generate . (rr taylor proofs)]
+        [generate . (rr taylor proofs evaluate)]
         [reduce . (regimes binary-search branch-expressions)]
         [rules
          . (arithmetic polynomials

--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -118,8 +118,7 @@
         [node (in-vector (batch-nodes batch))])
     (define fv
       (cond
-        [(symbol? node)
-         (set node)]
+        [(symbol? node) (set node)]
         [else
          (define arg-free-vars (mutable-set))
          (expr-recurse node (lambda (i) (set-union! arg-free-vars (vector-ref out i))))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -160,6 +160,7 @@
         [_
          (define event*
            (match event
+             [(list 'evaluate) (list 'evaluate loc0)]
              [(list 'taylor name var) (list 'taylor loc0 name var)]
              [(list 'rr input proof) (list 'rr loc0 input proof)]))
          (define expr* (location-set loc0 (alt-expr orig) (debatchref (alt-expr altn))))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -104,7 +104,7 @@
   (define free-vars (batch-free-vars global-batch))
   (define real-altns
     (for/list ([altn (in-list altns)]
-               #:when (set-empty? (vector-ref free-vars (batchref-idx (alt-expr  altn)))))
+               #:when (set-empty? (vector-ref free-vars (batchref-idx (alt-expr altn)))))
       altn))
   (define roots
     (for/vector ([altn (in-list real-altns)])
@@ -115,8 +115,7 @@
   (define batch* (batch-remove-zombie global-batch roots))
   (define specs (map prog->spec (batch->progs batch*)))
   (timeline-push! 'inputs (map ~a specs))
-  (define real-compiler
-    (make-real-compiler specs contexts))
+  (define real-compiler (make-real-compiler specs contexts))
   (define-values (status pts) (real-apply real-compiler (vector)))
   (define literals
     (for/list ([pt (in-list pts)]
@@ -190,7 +189,7 @@
   (define start-altns
     (for/list ([root (in-vector (batch-roots global-batch))])
       (alt (batchref global-batch root) 'patch '() '())))
-  
+
   (define evaluations
     (if (flag-set? 'generate 'evaluate)
         (run-evaluate start-altns global-batch)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -121,7 +121,7 @@
         (let ([real-compiler (make-real-compiler specs contexts)])
           (real-apply real-compiler (vector)))))
   (define literals
-    (for/list ([pt (in-list pts)]
+    (for/list ([pt (in-list (if (equal? status 'valid) pts '()))]
                [ctx (in-list contexts)]
                #:when (equal? status 'valid))
       (define repr (context-repr ctx))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -121,7 +121,9 @@
         (let ([real-compiler (make-real-compiler specs contexts)])
           (real-apply real-compiler (vector)))))
   (define literals
-    (for/list ([pt (in-list (if (equal? status 'valid) pts '()))]
+    (for/list ([pt (in-list (if (equal? status 'valid)
+                                pts
+                                '()))]
                [ctx (in-list contexts)]
                #:when (equal? status 'valid))
       (define repr (context-repr ctx))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -105,6 +105,7 @@
           (match altn
             [(alt prog 'start (list) _) (void)]
             [(alt prog 'add-preprocessing `(,prev) _) (loop prev)]
+            [(alt prog `(evaluate ,loc) `(,prev) _) (loop prev)]
             [(alt _ `(regimes ,splitpoints) prevs _) (for-each loop prevs)]
             [(alt prog `(taylor ,loc ,pt ,var) `(,prev) _) (loop prev)]
             [(alt prog `(rr ,loc ,input ,proof) `(,prev) _)
@@ -158,6 +159,16 @@
      (define core (mixed->fpcore prog ctx))
      `(,@(render-history prev pcontext ctx errcache mask)
        (li (p "Taylor expanded in " ,(~a var) " around " ,(~a pt))
+           (div ((class "math"))
+                "\\[\\leadsto "
+                ,(core->tex core #:loc (and loc (cons 2 loc)) #:color "blue")
+                "\\]")))]
+
+    [(alt prog `(evaluate ,loc) `(,prev) _)
+     (define core (mixed->fpcore prog ctx))
+     (define err (altn-errors altn pcontext ctx errcache mask))
+     `(,@(render-history prev pcontext ctx errcache mask)
+       (li (p "Evaluated real constant" (span ((class "error")) ,err))
            (div ((class "math"))
                 "\\[\\leadsto "
                 ,(core->tex core #:loc (and loc (cons 2 loc)) #:color "blue")
@@ -241,6 +252,13 @@
             (prev . ,(render-json prev pcontext ctx errcache mask))
             (pt . ,(~a pt))
             (var . ,(~a var))
+            (loc . ,loc)
+            (error . ,err))]
+
+    [(alt prog `(evaluate ,loc) `(,prev) _)
+     `#hash((program . ,(fpcore->string (expr->fpcore prog ctx)))
+            (type . "evaluate")
+            (prev . ,(render-json prev pcontext ctx errcache mask))
             (loc . ,loc)
             (error . ,err))]
 


### PR DESCRIPTION
A version of the evaluate real constants branch, but the error in the exception handler that was causing Herbie not to work is fixed