### PR TITLE
Fix warnings field handling

### DIFF
--- a/src/api/datafile.rkt
+++ b/src/api/datafile.rkt
@@ -136,7 +136,7 @@
                                 (end . ,end-bits)
                                 (target . ,target-bits)
                                 (vars . ,(and vars (map symbol->string vars)))
-                                (warnings . ,(map ~s warnings))
+                                (warnings . ,warnings)
                                 (input . ,(~s input))
                                 (output . ,(~s output))
                                 (spec . ,(~s spec))
@@ -215,7 +215,7 @@
                                     (parse-string cs)
                                     (map (curry map parse-string) cs)))
                               vars
-                              (map string->symbol (hash-ref test 'warnings '()))
+                              (hash-ref test 'warnings '())
                               (parse-string (get 'input))
                               (parse-string (get 'output))
                               (parse-string (hash-ref test 'spec "#f"))


### PR DESCRIPTION
Herbie's datafile writer was still escaping warnings with `~s` and the reader converted them back using `string->symbol`. Since warnings are already strings this produced extra quoting such as `|"foo"|`. This patch keeps warnings as plain strings on write and read.

https://chatgpt.com/codex/tasks/task_e_684a2e1ecd9c83319806979c52f3127f