### PR TITLE
Update egglog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ rival
 regraph
 egg-herbie/pkg
 odyssey
+/egglog
 
 # Racket
 *.zo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: help install egg-herbie nightly index start-server deploy
+EGGLOG_VERSION = b8ae2d18e68667af966ef392156db30a802ef07f
+EGGLOG_DIR = egglog
+
+.PHONY: help install egg-herbie egglog nightly index start-server deploy
 
 help:
 	@echo "Type 'make install' to install Herbie"
@@ -13,6 +16,7 @@ clean:
 	raco pkg remove --force --no-docs egg-herbie-windows && echo "Uninstalled old egg-herbie" || :
 	raco pkg remove --force --no-docs egg-herbie-osx && echo "Uninstalled old egg-herbie" || :
 	raco pkg remove --force --no-docs egg-herbie-macosm1 && echo "Uninstalled old egg-herbie" || :
+	cargo uninstall egglog && rm -rf $(EGGLOG_DIR) && echo "Uninstalled egglog" || :
 
 update:
 	raco pkg install --skip-installed --no-docs --auto --name herbie src/
@@ -28,9 +32,10 @@ egg-herbie:
 	raco pkg remove --force --no-docs egg-herbie-macosm1 && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg install ./egg-herbie
 
-egglog-herbie:
-	cargo install --git https://github.com/egraphs-good/egglog.git --rev c7cfe8b8a420455798e00171659332abb94a8148
-
+egglog:
+	git clone https://github.com/egraphs-good/egglog.git $(EGGLOG_DIR) && echo "Cloning egglog" || :
+	cd $(EGGLOG_DIR) && git fetch origin && git checkout $(EGGLOG_VERSION)
+	cd $(EGGLOG_DIR) && cargo install --path .
 
 distribution: minimal-distribution
 	cp -r bench herbie-compiled/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ egg-herbie:
 	raco pkg install ./egg-herbie
 
 egglog-herbie:
-	cargo install --git https://github.com/egraphs-good/egglog.git --rev 052a330de22d40e9eded19e7f0891c921f7f458c
+	cargo install --git https://github.com/egraphs-good/egglog.git --rev c7cfe8b8a420455798e00171659332abb94a8148
 
 
 distribution: minimal-distribution

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "Type 'make install' to install Herbie"
 	@echo "Then type 'racket -l herbie web' to run it."
 
-install: clean egg-herbie egglog-herbie update
+install: clean egg-herbie egglog update
 
 clean:
 	raco pkg remove --force --no-docs herbie && echo "Uninstalled old herbie" || :

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -26,7 +26,7 @@
   #hash([precision . ()]
         [setup . (search)]
         [localize . ()]
-        [generate . (rr taylor proofs)]
+        [generate . (rr taylor proofs egglog)]
         [reduce . (regimes binary-search branch-expressions)]
         [rules
          . (arithmetic polynomials


### PR DESCRIPTION
Updates egglog to the most recent commit (egraphs-good/egglog#613). The minimum Rust version was increased to 1.87. To ensure the right version is used, the Makefile now builds egglog locally.