### PR TITLE
updated demo.fpcore

### DIFF
--- a/bench/demo.fpcore
+++ b/bench/demo.fpcore
@@ -40,3 +40,10 @@
  :name "jeff quadratic root 2"
  (let ((d (sqrt (- (* b b) (* (* 4 a) c)))))
    (if (>= b 0) (/ (* 2 c) (- (- b) d)) (/ (+ (- b) d) (* 2 a)))))
+
+(FPCore (p)
+  :herbie-target
+    (if (and (>= p -1e-6) (<= p 0))
+      (- (+ p 1) (/ (* p p) (- p 1)))
+      (- p (fma (/ p (- p 1)) p -1)))
+  (- (+ p 1.0) (/ (pow (fmin p 0.0) 2.0) (- (fmin p 0.0) 1.0))))

--- a/bench/demo.fpcore
+++ b/bench/demo.fpcore
@@ -42,7 +42,9 @@
    (if (>= b 0) (/ (* 2 c) (- (- b) d)) (/ (+ (- b) d) (* 2 a)))))
 
 (FPCore (p)
-  :herbie-target
+  :name "peicewise-defined"
+  :pre (and (>= p -1.79e308) (<= p 1.79e308))
+  :alt
     (if (and (>= p -1e-6) (<= p 0))
       (- (+ p 1) (/ (* p p) (- p 1)))
       (- p (fma (/ p (- p 1)) p -1)))


### PR DESCRIPTION
I added a new benchmark to the demo.fpcore based on [user entry](https://herbie.uwplse.org/demo/fe5839acfca4da10082d4e20259dcd89b75b0617.1a83c9f5186db102b678a2d5f869f99992469071/graph.html). Herbie rewrote it to `p−fma(min(p,0)/min(p,0)-1,min(p,0),−1)`, but whenever `min(p,0)` is really small there would still be rounding errors, so I created a version with a if-else threshold to catch those values:

```
if (p >= 1e-6 && p <= 0) {
    // Use Taylor approximation for small p near 0
    result = p + 1 - p * p / (p - 1);
} else {
    result = p - fma(p / (p - 1), p, -1);
}
```

Brett formatted it to be able to be input as a FPCore statement:

```
(FPCore (p)
  :herbie-target
    (if (and (>= p -1e-6) (<= p 0))
      (- (+ p 1) (/ (* p p) (- p 1)))
      (- p (fma (/ p (- p 1)) p -1)))
  (- (+ p 1.0) (/ (pow (fmin p 0.0) 2.0) (- (fmin p 0.0) 1.0))))
```

Herbie was able to improve to an 87% accuracy compared to the original 76, so Brett said I should add it as a benchmark

