### PR TITLE
Refactor dropdown creation

### DIFF
--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -156,6 +156,20 @@ function toTitleCase(str) {
     )
 }
 
+function createDropdown(options, selected, placeholder, onChange) {
+    const select = Element("select", [
+        Element("option", { value: "", selected: !selected }, [placeholder]),
+        options.map((opt) =>
+            Element("option", { value: opt, selected: selected == opt }, [opt])
+        ),
+    ]);
+    select.addEventListener("input", () => {
+        onChange(select.value ?? "");
+        update();
+    });
+    return select;
+}
+
 // Based on https://observablehq.com/@fil/plot-onclick-experimental-plugin
 // However, simplified because we don't need hit box data
 function on(mark, listeners = {}) {
@@ -641,25 +655,19 @@ function buildFilterControls(jsonData) {
         filterButtons.push(button)
     }
 
-    const dropDown = Element("select", [
-        Element("option", { value: "", selected: !filterBySuite }, ["Filter by suite"]),
-        allSuites.map((suite, i) => 
-            Element("option", { value: suite, selected: filterBySuite == suite }, [toTitleCase(suite)]))
-    ]);
-    dropDown.addEventListener("input", (e) => {
-        filterBySuite = dropDown.value ?? "";
-        update();
-    });
+    const dropDown = createDropdown(
+        allSuites,
+        filterBySuite,
+        "Filter by suite",
+        (value) => { filterBySuite = value; },
+    );
 
-    const dropDown2 = Element("select", [
-        Element("option", { value: "", selected: !filterByWarning }, ["Filter to warning"]),
-        allWarnings.map((name) => 
-            Element("option", { value: name, selected: filterByWarning == name }, [name]))
-    ]);
-    dropDown2.addEventListener("input", (e) => {
-        filterByWarning = dropDown2.value ?? "";
-        update();
-    });
+    const dropDown2 = createDropdown(
+        allWarnings,
+        filterByWarning,
+        "Filter to warning",
+        (value) => { filterByWarning = value; },
+    );
 
     let groupButtons = [];
     for (let i in filterGroupState) {


### PR DESCRIPTION
## Summary
- simplify dropdown helper and update event
- use helper for suite and warning filters without title casing

## Testing
- `racket src/main.rkt report bench/tutorial.fpcore tmp`
- `raco test src/` *(fails: 2/25707 test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6844c3491f54833186dab8fadbde2924