### PR TITLE
Update all of the JS libraries we use to the latest `jsdelivr` version

### DIFF
--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -398,13 +398,15 @@
       "?"))
 
 (define js-tex-include
-  '((link ([rel "stylesheet"]
-           [href "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css"]
-           [integrity "sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH"]
-           [crossorigin "anonymous"]))
-    (script ([src "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js"]
-             [integrity "sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm"]
-             [crossorigin "anonymous"]))
-    (script ([src "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js"]
-             [integrity "sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH"]
-             [crossorigin "anonymous"]))))
+   '((link ([rel "stylesheet"]
+            [href "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"]
+            [integrity "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"]
+            [crossorigin "anonymous"]))
+     (script ([defer ""]
+              [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"]
+              [integrity "sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6"]
+              [crossorigin "anonymous"]))
+     (script ([defer ""]
+              [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"]
+              [integrity "sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh"]
+              [crossorigin "anonymous"]))))

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -398,15 +398,15 @@
       "?"))
 
 (define js-tex-include
-   '((link ([rel "stylesheet"]
-            [href "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"]
-            [integrity "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"]
-            [crossorigin "anonymous"]))
-     (script ([defer ""]
-              [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"]
-              [integrity "sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6"]
-              [crossorigin "anonymous"]))
-     (script ([defer ""]
-              [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"]
-              [integrity "sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh"]
-              [crossorigin "anonymous"]))))
+  '((link ([rel "stylesheet"]
+           [href "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"]
+           [integrity "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"]
+           [crossorigin "anonymous"]))
+    (script ([defer ""] [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"]
+                        [integrity
+                         "sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6"]
+                        [crossorigin "anonymous"]))
+    (script ([defer ""]
+             [src "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"]
+             [integrity "sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh"]
+             [crossorigin "anonymous"]))))

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -20,9 +20,9 @@
   `(html (head (meta ([charset "utf-8"]))
                (title "Result page for the " ,(~a command) " command is not available right now.")
                ,@js-tex-include
-               (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"]))
-               (script ([src "https://unpkg.com/d3@6.7.0/dist/d3.min.js"]))
-               (script ([src "https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"]))
+               (script ([src "https://www.jsdelivr.com/package/npm/mathjs@14"] [defer ""]))
+               (script ([src "https://cdn.jsdelivr.net/npm/d3@7"] [defer ""]))
+               (script ([src "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6"] [defer ""]))
                (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
                (script ([src "../report.js"])))
          (body (h2 "Result page for the " ,(~a command) " command is not available right now."))))
@@ -71,9 +71,9 @@
     (head (meta ([charset "utf-8"]))
           (title "Result for " ,(~a (test-name test)))
           ,@js-tex-include
-          (script ([src "https://unpkg.com/mathjs@4.4.2/dist/math.min.js"]))
-          (script ([src "https://unpkg.com/d3@6.7.0/dist/d3.min.js"]))
-          (script ([src "https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"]))
+          (script ([src "https://www.jsdelivr.com/package/npm/mathjs@14"] [defer ""]))
+          (script ([src "https://cdn.jsdelivr.net/npm/d3@7"] [defer ""]))
+          (script ([src "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6"] [defer ""]))
           (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
           (script ([src "../report.js"])))
     (body

--- a/src/reports/resources/report.html
+++ b/src/reports/resources/report.html
@@ -2,7 +2,7 @@
 <title>Herbie results</title>
 <meta charset="utf-8">
 <link rel="stylesheet" type="text/css" href="report.css">
-<script defer src="https://www.jsdelivr.com/package/npm/mathjs@14">
+<script defer src="https://www.jsdelivr.com/package/npm/mathjs@14"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6"></script>
 <script defer src="report-page.js"></script>

--- a/src/reports/resources/report.html
+++ b/src/reports/resources/report.html
@@ -2,7 +2,7 @@
 <title>Herbie results</title>
 <meta charset="utf-8">
 <link rel="stylesheet" type="text/css" href="report.css">
-<script defer src="https://unpkg.com/mathjs@4.4.2/dist/math.min.js"></script>
-<script defer src="https://unpkg.com/d3@6.7.0/dist/d3.min.js"></script>
-<script defer src="https://unpkg.com/@observablehq/plot@0.4.3/dist/plot.umd.min.js"></script>
+<script defer src="https://www.jsdelivr.com/package/npm/mathjs@14">
+<script defer src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6"></script>
 <script defer src="report-page.js"></script>


### PR DESCRIPTION
I don't know what exactly jsDelivr is but Observable and D3 now recommend it, and I guess using one CDN is better than using two.