### PR TITLE
Only support two-argument sort in preprocessing

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -58,8 +58,7 @@
   (define useful-preprocessing
     (remove-unnecessary-preprocessing expr context pcontext initial-preprocessing))
   (define expr*
-    (for/fold ([expr expr])
-              ([preprocessing (in-list (reverse useful-preprocessing))])
+    (for/fold ([expr expr]) ([preprocessing (in-list (reverse useful-preprocessing))])
       (compile-preprocessing expr context preprocessing)))
   (alt expr* 'add-preprocessing (list altn) '()))
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -61,7 +61,7 @@
     (for/fold ([expr expr])
               ([preprocessing (in-list (reverse useful-preprocessing))])
       (compile-preprocessing expr context preprocessing)))
-  (alt expr* 'add-preprocessing (list altn) (reverse final-preprocessing)))
+  (alt expr* 'add-preprocessing (list altn) '()))
 
 (define (extract!)
   (timeline-push-alts! '())

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -57,14 +57,10 @@
   (define initial-preprocessing (alt-preprocessing altn))
   (define useful-preprocessing
     (remove-unnecessary-preprocessing expr context pcontext initial-preprocessing))
-  (define-values (expr* final-preprocessing)
-    (for/fold ([expr expr]
-               [final-preprocessing '()])
+  (define expr*
+    (for/fold ([expr expr])
               ([preprocessing (in-list (reverse useful-preprocessing))])
-      (define compiled (compile-preprocessing expr context preprocessing))
-      (if compiled
-          (values compiled final-preprocessing)
-          (values expr (cons preprocessing final-preprocessing)))))
+      (compile-preprocessing expr context preprocessing)))
   (alt expr* 'add-preprocessing (list altn) (reverse final-preprocessing)))
 
 (define (extract!)

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -48,16 +48,16 @@
              #:when (and (has-fabs-impl? repr) (has-copysign-impl? (context-repr ctx))))
     (cons `(negabs ,var) (replace-expression `(neg ,spec) var `(neg ,var)))))
 
-;; Swap identities: f(a, b) = f(b, a)
+;; Sort identities: f(a, b) = f(b, a)
 ;; TODO: require both vars have the same repr
-(define (make-swap-identities spec ctx)
+(define (make-sort-identities spec ctx)
   (define pairs (combinations (context-vars ctx) 2))
   (for/list ([pair (in-list pairs)]
-             ;; Can only swap same-repr variables
+             ;; Can only sort same-repr variables
              #:when (equal? (context-lookup ctx (first pair)) (context-lookup ctx (second pair)))
              #:when (has-fmin-fmax-impl? (context-lookup ctx (first pair))))
     (match-define (list a b) pair)
-    (cons `(swap ,a ,b) (replace-vars `((,a . ,b) (,b . ,a)) spec))))
+    (cons `(sort ,a ,b) (replace-vars `((,a . ,b) (,b . ,a)) spec))))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
 (define (find-preprocessing expr ctx)
@@ -66,8 +66,8 @@
   ;; identities
   (define even-identities (make-even-identities spec ctx))
   (define odd-identities (make-odd-identities spec ctx))
-  (define swap-identities (make-swap-identities spec ctx))
-  (define identities (append even-identities odd-identities swap-identities))
+  (define sort-identities (make-sort-identities spec ctx))
+  (define identities (append even-identities odd-identities sort-identities))
 
   ;; make egg runner
   (define rules (*sound-rules*))
@@ -90,11 +90,11 @@
                #:when (egraph-equal? runner spec spec*))
       ident))
 
-  (define swaps
-    (for/list ([(ident spec*) (in-dict swap-identities)]
+  (define sort-instrs
+    (for/list ([(ident spec*) (in-dict sort-identities)]
                #:when (egraph-equal? runner spec spec*))
       ident))
-  (append abs-instrs negabs-instrs swaps))
+  (append abs-instrs negabs-instrs sort-instrs))
 
 (define (preprocess-pcontext context pcontext preprocessing)
   (define preprocess

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -97,13 +97,13 @@
                #:when (egraph-equal? runner spec spec*))
       (match-define (list 'swap a b) ident)
       (list a b)))
-  (define components (connected-components (context-vars ctx) swaps))
-  (define sort-instrs
+  ;(define components (connected-components (context-vars ctx) swaps))
+  ;(define sort-instrs
     (for/list ([component (in-list components)]
                #:when (> (length component) 1))
       (cons 'sort component)))
 
-  (append abs-instrs negabs-instrs sort-instrs))
+  (append abs-instrs negabs-instrs swaps))
 
 (define (connected-components variables swaps)
   (define components (disjoint-set (length variables)))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -93,8 +93,7 @@
   (define swaps
     (for/list ([(ident spec*) (in-dict swap-identities)]
                #:when (egraph-equal? runner spec spec*))
-      (match-define (list 'swap a b) ident)
-      (list a b)))
+      ident))
   (append abs-instrs negabs-instrs swaps))
 
 (define (preprocess-pcontext context pcontext preprocessing)

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -155,93 +155,15 @@
       (core->tex prog* #:loc (and loc (cons 2 loc)) #:color "blue")
       "ERROR"))
 
-(define (combine-fpcore-instruction i e c)
-  (match i
-    [(list 'abs x)
-     (define x* (string->symbol (string-append (symbol->string x) "_m")))
-     (define e* (replace-expression e x x*))
-     (define p (index-of (context-vars c) x))
-     (define c* (struct-copy context c [vars (list-set (context-vars c) p x*)]))
-     (cons e* c*)]
-    [(list 'negabs x)
-     (define x-string (symbol->string x))
-     (define x-sign (string->symbol (string-append x-string "_s")))
-     (define x* (string->symbol (string-append x-string "_m")))
-     (define p (index-of (context-vars c) x))
-     (define r (list-ref (context-var-reprs c) p))
-     (define c* (struct-copy context c [vars (list-set (context-vars c) p x*)]))
-     (define c** (context-extend c* x-sign r))
-     (define *-impl (get-fpcore-impl '* (repr->prop (context-repr c)) (list r (context-repr c))))
-     (define e* (list *-impl x-sign (replace-expression e x x*)))
-     (cons e* c**)]
-    [_ (cons e c)]))
-
-(define (format-prelude-instruction instruction ctx ctx* language converter)
-  (define (converter* e c)
-    (define fpcore (program->fpcore e c))
-    (define output (converter fpcore "code"))
-    (define lines (string-split output "\n"))
-    (match language
-      ["FPCore" (pretty-format e #:mode 'display)]
-      ["Fortran" (string-trim (third lines) #px"\\s+code\\s+=\\s+")]
-      ["MATLAB" (string-trim (second lines) #px"\\s+tmp\\s+=\\s+")]
-      ["Wolfram" (string-trim (first lines) #px".*:=\\s+")]
-      ["TeX" output]
-      [_ (string-trim (second lines) #px"\\s+return\\s+")]))
-  (match instruction
-    [(list 'sort vs ...) (list (format-sort-instruction vs language))]))
-
-(define (format-sort-instruction vs l)
-  (match l
-    ["C" (format "assert(~a);" (format-less-than-condition vs))]
-    ["Java" (format "assert ~a;" (format-less-than-condition vs))]
-    ["Python"
-     (define comma-joined (comma-join vs))
-     (format "[~a] = sort([~a])" comma-joined comma-joined)]
-    ["Julia"
-     (define comma-joined (comma-join vs))
-     (format "~a = sort([~a])" comma-joined comma-joined)]
-    ["MATLAB"
-     (define comma-joined (comma-join vs))
-     (format "~a = num2cell(sort([~a])){:}" comma-joined comma-joined)]
-    ["TeX"
-     (define comma-joined (comma-join vs))
-     (format "[~a] = \\mathsf{sort}([~a])\\\\" comma-joined comma-joined)]
-    [_
-     (match vs
-       [(list x y) (format sort-note (format "~a and ~a" x y))]
-       [(list vs ...)
-        (format sort-note
-                (string-join (map ~a vs)
-                             ", "
-                             ;; "Lil Jon, he always tells the truth"
-                             #:before-last ", and "))])]))
-
-(define (format-less-than-condition variables)
-  (string-join (for/list ([a (in-list variables)]
-                          [b (in-list (cdr variables))])
-                 (format "~a < ~a" a b))
-               " && "))
-
-(define (comma-join vs)
-  (string-join (map ~a vs) ", "))
-
-(define sort-note "NOTE: ~a should be sorted in increasing order before calling this function.")
-
 (define (render-program expr
                         ctx
                         #:ident [identifier #f]
                         #:pre [precondition '(TRUE)]
                         #:instructions [instructions empty])
   (define output-repr (context-repr ctx))
-  (match-define (cons expr* ctx*)
-    (foldl (match-lambda*
-             [(list i (cons e c)) (combine-fpcore-instruction i e c)])
-           (cons expr ctx)
-           instructions))
   (define out-prog
     (parameterize ([*expr-cse-able?* at-least-two-ops?])
-      (core-cse (program->fpcore expr* ctx* #:ident identifier))))
+      (core-cse (program->fpcore expr ctx #:ident identifier))))
 
   (define output-prec (representation-name output-repr))
   (define out-prog* (fpcore-add-props out-prog (list ':precision output-prec)))
@@ -257,19 +179,7 @@
                     (symbol->string identifier)
                     "code"))
               (define out (converter out-prog* name))
-              (define prelude-lines
-                (string-join
-                 (append-map (lambda (instruction)
-                               (format-prelude-instruction instruction ctx ctx* lang converter))
-                             instructions)
-                 (if (equal? lang "TeX") "\\\\\n" "\n")
-                 #:after-last "\n"))
-              (sow (cons lang
-                         ((if (equal? lang "TeX")
-                              (curry format "\\begin{array}{l}\n~a\\\\\n~a\\end{array}\n")
-                              string-append)
-                          prelude-lines
-                          out)))))))
+              (sow (cons lang out))))))
 
   (define math-out (dict-ref versions "TeX" ""))
 

--- a/src/utils/common.rkt
+++ b/src/utils/common.rkt
@@ -9,9 +9,6 @@
          drop-at
          find-duplicates
          partial-sums
-         disjoint-set
-         disjoint-set-find!
-         disjoint-set-union!
          get-seed
          set-seed!
          quasisyntax
@@ -67,23 +64,6 @@
 
 (define (find-duplicates l)
   (map car (filter (compose pair? rest) (group-by identity l))))
-
-;; Union-find
-
-(define (disjoint-set s)
-  (list->vector (range s)))
-
-(define (disjoint-set-find! d x)
-  (define p (vector-ref d x))
-  (cond
-    [(= p x) x]
-    [else
-     (define r (disjoint-set-find! d p))
-     (vector-set! d x r)
-     r]))
-
-(define (disjoint-set-union! d x y)
-  (vector-set! d y x))
 
 ;; Miscellaneous helper
 


### PR DESCRIPTION
It's annoying to compile preprocessing instructions like `(sort a b c)`. This PR just removes many-way sorts entirely. It's not as much of a loss as you might think:
- There's only three benchmarks that use it in our benchmark set
- They're all `sqrt(x*x + y*y + z*z)`, and honestly sorting is detrimental there (though it's not sorting's fault)
- Without `(sort a b c)` we'll get `(sort a b) (sort a c) (sort b c)`, which still sorts all three variables, though it's O(n^2) not O(n log n), not that it ever matters
The benefit is a _massive_ simplification of the preprocessing mechanism because preprocessing is now entirely compiled away.