### PR TITLE
Speed up timeline creation via batch->json

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -59,7 +59,7 @@
 
 (define (run-taylor altns global-batch)
   (timeline-event! 'series)
-  (timeline-push! 'inputs (map ~a (batch->progs global-batch)))
+  (timeline-push! 'inputs (batch->json global-batch))
 
   (define (key x)
     (approx-impl (deref (alt-expr x))))


### PR DESCRIPTION
This PR adds `batch->json` to convert batches to a compact JSON form. This avoids calling `batch->progs` during the Herbie core run and should speed up `timeline.json` generation. Now, *this* PR doesn't change `timeline.html`; it still expands out the full text form of the program. Later one I hope to change that to output a batch form too, possibly with some JS code to inline parts of it, but for now this is still an improvement.

https://chatgpt.com/codex/tasks/task_e_6851153dd8188331ba77625c98584b7f