### PR TITLE
Refactor preprocessing search

### DIFF
--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -64,10 +64,10 @@
   (define spec (prog->spec expr))
 
   ;; identities
-  (define even-identities (make-even-identities spec ctx))
-  (define odd-identities (make-odd-identities spec ctx))
-  (define sort-identities (make-sort-identities spec ctx))
-  (define identities (append even-identities odd-identities sort-identities))
+  (define identities
+    (append (make-even-identities spec ctx)
+            (make-odd-identities spec ctx)
+            (make-sort-identities spec ctx)))
 
   ;; make egg runner
   (define rules (*sound-rules*))
@@ -80,21 +80,9 @@
                  `((,rules . ((node . ,(*node-limit*)))))))
 
   ;; collect equalities
-  (define abs-instrs
-    (for/list ([(ident spec*) (in-dict even-identities)]
-               #:when (egraph-equal? runner spec spec*))
-      ident))
-
-  (define negabs-instrs
-    (for/list ([(ident spec*) (in-dict odd-identities)]
-               #:when (egraph-equal? runner spec spec*))
-      ident))
-
-  (define sort-instrs
-    (for/list ([(ident spec*) (in-dict sort-identities)]
-               #:when (egraph-equal? runner spec spec*))
-      ident))
-  (append abs-instrs negabs-instrs sort-instrs))
+  (for/list ([(ident spec*) (in-dict identities)]
+             #:when (egraph-equal? runner spec spec*))
+    ident))
 
 (define (preprocess-pcontext context pcontext preprocessing)
   (define preprocess


### PR DESCRIPTION
The preprocessing pass built three separate lists of potential
transformations and then filtered each with identical code. This
refactor constructs a single `identities` list and filters it once,
removing duplicated loops.

This change is purely a simplification of `find-preprocessing` and
should not affect behavior.


------
https://chatgpt.com/codex/tasks/task_e_6851169529308331848ec268b16c4ec5