### PR TITLE
Compatability with minor Rival's changes of `rival-analyze-with-hints`

### DIFF
--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -145,4 +145,4 @@
 ;; for the given inputs range. The result is an interval representing
 ;; how certain the result is: no, maybe, yes.
 (define (real-compiler-analyze compiler input-ranges [hint #f])
-  (rival-analyze (real-compiler-machine compiler) input-ranges hint))
+  (rival-analyze-with-hints (real-compiler-machine compiler) input-ranges hint))

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -21,7 +21,7 @@
                              "rackunit-lib"
                              "web-server-lib"
                              ("egg-herbie" #:version "2.2")
-                             ("rival" #:version "2.0")
+                             ("rival" #:version "2.2")
                              ("fpbench" #:version "2.0.3")
                              "fmt"))
 


### PR DESCRIPTION
This PR updates codebase to match new Rival changes - mainly a separation of `rival-analyze` and `rival-analyze-with-hints`.