### PR TITLE
Fix egglog build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ egg-herbie:
 	raco pkg install ./egg-herbie
 
 egglog-herbie:
-	cargo install --git https://github.com/egraphs-good/egglog.git --rev 052a330de22d40e9eded19e7f0891c921f7f458c
+	cargo install --locked --git https://github.com/egraphs-good/egglog.git --rev 052a330de22d40e9eded19e7f0891c921f7f458c
 
 
 distribution: minimal-distribution


### PR DESCRIPTION
Rust builds are more mysterious than I thought. Adding the `--locked` option when installing egglog to use the precise set of dependencies in the `Cargo.lock` file.