### PR TITLE
Pass start program explicitly

### DIFF
--- a/src/utils/alternative.rkt
+++ b/src/utils/alternative.rkt
@@ -6,7 +6,6 @@
          alt?
          alt-expr
          alt-add-event
-         *start-prog*
          *all-alts*
          alt-cost
          alt-equal?
@@ -43,9 +42,5 @@
 (define (alt-map f altn)
   (f (struct-copy alt altn [prevs (map (curry alt-map f) (alt-prevs altn))])))
 
-;; A useful parameter for many of Herbie's subsystems, though
-;; ultimately one that should be located somewhere else or perhaps
-;; exorcised
-
-(define *start-prog* (make-parameter #f))
+;; Keeps track of all alts so far.
 (define *all-alts* (make-parameter '()))


### PR DESCRIPTION
Herbie kept the original expression in a global parameter `*start-prog*`.  This
parameter was only read by the regimes and binary-search phases, so it has been
converted into an argument to those routines.  The global parameter now lives in
`mainloop.rkt` where it is set during `run-improve!`.  Binary search and regime
selection no longer depend on a global and instead receive the starting program
explicitly.  Unit tests continue to pass.

------
https://chatgpt.com/codex/tasks/task_e_685113218224833189c13549b4b81e20