### PR TITLE
Convert all platforms to the new `#lang`

### DIFF
--- a/infra/softposit.rkt
+++ b/infra/softposit.rkt
@@ -1,14 +1,9 @@
-#lang racket
+#lang s-exp "../src/platform.rkt"
 
-;;; Softposit platform:
-;;; Enable functions like real->posit16 or +.p16 in Herbie through David Thien's package
+;;; Softposit platform, using David Thien's softposit-rkt package for
+;;; bindings. Provides operations like real->posit16 or +.p16.
 
-(require math/flonum
-         math/bigfloat
-         softposit-rkt
-         "../src/syntax/types.rkt"  ; for shift/unshift
-         "../src/syntax/platform.rkt")
-(provide platform)
+(require softposit-rkt)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; utils ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -40,6 +35,7 @@
 (define quire8-nmax  (quire8-fdp-sub  (double->quire8 0.0)  posit8-max  posit8-max))
 (define quire16-max  (quire16-fdp-add (double->quire16 0.0) posit16-max posit16-max))
 (define quire16-nmax (quire16-fdp-sub (double->quire16 0.0) posit16-max posit16-max))
+
 ; These crash
 ; (define quire32-max (quire32-fdp-add (double->quire32 0.0) posit32-max posit32-max))
 ; (define quire32-nmax (quire32-fdp-sub (double->quire32 0.0) posit32-max posit32-max))
@@ -84,19 +80,11 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; EMPTY PLATFORM ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define cost 1)
-
-(define platform (make-empty-platform 'softposit))
-
-(platform-register-if-cost! platform #:cost 1)
+(define-if #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; REPRESENTATIONS ;;;;;;;;;;;;;;;;;;;;;;;
 
-(define bool <bool>)
-
-(define binary64 <binary64>)
-
-(define posit8
+(define <posit8>
   (make-representation #:name 'posit8
                        #:bf->repr (compose double->posit8* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit8->double)
@@ -105,7 +93,7 @@
                        #:total-bits 8
                        #:special-value? (curry posit8= (posit8-nar))))
 
-(define posit16
+(define <posit16>
   (make-representation #:name 'posit16
                        #:bf->repr (compose double->posit16* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit16->double)
@@ -114,7 +102,7 @@
                        #:total-bits 16
                        #:special-value? (curry posit16= (posit16-nar))))
 
-(define posit32
+(define <posit32>
   (make-representation #:name 'posit32
                        #:bf->repr (compose double->posit32* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit32->double)
@@ -123,7 +111,7 @@
                        #:total-bits 32
                        #:special-value? (curry posit32= (posit32-nar))))
 
-(define quire8
+(define <quire8>
   (make-representation #:name 'quire8
                        #:bf->repr (compose double->quire8* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan quire8->double)
@@ -132,7 +120,7 @@
                        #:total-bits 64
                        #:special-value? (const #f)))
 
-(define quire16
+(define <quire16>
   (make-representation #:name 'quire16
                        #:bf->repr (compose double->quire16* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan quire16->double)
@@ -141,7 +129,7 @@
                        #:total-bits 64
                        #:special-value? (const #f)))
 
-(define quire32
+(define <quire32>
   (make-representation #:name 'quire32
                        #:bf->repr (compose double->quire32 bigfloat->flonum) ; TODO: use double->quire32* when crash fixed
                        #:repr->bf (compose bf-inf->nan quire32->double)
@@ -150,110 +138,141 @@
                        #:total-bits 64
                        #:special-value? (const #f)))
 
-(platform-register-representation! platform #:repr bool     #:cost cost)
-(platform-register-representation! platform #:repr binary64 #:cost cost)
-(platform-register-representation! platform #:repr posit8   #:cost cost)
-(platform-register-representation! platform #:repr posit16  #:cost cost)
-(platform-register-representation! platform #:repr posit32  #:cost cost)
-(platform-register-representation! platform #:repr quire8   #:cost cost)
-(platform-register-representation! platform #:repr quire16  #:cost cost)
-(platform-register-representation! platform #:repr quire32  #:cost cost)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; OPERATORS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN IMPLS ;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(platform-register-implementations!
- platform
- ([TRUE  ()                      bool (TRUE)    (const true)  (! TRUE)  cost]
-  [FALSE ()                      bool (FALSE)   (const false) (! FALSE) cost]
-  [not   ([x : bool])            bool (not x)   not           (not x)   cost]
-  [and   ([x : bool] [y : bool]) bool (and x y) and-fn        (and x y) cost]
-  [or    ([x : bool] [y : bool]) bool (or x y)  or-fn         (or x y)  cost]))
+(define-representation <bool> #:cost boolean-move-cost)
+
+(define-operations () <bool>
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost boolean-move-cost]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost boolean-move-cost])
+
+(define-operations ([x <bool>] [y <bool>]) <bool>
+  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost boolean-move-cost]
+  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost boolean-move-cost])
+
+(define-operation (not [x <bool>]) <bool>
+  #:spec (not x) #:impl not #:cost boolean-move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; POSIT IMPLS ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; ([name           ([var : repr] ...)                          otype   spec          fl                fpcore                           cost])
-(platform-register-implementations!
- platform
- (; Posit8
-  [neg.p8          ([x : posit8])                              posit8  (neg x)       posit8-neg        (! :precision posit8 (- x))        cost]
-  [+.p8            ([x : posit8]  [y : posit8])                posit8  (+ x y)       posit8-add        (! :precision posit8 (+ x y))      cost]
-  [-.p8            ([x : posit8]  [y : posit8])                posit8  (- x y)       posit8-sub        (! :precision posit8 (- x y))      cost]
-  [*.p8            ([x : posit8]  [y : posit8])                posit8  (* x y)       posit8-mul        (! :precision posit8 (* x y))      cost]
-  [/.p8            ([x : posit8]  [y : posit8])                posit8  (/ x y)       posit8-div        (! :precision posit8 (/ x y))      cost]
-  [sqrt.p8         ([x : posit8])                              posit8  (sqrt x)      posit8-sqrt       (! :precision posit8 (sqrt x))     cost]
-  [==.p8           ([x : posit8]  [y : posit8])                bool    (== x y)      posit8=           (== x y)                           cost]
-  [!=.p8           ([x : posit8]  [y : posit8])                bool    (!= x y)      (negate posit8=)  (!= x y)                           cost]
-  [<.p8            ([x : posit8]  [y : posit8])                bool    (< x y)       posit8<           (< x y)                            cost]
-  [>.p8            ([x : posit8]  [y : posit8])                bool    (> x y)       posit8>           (> x y)                            cost]
-  [<=.p8           ([x : posit8]  [y : posit8])                bool    (<= x y)      posit8<=          (<= x y)                           cost]
-  [>=.p8           ([x : posit8]  [y : posit8])                bool    (>= x y)      posit8>=          (>= x y)                           cost]
-  ; Posit 16
-  [neg.p16         ([x : posit16])                             posit16 (neg x)       posit16-neg       (! :precision posit16 (- x))       cost]
-  [+.p16           ([x : posit16] [y : posit16])               posit16 (+ x y)       posit16-add       (! :precision posit16 (+ x y))     cost]
-  [-.p16           ([x : posit16] [y : posit16])               posit16 (- x y)       posit16-sub       (! :precision posit16 (- x y))     cost]
-  [*.p16           ([x : posit16] [y : posit16])               posit16 (* x y)       posit16-mul       (! :precision posit16 (* x y))     cost]
-  [/.p16           ([x : posit16] [y : posit16])               posit16 (/ x y)       posit16-div       (! :precision posit16 (/ x y))     cost]
-  [sqrt.p16        ([x : posit16])                             posit16 (sqrt x)      posit16-sqrt      (! :precision posit16 (sqrt x))    cost]
-  [==.p16          ([x : posit16] [y : posit16])               bool    (== x y)      posit16=          (== x y)                           cost]
-  [!=.p16          ([x : posit16] [y : posit16])               bool    (!= x y)      (negate posit16=) (!= x y)                           cost]
-  [<.p16           ([x : posit16] [y : posit16])               bool    (< x y)       posit16<          (< x y)                            cost]
-  [>.p16           ([x : posit16] [y : posit16])               bool    (> x y)       posit16>          (> x y)                            cost]
-  [<=.p16          ([x : posit16] [y : posit16])               bool    (<= x y)      posit16<=         (<= x y)                           cost]
-  [>=.p16          ([x : posit16] [y : posit16])               bool    (>= x y)      posit16>=         (>= x y)                           cost]
-  ; Posit 32
-  [neg.p32         ([x : posit32])                             posit32 (neg x)       posit32-neg       (! :precision posit32 (- x))       cost]
-  [+.p32           ([x : posit32] [y : posit32])               posit32 (+ x y)       posit32-add       (! :precision posit32 (+ x y))     cost]
-  [-.p32           ([x : posit32] [y : posit32])               posit32 (- x y)       posit32-sub       (! :precision posit32 (- x y))     cost]
-  [*.p32           ([x : posit32] [y : posit32])               posit32 (* x y)       posit32-mul       (! :precision posit32 (* x y))     cost]
-  [/.p32           ([x : posit32] [y : posit32])               posit32 (/ x y)       posit32-div       (! :precision posit32 (/ x y))     cost]
-  [sqrt.p32        ([x : posit32])                             posit32 (sqrt x)      posit32-sqrt      (! :precision posit32 (sqrt x))    cost]
-  [==.p32          ([x : posit32] [y : posit32])               bool    (== x y)      posit32=          (== x y)                           cost]
-  [!=.p32          ([x : posit32] [y : posit32])               bool    (!= x y)      (negate posit32=) (!= x y)                           cost]
-  [<.p32           ([x : posit32] [y : posit32])               bool    (< x y)       posit32<          (< x y)                            cost]
-  [>.p32           ([x : posit32] [y : posit32])               bool    (> x y)       posit32>          (> x y)                            cost]
-  [<=.p32          ([x : posit32] [y : posit32])               bool    (<= x y)      posit32<=         (<= x y)                           cost]
-  [>=.p32          ([x : posit32] [y : posit32])               bool    (>= x y)      posit32>=         (>= x y)                           cost]
-  ; Quire/posit fused impl
-  [quire8-mul-add  ([x : quire8]  [y : posit8]  [z : posit8])  quire8  (+ x (* y z)) quire8-fdp-add    (! :precision quire8 (fdp x y z))  cost]
-  [quire16-mul-add ([x : quire16] [y : posit16] [z : posit16]) quire16 (+ x (* y z)) quire16-fdp-add   (! :precision quire16 (fdp x y z)) cost]
-  [quire32-mul-add ([x : quire32] [y : posit32] [z : posit32]) quire32 (+ x (* y z)) quire32-fdp-add   (! :precision quire32 (fdp x y z)) cost]
-  [quire8-mul-sub  ([x : quire8]  [y : posit8]  [z : posit8])  quire8  (- x (* y z)) quire8-fdp-sub    (! :precision quire8 (fdm x y z))  cost]
-  [quire16-mul-sub ([x : quire16] [y : posit16] [z : posit16]) quire16 (- x (* y z)) quire16-fdp-sub   (! :precision quire16 (fdm x y z)) cost]
-  [quire32-mul-sub ([x : quire32] [y : posit32] [z : posit32]) quire32 (- x (* y z)) quire32-fdp-sub   (! :precision quire32 (fdm x y z)) cost]))
+(define-representation <posit8>  #:cost cost)
+(define-representation <posit16> #:cost cost)
+(define-representation <posit32> #:cost cost)
+
+(define-operations ([x <posit8>] [y <posit8>]) <bool>
+  [==.p8 #:spec (== x y) #:impl posit8=  #:cost 1]
+  [<.p8  #:spec (< x y)  #:impl posit8<  #:cost 1]
+  [>.p8  #:spec (> x y)  #:impl posit8>  #:cost 1]
+  [<=.p8 #:spec (<= x y) #:impl posit8<= #:cost 1]
+  [>=.p8 #:spec (>= x y) #:impl posit8>= #:cost 1])
+
+(parameterize ([fpcore-context '(:precision posit8)])
+  (define-operations ([x <posit8>]) <posit8>
+    [neg.p8  #:spec (neg x)  #:impl posit8-neg  #:cost 1]
+    [sqrt.p8 #:spec (sqrt x) #:impl posit8-sqrt #:cost 1])
+
+  (define-operations ([x <posit8>] [y <posit8>]) <posit8>
+    [+.p8 #:spec (+ x y) #:impl posit8-add #:cost 1]
+    [-.p8 #:spec (- x y) #:impl posit8-sub #:cost 1]
+    [*.p8 #:spec (* x y) #:impl posit8-mul #:cost 1]
+    [/.p8 #:spec (/ x y) #:impl posit8-div #:cost 1]))
+
+(define-operations ([x <posit16>] [y <posit16>]) <bool>
+  [==.p16 #:spec (== x y) #:impl posit16=  #:cost 1]
+  [<.p16  #:spec (< x y)  #:impl posit16<  #:cost 1]
+  [>.p16  #:spec (> x y)  #:impl posit16>  #:cost 1]
+  [<=.p16 #:spec (<= x y) #:impl posit16<= #:cost 1]
+  [>=.p16 #:spec (>= x y) #:impl posit16>= #:cost 1])
+
+(parameterize ([fpcore-context '(:precision posit16)])
+  (define-operations ([x <posit16>]) <posit16>
+    [neg.p16  #:spec (neg x)  #:impl posit16-neg  #:cost 1]
+    [sqrt.p16 #:spec (sqrt x) #:impl posit16-sqrt #:cost 1])
+
+  (define-operations ([x <posit16>] [y <posit16>]) <posit16>
+    [+.p16 #:spec (+ x y) #:impl posit16-add #:cost 1]
+    [-.p16 #:spec (- x y) #:impl posit16-sub #:cost 1]
+    [*.p16 #:spec (* x y) #:impl posit16-mul #:cost 1]
+    [/.p16 #:spec (/ x y) #:impl posit16-div #:cost 1]))
+
+(define-operations ([x <posit32>] [y <posit32>]) <bool>
+  [==.p32 #:spec (== x y) #:impl posit32=  #:cost 1]
+  [<.p32  #:spec (< x y)  #:impl posit32<  #:cost 1]
+  [>.p32  #:spec (> x y)  #:impl posit32>  #:cost 1]
+  [<=.p32 #:spec (<= x y) #:impl posit32<= #:cost 1]
+  [>=.p32 #:spec (>= x y) #:impl posit32>= #:cost 1])
+
+(parameterize ([fpcore-context '(:precision posit32)])
+  (define-operations ([x <posit32>]) <posit32>
+    [neg.p32  #:spec (neg x)  #:impl posit32-neg  #:cost 1]
+    [sqrt.p32 #:spec (sqrt x) #:impl posit32-sqrt #:cost 1])
+
+  (define-operations ([x <posit32>] [y <posit32>]) <posit32>
+    [+.p32 #:spec (+ x y) #:impl posit32-add #:cost 1]
+    [-.p32 #:spec (- x y) #:impl posit32-sub #:cost 1]
+    [*.p32 #:spec (* x y) #:impl posit32-mul #:cost 1]
+    [/.p32 #:spec (/ x y) #:impl posit32-div #:cost 1]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; QUIRE OPERATIONS ;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-representation <quire8>  #:cost cost)
+(define-representation <quire16> #:cost cost)
+(define-representation <quire32> #:cost cost)
+
+(parameterize ([fpcore-context '(:precision quire8)])
+  (define-operations ([x <quire8>] [y <posit8>] [z <posit8>]) <quire8>
+    [quire8-mul-add #:spec (+ x (* y z)) #:impl quire8-fdp-add #:fpcore (fma y z x)     #:cost 1]
+    [quire8-mul-sub #:spec (- x (* y z)) #:impl quire8-fdp-sub #:fpcore (fma (- y) z x) #:cost 1]))
+
+(parameterize ([fpcore-context '(:precision quire16)])
+  (define-operations ([x <quire16>] [y <posit16>] [z <posit16>]) <quire16>
+    [quire16-mul-add #:spec (+ x (* y z)) #:impl quire16-fdp-add #:fpcore (fma y z x)     #:cost 1]
+    [quire16-mul-sub #:spec (- x (* y z)) #:impl quire16-fdp-sub #:fpcore (fma (- y) z x) #:cost 1]))
+
+(parameterize ([fpcore-context '(:precision quire32)])
+  (define-operations ([x <quire32>] [y <posit32>] [z <posit32>]) <quire32>
+    [quire32-mul-add #:spec (+ x (* y z)) #:impl quire32-fdp-add #:fpcore (fma y z x)     #:cost 1]
+    [quire32-mul-sub #:spec (- x (* y z)) #:impl quire32-fdp-sub #:fpcore (fma (- y) z x) #:cost 1]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CONVERTERS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; ([name             ([var : repr] ...) otype  spec fl             fpcore                        cost])
-(platform-register-implementations!
- platform
- (; Posit/float implementations
-  [binary64->posit8  ([x : binary64]) posit8   x double->posit8   (! :precision posit8 (cast x))   cost]
-  [binary64->posit16 ([x : binary64]) posit16  x double->posit16  (! :precision posit16 (cast x))  cost]
-  [binary64->posit32 ([x : binary64]) posit32  x double->posit32  (! :precision posit32 (cast x))  cost]
-  [posit8->binary64  ([x : posit8])   binary64 x posit8->double   (! :precision binary64 (cast x)) cost]
-  [posit16->binary64 ([x : posit16])  binary64 x posit16->double  (! :precision binary64 (cast x)) cost]
-  [posit32->binary64 ([x : posit32])  binary64 x posit32->double  (! :precision binary64 (cast x)) cost]
-  ; Quire/float implementations
-  [binary64->quire8  ([x : binary64]) quire8   x double->quire8   (! :precision quire8 (cast x))   cost]
-  [binary64->quire16 ([x : binary64]) quire16  x double->quire16  (! :precision quire16 (cast x))  cost]
-  [binary64->quire32 ([x : binary64]) quire32  x double->quire32  (! :precision quire32 (cast x))  cost]
-  [quire8->binary64  ([x : quire8])   binary64 x quire8->double   (! :precision binary64 (cast x)) cost]
-  [quire16->binary64 ([x : quire16])  binary64 x quire16->double  (! :precision binary64 (cast x)) cost]
-  [quire32->binary64 ([x : quire32])  binary64 x quire32->double  (! :precision binary64 (cast x)) cost]
-  ; Quire/posit implementations
-  [quire8->posit8    ([x : quire8])   posit8   x quire8->posit8   (! :precision posit8 (cast x))   cost]
-  [quire16->posit16  ([x : quire16])  posit16  x quire16->posit16 (! :precision posit16 (cast x))  cost]
-  [quire32->posit32  ([x : quire32])  posit32  x quire32->posit32 (! :precision posit32 (cast x))  cost]
-  [posit8->quire8    ([x : posit8])   quire8   x posit8->quire8   (! :precision quire8 (cast x))   cost]
-  [posit16->quire16  ([x : posit16])  quire16  x posit16->quire16 (! :precision quire16 (cast x))  cost]
-  [posit32->quire32  ([x : posit32])  quire32  x posit32->quire32 (! :precision quire32 (cast x))  cost]))
+(define-representation <binary64> #:cost cost)
 
-(module+ main
-  (display-platform platform))
+(define-operation (binary64->posit8  [x <binary64>]) <posit8>
+  #:spec x #:impl double->posit8   #:fpcore (! :precision posit8 (cast x))   #:cost cost]
+(define-operation (binary64->posit16 [x <binary64>]) <posit16>
+  #:spec x #:impl double->posit16  #:fpcore (! :precision posit16 (cast x))  #:cost cost]
+(define-operation (binary64->posit32 [x <binary64>]) <posit32>
+  #:spec x #:impl double->posit32  #:fpcore (! :precision posit32 (cast x))  #:cost cost]
+(define-operation (posit8->binary64  [x <posit8>])   <binary64>
+  #:spec x #:impl posit8->double   #:fpcore (! :precision binary64 (cast x)) #:cost cost]
+(define-operation (posit16->binary64 [x <posit16>])  <binary64>
+  #:spec x #:impl posit16->double  #:fpcore (! :precision binary64 (cast x)) #:cost cost]
+(define-operation (posit32->binary64 [x <posit32>])  <binary64>
+  #:spec x #:impl posit32->double  #:fpcore (! :precision binary64 (cast x)) #:cost cost]
 
-;; Do not run this file during testing
-(module test racket/base
-  )
-  
+(define-operation (binary64->quire8  [x <binary64>]) <quire8>
+  #:spec x #:impl double->quire8   #:fpcore (! :precision quire8 (cast x))   #:cost cost]
+(define-operation (binary64->quire16 [x <binary64>]) <quire16>
+  #:spec x #:impl double->quire16  #:fpcore (! :precision quire16 (cast x))  #:cost cost]
+(define-operation (binary64->quire32 [x <binary64>]) <quire32>
+  #:spec x #:impl double->quire32  #:fpcore (! :precision quire32 (cast x))  #:cost cost]
+(define-operation (quire8->binary64  [x <quire8>])   <binary64>
+  #:spec x #:impl quire8->double   #:fpcore (! :precision binary64 (cast x)) #:cost cost]
+(define-operation (quire16->binary64 [x <quire16>])  <binary64>
+  #:spec x #:impl quire16->double  #:fpcore (! :precision binary64 (cast x)) #:cost cost]
+(define-operation (quire32->binary64 [x <quire32>])  <binary64>
+  #:spec x #:impl quire32->double  #:fpcore (! :precision binary64 (cast x)) #:cost cost]
+
+(define-operation (quire8->posit8    [x <quire8>])   <posit8>
+  #:spec x #:impl quire8->posit8   #:fpcore (! :precision posit8 (cast x))   #:cost cost]
+(define-operation (quire16->posit16  [x <quire16>])  <posit16>
+  #:spec x #:impl quire16->posit16 #:fpcore (! :precision posit16 (cast x))  #:cost cost]
+(define-operation (quire32->posit32  [x <quire32>])  <posit32>
+  #:spec x #:impl quire32->posit32 #:fpcore (! :precision posit32 (cast x))  #:cost cost]
+(define-operation (posit8->quire8    [x <posit8>])   <quire8>
+  #:spec x #:impl posit8->quire8   #:fpcore (! :precision quire8 (cast x))   #:cost cost]
+(define-operation (posit16->quire16  [x <posit16>])  <quire16>
+  #:spec x #:impl posit16->quire16 #:fpcore (! :precision quire16 (cast x))  #:cost cost]
+(define-operation (posit32->quire32  [x <posit32>])  <quire32>
+  #:spec x #:impl posit32->quire32 #:fpcore (! :precision quire32 (cast x))  #:cost cost]))

--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -15,8 +15,8 @@
 (define-representation <bool> #:cost boolean-move-cost)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost boolean-move-cost]
-  [FALSE #:spec (FALSE) #:impl (const false) #:cost boolean-move-cost])
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost boolean-move-cost]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost boolean-move-cost])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost boolean-move-cost]
@@ -39,10 +39,10 @@
 
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 32bit-move-cost]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 32bit-move-cost]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 32bit-move-cost]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 32bit-move-cost])
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32bit-move-cost]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32bit-move-cost]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32bit-move-cost]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32bit-move-cost])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 0.125)
@@ -110,10 +110,10 @@
 
 (parameterize ([fpcore-context '(:precision binary64)])
   (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 64bit-move-cost]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 64bit-move-cost]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 64bit-move-cost]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 64bit-move-cost])
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64bit-move-cost]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64bit-move-cost]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64bit-move-cost]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64bit-move-cost])
   
   (define-operation (neg.f64 [x <binary64>]) <binary64>
     #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0.125)

--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -65,7 +65,7 @@
     [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 1.125]
     [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 1.100]
     [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 0.500]
-    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 2.00]
+    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 2.000]
     [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 0.250]
     [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 1.125]
     [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 1.375]

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -15,8 +15,8 @@
 (define-representation <bool> #:cost boolean-move-cost)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost boolean-move-cost]
-  [FALSE #:spec (FALSE) #:impl (const false) #:cost boolean-move-cost])
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost boolean-move-cost]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost boolean-move-cost])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost boolean-move-cost]
@@ -39,10 +39,10 @@
 
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 32bit-move-cost]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 32bit-move-cost]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 32bit-move-cost]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 32bit-move-cost])
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32bit-move-cost]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32bit-move-cost]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32bit-move-cost]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32bit-move-cost])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 0.125)
@@ -119,10 +119,10 @@
 
 (parameterize ([fpcore-context '(:precision binary64)])
   (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 64bit-move-cost]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 64bit-move-cost]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 64bit-move-cost]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 64bit-move-cost])
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64bit-move-cost]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64bit-move-cost]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64bit-move-cost]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64bit-move-cost])
   
   (define-operation (neg.f64 [x <binary64>]) <binary64>
     #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0.125)

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -66,7 +66,7 @@
     [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 1.125]
     [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 1.100]
     [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 0.500]
-    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 2.00]
+    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 2.000]
     [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 0.250]
     [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 1.125]
     [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 1.375]

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -12,8 +12,8 @@
 (define-representation <bool> #:cost 0)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost 0]
-  [FALSE #:spec (FALSE) #:impl (const false) #:cost 0])
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost 0]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost 0])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost 0]
@@ -36,10 +36,10 @@
 
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 0]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 0]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 0]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 0])
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 0]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 0]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 0]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 0])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 0)
@@ -116,10 +116,10 @@
 
 (parameterize ([fpcore-context '(:precision binary64)])
   (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 0]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 0]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 0]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 0])
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 0]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 0]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 0]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 0])
   
   (define-operations ([x <binary64>] [y <binary64>]) <binary64>
     [+.f64 #:spec (+ x y) #:impl + #:cost 0]

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -1,248 +1,191 @@
-#lang racket
+#lang s-exp "../platform.rkt"
 
-;;; Herbie10 platform:
-;;; C/C++ on Linux with a full libm
+;; Herbie 1.0 platform. Based on the C Windows platform, but with
+;; every operation having cost 0, so as to emulate no-pareto mode.
 
-(require math/bigfloat
-         math/flonum
-         "../syntax/types.rkt"  ; for shift/unshift
-         "../syntax/platform.rkt")
-(provide platform)
+(require math/flonum)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; EMPTY PLATFORM ;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define platform (make-empty-platform 'herbie10))
-
-(platform-register-if-cost! platform #:if-cost 0)
+(define-if #:cost 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <bool> #:cost 0)
 
-(define bool <bool>)
+(define-operations () <bool>
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost 0]
+  [FALSE #:spec (FALSE) #:impl (const false) #:cost 0])
 
-(platform-register-representation! platform #:repr bool #:cost 0)
+(define-operations ([x <bool>] [y <bool>]) <bool>
+  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost 0]
+  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost 0])
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([TRUE  () bool (TRUE)  (const true)  (! TRUE)  0]
-  [FALSE () bool (FALSE) (const false) (! FALSE) 0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (and-fn . as)
-  (andmap identity as))
-(define (or-fn . as)
-  (ormap identity as))
-
-(platform-register-implementations!
- platform
- ([not ([x : bool])            bool (not x)   not    (not x)   0]
-  [and ([x : bool] [y : bool]) bool (and x y) and-fn (and x y) 0]
-  [or  ([x : bool] [y : bool]) bool (or x y)  or-fn  (or x y)  0]))
+(define-operation (not [x <bool>]) <bool>
+  #:spec (not x) #:impl not #:cost 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <binary32> #:cost 0)
 
-(define binary32 <binary32>)
+(define-operations ([x <binary32>] [y <binary32>]) <bool>
+  [==.f32 #:spec (== x y) #:impl =          #:cost 0]
+  [!=.f32 #:spec (!= x y) #:impl (negate =) #:cost 0]
+  [<.f32  #:spec (< x y)  #:impl <          #:cost 0]
+  [>.f32  #:spec (> x y)  #:impl >          #:cost 0]
+  [<=.f32 #:spec (<= x y) #:impl <=         #:cost 0]
+  [>=.f32 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(platform-register-representation! platform #:repr binary32 #:cost 0)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([PI.f32       () binary32 (PI)       (const (flsingle pi))        (! :precision binary32 PI)       0]
-  [E.f32        () binary32 (E)        (const (flsingle (exp 1.0))) (! :precision binary32 E)        0]
-  [INFINITY.f32 () binary32 (INFINITY) (const +inf.0)               (! :precision binary32 INFINITY) 0]
-  [NAN.f32      () binary32 (NAN)      (const +nan.0)               (! :precision binary32 NAN)      0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name   ([var : repr] ...)              otype    spec     fl         fpcore                         cost])
-(platform-register-implementations!
- platform
- ([neg.f32 ([x : binary32])                binary32 (neg x)  (compose flsingle -)      (! :precision binary32 (- x))   0]
-  [+.f32   ([x : binary32] [y : binary32]) binary32 (+ x y)  (compose flsingle +)      (! :precision binary32 (+ x y)) 0]
-  [-.f32   ([x : binary32] [y : binary32]) binary32 (- x y)  (compose flsingle -)      (! :precision binary32 (- x y)) 0]
-  [*.f32   ([x : binary32] [y : binary32]) binary32 (* x y)  (compose flsingle *)      (! :precision binary32 (* x y)) 0]
-  [/.f32   ([x : binary32] [y : binary32]) binary32 (/ x y)  (compose flsingle /)      (! :precision binary32 (/ x y)) 0]
-  [==.f32  ([x : binary32] [y : binary32]) bool     (== x y) =          (== x y)                        0]
-  [!=.f32  ([x : binary32] [y : binary32]) bool     (!= x y) (negate =) (!= x y)                        0]
-  [<.f32   ([x : binary32] [y : binary32]) bool     (< x y)  <          (< x y)                         0]
-  [>.f32   ([x : binary32] [y : binary32]) bool     (> x y)  >          (> x y)                         0]
-  [<=.f32  ([x : binary32] [y : binary32]) bool     (<= x y) <=         (<= x y)                        0]
-  [>=.f32  ([x : binary32] [y : binary32]) bool     (>= x y) >=         (>= x y)                        0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm operators ;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name         ([var : repr] ...)              otype    spec            fl    fpcore                                  cost])
-(platform-register-implementations!
- platform
- (; Unary libm operators
-  [fabs.f32      ([x : binary32])                binary32 (fabs x)        (from-libm 'fabsf)      (! :precision binary32 (fabs x))        0]
-  [sin.f32       ([x : binary32])                binary32 (sin x)         (from-libm 'sinf)       (! :precision binary32 (sin x))         0]
-  [cos.f32       ([x : binary32])                binary32 (cos x)         (from-libm 'cosf)       (! :precision binary32 (cos x))         0]
-  [tan.f32       ([x : binary32])                binary32 (tan x)         (from-libm 'tanf)       (! :precision binary32 (tan x))         0]
-  [sinh.f32      ([x : binary32])                binary32 (sinh x)        (from-libm 'sinhf)      (! :precision binary32 (sinh x))        0]
-  [cosh.f32      ([x : binary32])                binary32 (cosh x)        (from-libm 'coshf)      (! :precision binary32 (cosh x))        0]
-  [acos.f32      ([x : binary32])                binary32 (acos x)        (from-libm 'acosf)      (! :precision binary32 (acos x))        0]
-  [acosh.f32     ([x : binary32])                binary32 (acosh x)       (from-libm 'acoshf)     (! :precision binary32 (acosh x))       0]
-  [asin.f32      ([x : binary32])                binary32 (asin x)        (from-libm 'asinf)      (! :precision binary32 (asin x))        0]
-  [asinh.f32     ([x : binary32])                binary32 (asinh x)       (from-libm 'asinhf)     (! :precision binary32 (asinh x))       0]
-  [atan.f32      ([x : binary32])                binary32 (atan x)        (from-libm 'atanf)      (! :precision binary32 (atan x))        0]
-  [atanh.f32     ([x : binary32])                binary32 (atanh x)       (from-libm 'atanhf)     (! :precision binary32 (atanh x))       0]
-  [cbrt.f32      ([x : binary32])                binary32 (cbrt x)        (from-libm 'cbrtf)      (! :precision binary32 (cbrt x))        0]
-  [ceil.f32      ([x : binary32])                binary32 (ceil x)        (from-libm 'ceilf)      (! :precision binary32 (ceil x))        0]
-  [erf.f32       ([x : binary32])                binary32 (erf x)         (from-libm 'erff)       (! :precision binary32 (erf x))         0]
-  [exp.f32       ([x : binary32])                binary32 (exp x)         (from-libm 'expf)       (! :precision binary32 (exp x))         0]
-  [exp2.f32      ([x : binary32])                binary32 (exp2 x)        (from-libm 'exp2f)      (! :precision binary32 (exp2 x))        0]
-  [floor.f32     ([x : binary32])                binary32 (floor x)       (from-libm 'floorf)     (! :precision binary32 (floor x))       0]
-  [lgamma.f32    ([x : binary32])                binary32 (lgamma x)      (from-libm 'lgammaf)    (! :precision binary32 (lgamma x))      0]
-  [log.f32       ([x : binary32])                binary32 (log x)         (from-libm 'logf)       (! :precision binary32 (log x))         0]
-  [log10.f32     ([x : binary32])                binary32 (log10 x)       (from-libm 'log10f)     (! :precision binary32 (log10 x))       0]
-  [log2.f32      ([x : binary32])                binary32 (log2 x)        (from-libm 'log2f)      (! :precision binary32 (log2 x))        0]
-  [logb.f32      ([x : binary32])                binary32 (logb x)        (from-libm 'logbf)      (! :precision binary32 (logb x))        0]
-  [rint.f32      ([x : binary32])                binary32 (rint x)        (from-libm 'rintf)      (! :precision binary32 (rint x))        0]
-  [round.f32     ([x : binary32])                binary32 (round x)       (from-libm 'roundf)     (! :precision binary32 (round x))       0]
-  [sqrt.f32      ([x : binary32])                binary32 (sqrt x)        (from-libm 'sqrtf)      (! :precision binary32 (sqrt x))        0]
-  [tanh.f32      ([x : binary32])                binary32 (tanh x)        (from-libm 'tanhf)      (! :precision binary32 (tanh x))        0]
-  [tgamma.f32    ([x : binary32])                binary32 (tgamma x)      (from-libm 'tgammaf)    (! :precision binary32 (tgamma x))      0]
-  [trunc.f32     ([x : binary32])                binary32 (trunc x)       (from-libm 'truncf)     (! :precision binary32 (trunc x))       0]
-  ; Binary libm operators
-  [pow.f32       ([x : binary32] [y : binary32]) binary32 (pow x y)       (from-libm 'powf)       (! :precision binary32 (pow x y))       0]
-  [atan2.f32     ([x : binary32] [y : binary32]) binary32 (atan2 x y)     (from-libm 'atan2f)     (! :precision binary32 (atan2 x y))     0]
-  [copysign.f32  ([x : binary32] [y : binary32]) binary32 (copysign x y)  (from-libm 'copysignf)  (! :precision binary32 (copysign x y))  0]
-  [fdim.f32      ([x : binary32] [y : binary32]) binary32 (fdim x y)      (from-libm 'fdimf)      (! :precision binary32 (fdim x y))      0]
-  [fmax.f32      ([x : binary32] [y : binary32]) binary32 (fmax x y)      (from-libm 'fmaxf)      (! :precision binary32 (fmax x y))      0]
-  [fmin.f32      ([x : binary32] [y : binary32]) binary32 (fmin x y)      (from-libm 'fminf)      (! :precision binary32 (fmin x y))      0]
-  [fmod.f32      ([x : binary32] [y : binary32]) binary32 (fmod x y)      (from-libm 'fmodf)      (! :precision binary32 (fmod x y))      0]
-  [remainder.f32 ([x : binary32] [y : binary32]) binary32 (remainder x y) (from-libm 'remainderf) (! :precision binary32 (remainder x y)) 0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm accelerators ;;;;;;;;;;;;;;;;;;;;;
-
-; ([name     ([var : repr] ...)                             otype    spec                       fl      fpcore                               cost])
-(platform-register-implementations!
- platform
- ([erfc.f32  ([x : binary32])                               binary32 (- 1 (erf x))              (from-libm 'erfcf)  (! :precision binary32 (erfc x))    0]
-  [expm1.f32 ([x : binary32])                               binary32 (- (exp x) 1)              (from-libm 'expm1f) (! :precision binary32 (expm1 x))   0]
-  [log1p.f32 ([x : binary32])                               binary32 (log (+ 1 x))              (from-libm 'log1pf) (! :precision binary32 (log1p x))   0]
-  [hypot.f32 ([x : binary32] [y : binary32])                binary32 (sqrt (+ (* x x) (* y y))) (from-libm 'hypotf) (! :precision binary32 (hypot x y)) 0]
-  [fma.f32   ([x : binary32] [y : binary32] [z : binary32]) binary32 (+ (* x y) z)              (from-libm 'fmaf)   (! :precision binary32 (fma x y z)) 0]))
+(parameterize ([fpcore-context '(:precision binary32)])
+  (define-operations () <binary32>
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 0]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 0]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 0]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 0])
+  
+  (define-operation (neg.f32 [x <binary32>]) <binary32>
+    #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 0)
+  
+  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+    [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0]
+    [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0]
+    [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0]
+    [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0])
+  
+  (define-operations ([x <binary32>]) <binary32>
+    [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0]
+    [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 0]
+    [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 0]
+    [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 0]
+    [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 0]
+    [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 0]
+    [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 0]
+    [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 0]
+    [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 0]
+    [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 0]
+    [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 0]
+    [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 0]
+    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 0]
+    [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 0]
+    [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 0]
+    [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 0]
+    [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 0]
+    [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 0]
+    [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 0]
+    [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 0]
+    [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 0]
+    [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 0]
+    [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 0]
+    [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 0]
+    [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 0]
+    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 0]
+    [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 0]
+    [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 0]
+    [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0])
+  
+  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+    [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 0]
+    [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 0]
+    [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0]
+    [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 0]
+    [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 0]
+    [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 0]
+    [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 0]
+    [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 0])
+  
+  (define-operations ([x <binary32>]) <binary32>
+    [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0]
+    [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0]
+    [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 0])
+  
+  (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
+    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf) #:fpcore (hypot x y) #:cost 0)
+  
+  (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
+    #:spec (+ (* x y) z) #:impl (from-libm 'fmaf) #:fpcore (fma x y z) #:cost 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <binary64> #:cost 0)
 
-(define binary64 <binary64>)
+(define-operations ([x <binary64>] [y <binary64>]) <bool>
+  [==.f64 #:spec (== x y) #:impl =          #:cost 0]
+  [!=.f64 #:spec (!= x y) #:impl (negate =) #:cost 0]
+  [<.f64  #:spec (< x y)  #:impl <          #:cost 0]
+  [>.f64  #:spec (> x y)  #:impl >          #:cost 0]
+  [<=.f64 #:spec (<= x y) #:impl <=         #:cost 0]
+  [>=.f64 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(platform-register-representation! platform #:repr binary64 #:cost 0)
+(parameterize ([fpcore-context '(:precision binary64)])
+  (define-operations () <binary64>
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 0]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 0]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 0]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 0])
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [+.f64 #:spec (+ x y) #:impl + #:cost 0]
+    [-.f64 #:spec (- x y) #:impl - #:cost 0]
+    [*.f64 #:spec (* x y) #:impl * #:cost 0]
+    [/.f64 #:spec (/ x y) #:impl / #:cost 0])
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  (define-operation (neg.f64 [x <binary64>]) <binary64>
+    #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0)
+  
+  (define-operations ([x <binary64>]) <binary64>
+    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0]
+    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 0]
+    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 0]
+    [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 0]
+    [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 0]
+    [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 0]
+    [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 0]
+    [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 0]
+    [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 0]
+    [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 0]
+    [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 0]
+    [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 0]
+    [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 0]
+    [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 0]
+    [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 0]
+    [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 0]
+    [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 0]
+    [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 0]
+    [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 0]
+    [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 0]
+    [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 0]
+    [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 0]
+    [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 0]
+    [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 0]
+    [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 0]
+    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 0]
+    [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 0]
+    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 0]
+    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0])
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 0]
+    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 0]
+    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0]
+    [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 0]
+    [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 0]
+    [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 0]
+    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 0]
+    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 0])
+  
+  (define-operations ([x <binary64>]) <binary64>
+    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0]
+    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0]
+    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 0])
+  
+  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot) #:fpcore (hypot x y) #:cost 0)
+  
+  (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+    #:spec (+ (* x y) z) #:impl (from-libm 'fma) #:fpcore (fma x y z) #:cost 0))
 
-(platform-register-implementations!
- platform
- ([PI.f64       () binary64 (PI)       (const pi)        (! :precision binary64 PI)       0]
-  [E.f64        () binary64 (E)        (const (exp 1.0)) (! :precision binary64 E)        0]
-  [INFINITY.f64 () binary64 (INFINITY) (const +inf.0)    (! :precision binary64 INFINITY) 0]
-  [NAN.f64      () binary64 (NAN)      (const +nan.0)    (! :precision binary64 NAN)      0]))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-operation (binary64->binary32 [x <binary64>]) <binary32>
+  #:spec x #:fpcore (! :precision binary32 (cast x)) #:impl flsingle #:cost 0)
 
-(platform-register-implementations!
- platform
- ([neg.f64 ([x : binary64])                binary64 (neg x)  -          (! :precision binary64 (- x))   0]
-  [+.f64   ([x : binary64] [y : binary64]) binary64 (+ x y)  +          (! :precision binary64 (+ x y)) 0]
-  [-.f64   ([x : binary64] [y : binary64]) binary64 (- x y)  -          (! :precision binary64 (- x y)) 0]
-  [*.f64   ([x : binary64] [y : binary64]) binary64 (* x y)  *          (! :precision binary64 (* x y)) 0]
-  [/.f64   ([x : binary64] [y : binary64]) binary64 (/ x y)  /          (! :precision binary64 (/ x y)) 0]
-  [==.f64  ([x : binary64] [y : binary64]) bool     (== x y) =          (== x y)                        0]
-  [!=.f64  ([x : binary64] [y : binary64]) bool     (!= x y) (negate =) (!= x y)                        0]
-  [<.f64   ([x : binary64] [y : binary64]) bool     (< x y)  <          (< x y)                         0]
-  [>.f64   ([x : binary64] [y : binary64]) bool     (> x y)  >          (> x y)                         0]
-  [<=.f64  ([x : binary64] [y : binary64]) bool     (<= x y) <=         (<= x y)                        0]
-  [>=.f64  ([x : binary64] [y : binary64]) bool     (>= x y) >=         (>= x y)                        0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm operators ;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name         ([var : repr] ...)              otype    spec            fl    fpcore                                  cost])
-(platform-register-implementations!
- platform
- (; Unary libm operators
-  [fabs.f64      ([x : binary64])                binary64 (fabs x)        (from-libm 'fabs)      (! :precision binary64 (fabs x))        0]
-  [sin.f64       ([x : binary64])                binary64 (sin x)         (from-libm 'sin)       (! :precision binary64 (sin x))         0]
-  [cos.f64       ([x : binary64])                binary64 (cos x)         (from-libm 'cos)       (! :precision binary64 (cos x))         0]
-  [tan.f64       ([x : binary64])                binary64 (tan x)         (from-libm 'tan)       (! :precision binary64 (tan x))         0]
-  [sinh.f64      ([x : binary64])                binary64 (sinh x)        (from-libm 'sinh)      (! :precision binary64 (sinh x))        0]
-  [cosh.f64      ([x : binary64])                binary64 (cosh x)        (from-libm 'cosh)      (! :precision binary64 (cosh x))        0]
-  [acos.f64      ([x : binary64])                binary64 (acos x)        (from-libm 'acos)      (! :precision binary64 (acos x))        0]
-  [acosh.f64     ([x : binary64])                binary64 (acosh x)       (from-libm 'acosh)     (! :precision binary64 (acosh x))       0]
-  [asin.f64      ([x : binary64])                binary64 (asin x)        (from-libm 'asin)      (! :precision binary64 (asin x))        0]
-  [asinh.f64     ([x : binary64])                binary64 (asinh x)       (from-libm 'asinh)     (! :precision binary64 (asinh x))       0]
-  [atan.f64      ([x : binary64])                binary64 (atan x)        (from-libm 'atan)      (! :precision binary64 (atan x))        0]
-  [atanh.f64     ([x : binary64])                binary64 (atanh x)       (from-libm 'atanh)     (! :precision binary64 (atanh x))       0]
-  [cbrt.f64      ([x : binary64])                binary64 (cbrt x)        (from-libm 'cbrt)      (! :precision binary64 (cbrt x))        0]
-  [ceil.f64      ([x : binary64])                binary64 (ceil x)        (from-libm 'ceil)      (! :precision binary64 (ceil x))        0]
-  [erf.f64       ([x : binary64])                binary64 (erf x)         (from-libm 'erf)       (! :precision binary64 (erf x))         0]
-  [exp.f64       ([x : binary64])                binary64 (exp x)         (from-libm 'exp)       (! :precision binary64 (exp x))         0]
-  [exp2.f64      ([x : binary64])                binary64 (exp2 x)        (from-libm 'exp2)      (! :precision binary64 (exp2 x))        0]
-  [floor.f64     ([x : binary64])                binary64 (floor x)       (from-libm 'floor)     (! :precision binary64 (floor x))       0]
-  [lgamma.f64    ([x : binary64])                binary64 (lgamma x)      (from-libm 'lgamma)    (! :precision binary64 (lgamma x))      0]
-  [log.f64       ([x : binary64])                binary64 (log x)         (from-libm 'log)       (! :precision binary64 (log x))         0]
-  [log10.f64     ([x : binary64])                binary64 (log10 x)       (from-libm 'log10)     (! :precision binary64 (log10 x))       0]
-  [log2.f64      ([x : binary64])                binary64 (log2 x)        (from-libm 'log2)      (! :precision binary64 (log2 x))        0]
-  [logb.f64      ([x : binary64])                binary64 (logb x)        (from-libm 'logb)      (! :precision binary64 (logb x))        0]
-  [rint.f64      ([x : binary64])                binary64 (rint x)        (from-libm 'rint)      (! :precision binary64 (rint x))        0]
-  [round.f64     ([x : binary64])                binary64 (round x)       (from-libm 'round)     (! :precision binary64 (round x))       0]
-  [sqrt.f64      ([x : binary64])                binary64 (sqrt x)        (from-libm 'sqrt)      (! :precision binary64 (sqrt x))        0]
-  [tanh.f64      ([x : binary64])                binary64 (tanh x)        (from-libm 'tanh)      (! :precision binary64 (tanh x))        0]
-  [tgamma.f64    ([x : binary64])                binary64 (tgamma x)      (from-libm 'tgamma)    (! :precision binary64 (tgamma x))      0]
-  [trunc.f64     ([x : binary64])                binary64 (trunc x)       (from-libm 'trunc)     (! :precision binary64 (trunc x))       0]
-  ; Binary libm operators
-  [pow.f64       ([x : binary64] [y : binary64]) binary64 (pow x y)       (from-libm 'pow)       (! :precision binary64 (pow x y))       0]
-  [atan2.f64     ([x : binary64] [y : binary64]) binary64 (atan2 x y)     (from-libm 'atan2)     (! :precision binary64 (atan2 x y))     0]
-  [copysign.f64  ([x : binary64] [y : binary64]) binary64 (copysign x y)  (from-libm 'copysign)  (! :precision binary64 (copysign x y))  0]
-  [fdim.f64      ([x : binary64] [y : binary64]) binary64 (fdim x y)      (from-libm 'fdim)      (! :precision binary64 (fdim x y))      0]
-  [fmax.f64      ([x : binary64] [y : binary64]) binary64 (fmax x y)      (from-libm 'fmax)      (! :precision binary64 (fmax x y))      0]
-  [fmin.f64      ([x : binary64] [y : binary64]) binary64 (fmin x y)      (from-libm 'fmin)      (! :precision binary64 (fmin x y))      0]
-  [fmod.f64      ([x : binary64] [y : binary64]) binary64 (fmod x y)      (from-libm 'fmod)      (! :precision binary64 (fmod x y))      0]
-  [remainder.f64 ([x : binary64] [y : binary64]) binary64 (remainder x y) (from-libm 'remainder) (! :precision binary64 (remainder x y)) 0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm accelerators ;;;;;;;;;;;;;;;;;;;;;
-
-; ([name     ([var : repr] ...)                             otype    spec                       fl    fpcore                              cost])
-(platform-register-implementations!
- platform
- ([erfc.f64  ([x : binary64])                               binary64 (- 1 (erf x))              (from-libm 'erfc)  (! :precision binary64 (erfc x))    0]
-  [expm1.f64 ([x : binary64])                               binary64 (- (exp x) 1)              (from-libm 'expm1) (! :precision binary64 (expm1 x))   0]
-  [log1p.f64 ([x : binary64])                               binary64 (log (+ 1 x))              (from-libm 'log1p) (! :precision binary64 (log1p x))   0]
-  [hypot.f64 ([x : binary64] [y : binary64])                binary64 (sqrt (+ (* x x) (* y y))) (from-libm 'hypot) (! :precision binary64 (hypot x y)) 0]
-  [fma.f64   ([x : binary64] [y : binary64] [z : binary64]) binary64 (+ (* x y) z)              (from-libm 'fma)   (! :precision binary64 (fma x y z)) 0]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; additional converters ;;;;;;;;;;;;;;;;;
-
-#;(platform-register-implementation! platform
-                                     (make-operator-impl (binary64->binary32 [x : binary64])
-                                                         binary32
-                                                         #:spec x
-                                                         #:fpcore (! :precision binary32 (cast x))
-                                                         #:impl flsingle))
-
-#;(platform-register-implementation! platform
-                                     (make-operator-impl (binary32->binary64 [x : binary32])
-                                                         binary64
-                                                         #:spec x
-                                                         #:fpcore (! :precision binary64 (cast x))
-                                                         #:impl identity))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; REGISTER PLATFORM ;;;;;;;;;;;;;;;;;;;;;
-
-(module+ main
-  (display-platform platform))
-
-;; Do not run this file during testing
-(module test racket/base
-  )
+(define-operation (binary32->binary64 [x <binary32>]) <binary64>
+  #:spec x #:fpcore (! :precision binary64 (cast x)) #:impl identity #:cost 0)

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -1,250 +1,191 @@
-#lang racket
+#lang s-exp "../platform.rkt"
 
-;;; The default platform:
-;;; C/C++ on Linux with a full libm
+;; Herbie 2.0 platform. Based on the C Windows platform, but with
+;; every operation having heuristic costs from Herbie 2.0.
 
-(require math/bigfloat
-         math/flonum
-         "../syntax/types.rkt"  ; for shift/unshift
-         "../syntax/platform.rkt")
-(provide platform)
+(require math/flonum)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; EMPTY PLATFORM ;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define platform (make-empty-platform 'herbie20))
-
-(platform-register-if-cost! platform #:if-cost 1)
+(define-if #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <bool> #:cost 1)
 
-(define bool <bool>)
+(define-operations () <bool>
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost 1]
+  [FALSE #:spec (FALSE) #:impl (const false) #:cost 1])
 
-(platform-register-representation! platform #:repr bool #:cost 1)
+(define-operations ([x <bool>] [y <bool>]) <bool>
+  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost 1]
+  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost 1])
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([TRUE  () bool (TRUE)  (const true)  (! TRUE)  1]
-  [FALSE () bool (FALSE) (const false) (! FALSE) 1]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (and-fn . as)
-  (andmap identity as))
-(define (or-fn . as)
-  (ormap identity as))
-
-(platform-register-implementations!
- platform
- ([not ([x : bool])            bool (not x)   not    (not x)   1]
-  [and ([x : bool] [y : bool]) bool (and x y) and-fn (and x y) 1]
-  [or  ([x : bool] [y : bool]) bool (or x y)  or-fn  (or x y)  1]))
+(define-operation (not [x <bool>]) <bool>
+  #:spec (not x) #:impl not #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <binary32> #:cost 32)
 
-(define binary32 <binary32>)
+(define-operations ([x <binary32>] [y <binary32>]) <bool>
+  [==.f32 #:spec (== x y) #:impl =          #:cost 128]
+  [!=.f32 #:spec (!= x y) #:impl (negate =) #:cost 128]
+  [<.f32  #:spec (< x y)  #:impl <          #:cost 128]
+  [>.f32  #:spec (> x y)  #:impl >          #:cost 128]
+  [<=.f32 #:spec (<= x y) #:impl <=         #:cost 128]
+  [>=.f32 #:spec (>= x y) #:impl >=         #:cost 128])
 
-(platform-register-representation! platform #:repr binary32 #:cost 32)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([PI.f32       () binary32 (PI)       (const (flsingle pi))        (! :precision binary32 PI)       32]
-  [E.f32        () binary32 (E)        (const (flsingle (exp 1.0))) (! :precision binary32 E)        32]
-  [INFINITY.f32 () binary32 (INFINITY) (const +inf.0)               (! :precision binary32 INFINITY) 32]
-  [NAN.f32      () binary32 (NAN)      (const +nan.0)               (! :precision binary32 NAN)      32]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name   ([var : repr] ...)              otype    spec     fl         fpcore                         cost])
-(platform-register-implementations!
- platform
- ([neg.f32 ([x : binary32])                binary32 (neg x)  (compose flsingle -)      (! :precision binary32 (- x))   64]
-  [+.f32   ([x : binary32] [y : binary32]) binary32 (+ x y)  (compose flsingle +)      (! :precision binary32 (+ x y)) 64]
-  [-.f32   ([x : binary32] [y : binary32]) binary32 (- x y)  (compose flsingle -)      (! :precision binary32 (- x y)) 64]
-  [*.f32   ([x : binary32] [y : binary32]) binary32 (* x y)  (compose flsingle *)      (! :precision binary32 (* x y)) 128]
-  [/.f32   ([x : binary32] [y : binary32]) binary32 (/ x y)  (compose flsingle /)      (! :precision binary32 (/ x y)) 320]
-  [==.f32  ([x : binary32] [y : binary32]) bool     (== x y) =          (== x y)                        128]
-  [!=.f32  ([x : binary32] [y : binary32]) bool     (!= x y) (negate =) (!= x y)                        128]
-  [<.f32   ([x : binary32] [y : binary32]) bool     (< x y)  <          (< x y)                         128]
-  [>.f32   ([x : binary32] [y : binary32]) bool     (> x y)  >          (> x y)                         128]
-  [<=.f32  ([x : binary32] [y : binary32]) bool     (<= x y) <=         (<= x y)                        128]
-  [>=.f32  ([x : binary32] [y : binary32]) bool     (>= x y) >=         (>= x y)                        128]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm operators ;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name         ([var : repr] ...)              otype    spec            fl    fpcore                                  cost])
-(platform-register-implementations!
- platform
- (; Unary libm operators
-  [fabs.f32      ([x : binary32])                binary32 (fabs x)        (from-libm 'fabsf)      (! :precision binary32 (fabs x))        64]
-  [sin.f32       ([x : binary32])                binary32 (sin x)         (from-libm 'sinf)       (! :precision binary32 (sin x))         3200]
-  [cos.f32       ([x : binary32])                binary32 (cos x)         (from-libm 'cosf)       (! :precision binary32 (cos x))         3200]
-  [tan.f32       ([x : binary32])                binary32 (tan x)         (from-libm 'tanf)       (! :precision binary32 (tan x))         3200]
-  [sinh.f32      ([x : binary32])                binary32 (sinh x)        (from-libm 'sinhf)      (! :precision binary32 (sinh x))        3200]
-  [cosh.f32      ([x : binary32])                binary32 (cosh x)        (from-libm 'coshf)      (! :precision binary32 (cosh x))        3200]
-  [acos.f32      ([x : binary32])                binary32 (acos x)        (from-libm 'acosf)      (! :precision binary32 (acos x))        3200]
-  [acosh.f32     ([x : binary32])                binary32 (acosh x)       (from-libm 'acoshf)     (! :precision binary32 (acosh x))       3200]
-  [asin.f32      ([x : binary32])                binary32 (asin x)        (from-libm 'asinf)      (! :precision binary32 (asin x))        3200]
-  [asinh.f32     ([x : binary32])                binary32 (asinh x)       (from-libm 'asinhf)     (! :precision binary32 (asinh x))       3200]
-  [atan.f32      ([x : binary32])                binary32 (atan x)        (from-libm 'atanf)      (! :precision binary32 (atan x))        3200]
-  [atanh.f32     ([x : binary32])                binary32 (atanh x)       (from-libm 'atanhf)     (! :precision binary32 (atanh x))       3200]
-  [cbrt.f32      ([x : binary32])                binary32 (cbrt x)        (from-libm 'cbrtf)      (! :precision binary32 (cbrt x))        3200]
-  [ceil.f32      ([x : binary32])                binary32 (ceil x)        (from-libm 'ceilf)      (! :precision binary32 (ceil x))        3200]
-  [erf.f32       ([x : binary32])                binary32 (erf x)         (from-libm 'erff)       (! :precision binary32 (erf x))         3200]
-  [exp.f32       ([x : binary32])                binary32 (exp x)         (from-libm 'expf)       (! :precision binary32 (exp x))         3200]
-  [exp2.f32      ([x : binary32])                binary32 (exp2 x)        (from-libm 'exp2f)      (! :precision binary32 (exp2 x))        3200]
-  [floor.f32     ([x : binary32])                binary32 (floor x)       (from-libm 'floorf)     (! :precision binary32 (floor x))       3200]
-  [lgamma.f32    ([x : binary32])                binary32 (lgamma x)      (from-libm 'lgammaf)    (! :precision binary32 (lgamma x))      3200]
-  [log.f32       ([x : binary32])                binary32 (log x)         (from-libm 'logf)       (! :precision binary32 (log x))         3200]
-  [log10.f32     ([x : binary32])                binary32 (log10 x)       (from-libm 'log10f)     (! :precision binary32 (log10 x))       3200]
-  [log2.f32      ([x : binary32])                binary32 (log2 x)        (from-libm 'log2f)      (! :precision binary32 (log2 x))        3200]
-  [logb.f32      ([x : binary32])                binary32 (logb x)        (from-libm 'logbf)      (! :precision binary32 (logb x))        3200]
-  [rint.f32      ([x : binary32])                binary32 (rint x)        (from-libm 'rintf)      (! :precision binary32 (rint x))        3200]
-  [round.f32     ([x : binary32])                binary32 (round x)       (from-libm 'roundf)     (! :precision binary32 (round x))       3200]
-  [sqrt.f32      ([x : binary32])                binary32 (sqrt x)        (from-libm 'sqrtf)      (! :precision binary32 (sqrt x))        320]
-  [tanh.f32      ([x : binary32])                binary32 (tanh x)        (from-libm 'tanhf)      (! :precision binary32 (tanh x))        3200]
-  [tgamma.f32    ([x : binary32])                binary32 (tgamma x)      (from-libm 'tgammaf)    (! :precision binary32 (tgamma x))      3200]
-  [trunc.f32     ([x : binary32])                binary32 (trunc x)       (from-libm 'truncf)     (! :precision binary32 (trunc x))       3200]
-  ; Binary libm operators
-  [pow.f32       ([x : binary32] [y : binary32]) binary32 (pow x y)       (from-libm 'powf)       (! :precision binary32 (pow x y))       3200]
-  [atan2.f32     ([x : binary32] [y : binary32]) binary32 (atan2 x y)     (from-libm 'atan2f)     (! :precision binary32 (atan2 x y))     3200]
-  [copysign.f32  ([x : binary32] [y : binary32]) binary32 (copysign x y)  (from-libm 'copysignf)  (! :precision binary32 (copysign x y))  3200]
-  [fdim.f32      ([x : binary32] [y : binary32]) binary32 (fdim x y)      (from-libm 'fdimf)      (! :precision binary32 (fdim x y))      3200]
-  [fmax.f32      ([x : binary32] [y : binary32]) binary32 (fmax x y)      (from-libm 'fmaxf)      (! :precision binary32 (fmax x y))      3200]
-  [fmin.f32      ([x : binary32] [y : binary32]) binary32 (fmin x y)      (from-libm 'fminf)      (! :precision binary32 (fmin x y))      3200]
-  [fmod.f32      ([x : binary32] [y : binary32]) binary32 (fmod x y)      (from-libm 'fmodf)      (! :precision binary32 (fmod x y))      3200]
-  [remainder.f32 ([x : binary32] [y : binary32]) binary32 (remainder x y) (from-libm 'remainderf) (! :precision binary32 (remainder x y)) 3200]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm accelerators ;;;;;;;;;;;;;;;;;;;;;
-
-; ([name     ([var : repr] ...)                             otype    spec                       fl      fpcore                               cost])
-(platform-register-implementations!
- platform
- ([erfc.f32  ([x : binary32])                               binary32 (- 1 (erf x))              (from-libm 'erfcf)  (! :precision binary32 (erfc x))    3200]
-  [expm1.f32 ([x : binary32])                               binary32 (- (exp x) 1)              (from-libm 'expm1f) (! :precision binary32 (expm1 x))   3200]
-  [log1p.f32 ([x : binary32])                               binary32 (log (+ 1 x))              (from-libm 'log1pf) (! :precision binary32 (log1p x))   3200]
-  [hypot.f32 ([x : binary32] [y : binary32])                binary32 (sqrt (+ (* x x) (* y y))) (from-libm 'hypotf) (! :precision binary32 (hypot x y)) 3200]
-  [fma.f32   ([x : binary32] [y : binary32] [z : binary32]) binary32 (+ (* x y) z)              (from-libm 'fmaf)   (! :precision binary32 (fma x y z)) 128]))
+(parameterize ([fpcore-context '(:precision binary32)])
+  (define-operations () <binary32>
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 32]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 32]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 32]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 32])
+  
+  (define-operation (neg.f32 [x <binary32>]) <binary32>
+    #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 64)
+  
+  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+    [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 64]
+    [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 64]
+    [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 128]
+    [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 320])
+  
+  (define-operations ([x <binary32>]) <binary32>
+    [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 64]
+    [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 3200]
+    [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 3200]
+    [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 3200]
+    [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 3200]
+    [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 3200]
+    [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 3200]
+    [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 3200]
+    [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 3200]
+    [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 3200]
+    [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 3200]
+    [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 3200]
+    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 3200]
+    [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 3200]
+    [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 3200]
+    [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 3200]
+    [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 3200]
+    [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 3200]
+    [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 3200]
+    [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 3200]
+    [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 3200]
+    [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 3200]
+    [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 3200]
+    [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 3200]
+    [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 3200]
+    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 3200]
+    [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 3200]
+    [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
+    [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
+  
+  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+    [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 3200]
+    [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 3200]
+    [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 3200]
+    [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 3200]
+    [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 3200]
+    [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 3200]
+    [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 3200]
+    [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 3200])
+  
+  (define-operations ([x <binary32>]) <binary32>
+    [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 3200]
+    [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 3200]
+    [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 3200])
+  
+  (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
+    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf) #:fpcore (hypot x y) #:cost 3200)
+  
+  (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
+    #:spec (+ (* x y) z) #:impl (from-libm 'fmaf) #:fpcore (fma x y z) #:cost 128))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <binary64> #:cost 64)
 
-(define binary64 <binary64>)
+(define-operations ([x <binary64>] [y <binary64>]) <bool>
+  [==.f64 #:spec (== x y) #:impl =          #:cost 256]
+  [!=.f64 #:spec (!= x y) #:impl (negate =) #:cost 256]
+  [<.f64  #:spec (< x y)  #:impl <          #:cost 256]
+  [>.f64  #:spec (> x y)  #:impl >          #:cost 256]
+  [<=.f64 #:spec (<= x y) #:impl <=         #:cost 256]
+  [>=.f64 #:spec (>= x y) #:impl >=         #:cost 256])
+  
+(parameterize ([fpcore-context '(:precision binary64)])
+  (define-operations () <binary64>
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 64]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 64]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 64]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 64])
+  
+  (define-operation (neg.f64 [x <binary64>]) <binary64>
+    #:spec (neg x) #:impl - #:fpcore (- x) #:cost 128)
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [+.f64 #:spec (+ x y) #:impl + #:cost 128]
+    [-.f64 #:spec (- x y) #:impl - #:cost 128]
+    [*.f64 #:spec (* x y) #:impl * #:cost 256]
+    [/.f64 #:spec (/ x y) #:impl / #:cost 640])
 
-(platform-register-representation! platform #:repr binary64 #:cost 64)
+  (define-operations ([x <binary64>]) <binary64>
+    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 128]
+    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 6400]
+    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 6400]
+    [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 6400]
+    [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 6400]
+    [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 6400]
+    [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 6400]
+    [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 6400]
+    [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 6400]
+    [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 6400]
+    [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 6400]
+    [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 6400]
+    [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 6400]
+    [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 6400]
+    [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 6400]
+    [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 6400]
+    [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 6400]
+    [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 6400]
+    [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 6400]
+    [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 6400]
+    [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 6400]
+    [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 6400]
+    [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 6400]
+    [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 6400]
+    [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 6400]
+    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 6400]
+    [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 6400]
+    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
+    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 6400]
+    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 6400]
+    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 6400]
+    [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 6400]
+    [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 6400]
+    [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 6400]
+    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 6400]
+    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 6400])
+  
+  (define-operations ([x <binary64>]) <binary64>
+    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 6400]
+    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 6400]
+    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 6400])
+  
+  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot) #:fpcore (hypot x y) #:cost 6400)
+  
+  (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+    #:spec (+ (* x y) z) #:impl (from-libm 'fma) #:fpcore (fma x y z) #:cost 256))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(platform-register-implementations!
- platform
- ([PI.f64       () binary64 (PI)       (const pi)        (! :precision binary64 PI)       64]
-  [E.f64        () binary64 (E)        (const (exp 1.0)) (! :precision binary64 E)        64]
-  [INFINITY.f64 () binary64 (INFINITY) (const +inf.0)    (! :precision binary64 INFINITY) 64]
-  [NAN.f64      () binary64 (NAN)      (const +nan.0)    (! :precision binary64 NAN)      64]))
+(define-operation (binary64->binary32 [x <binary64>]) <binary32>
+  #:spec x #:fpcore (! :precision binary32 (cast x)) #:impl flsingle #:cost 64)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([neg.f64 ([x : binary64])                binary64 (neg x)  -          (! :precision binary64 (- x))   128]
-  [+.f64   ([x : binary64] [y : binary64]) binary64 (+ x y)  +          (! :precision binary64 (+ x y)) 128]
-  [-.f64   ([x : binary64] [y : binary64]) binary64 (- x y)  -          (! :precision binary64 (- x y)) 128]
-  [*.f64   ([x : binary64] [y : binary64]) binary64 (* x y)  *          (! :precision binary64 (* x y)) 256]
-  [/.f64   ([x : binary64] [y : binary64]) binary64 (/ x y)  /          (! :precision binary64 (/ x y)) 640]
-  [==.f64  ([x : binary64] [y : binary64]) bool     (== x y) =          (== x y)                        256]
-  [!=.f64  ([x : binary64] [y : binary64]) bool     (!= x y) (negate =) (!= x y)                        256]
-  [<.f64   ([x : binary64] [y : binary64]) bool     (< x y)  <          (< x y)                         256]
-  [>.f64   ([x : binary64] [y : binary64]) bool     (> x y)  >          (> x y)                         256]
-  [<=.f64  ([x : binary64] [y : binary64]) bool     (<= x y) <=         (<= x y)                        256]
-  [>=.f64  ([x : binary64] [y : binary64]) bool     (>= x y) >=         (>= x y)                        256]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm operators ;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name         ([var : repr] ...)              otype    spec            fl    fpcore                                  cost])
-(platform-register-implementations!
- platform
- (; Unary libm operators
-  [fabs.f64      ([x : binary64])                binary64 (fabs x)        (from-libm 'fabs)      (! :precision binary64 (fabs x))        128]
-  [sin.f64       ([x : binary64])                binary64 (sin x)         (from-libm 'sin)       (! :precision binary64 (sin x))         6400]
-  [cos.f64       ([x : binary64])                binary64 (cos x)         (from-libm 'cos)       (! :precision binary64 (cos x))         6400]
-  [tan.f64       ([x : binary64])                binary64 (tan x)         (from-libm 'tan)       (! :precision binary64 (tan x))         6400]
-  [sinh.f64      ([x : binary64])                binary64 (sinh x)        (from-libm 'sinh)      (! :precision binary64 (sinh x))        6400]
-  [cosh.f64      ([x : binary64])                binary64 (cosh x)        (from-libm 'cosh)      (! :precision binary64 (cosh x))        6400]
-  [acos.f64      ([x : binary64])                binary64 (acos x)        (from-libm 'acos)      (! :precision binary64 (acos x))        6400]
-  [acosh.f64     ([x : binary64])                binary64 (acosh x)       (from-libm 'acosh)     (! :precision binary64 (acosh x))       6400]
-  [asin.f64      ([x : binary64])                binary64 (asin x)        (from-libm 'asin)      (! :precision binary64 (asin x))        6400]
-  [asinh.f64     ([x : binary64])                binary64 (asinh x)       (from-libm 'asinh)     (! :precision binary64 (asinh x))       6400]
-  [atan.f64      ([x : binary64])                binary64 (atan x)        (from-libm 'atan)      (! :precision binary64 (atan x))        6400]
-  [atanh.f64     ([x : binary64])                binary64 (atanh x)       (from-libm 'atanh)     (! :precision binary64 (atanh x))       6400]
-  [cbrt.f64      ([x : binary64])                binary64 (cbrt x)        (from-libm 'cbrt)      (! :precision binary64 (cbrt x))        6400]
-  [ceil.f64      ([x : binary64])                binary64 (ceil x)        (from-libm 'ceil)      (! :precision binary64 (ceil x))        6400]
-  [erf.f64       ([x : binary64])                binary64 (erf x)         (from-libm 'erf)       (! :precision binary64 (erf x))         6400]
-  [exp.f64       ([x : binary64])                binary64 (exp x)         (from-libm 'exp)       (! :precision binary64 (exp x))         6400]
-  [exp2.f64      ([x : binary64])                binary64 (exp2 x)        (from-libm 'exp2)      (! :precision binary64 (exp2 x))        6400]
-  [floor.f64     ([x : binary64])                binary64 (floor x)       (from-libm 'floor)     (! :precision binary64 (floor x))       6400]
-  [lgamma.f64    ([x : binary64])                binary64 (lgamma x)      (from-libm 'lgamma)    (! :precision binary64 (lgamma x))      6400]
-  [log.f64       ([x : binary64])                binary64 (log x)         (from-libm 'log)       (! :precision binary64 (log x))         6400]
-  [log10.f64     ([x : binary64])                binary64 (log10 x)       (from-libm 'log10)     (! :precision binary64 (log10 x))       6400]
-  [log2.f64      ([x : binary64])                binary64 (log2 x)        (from-libm 'log2)      (! :precision binary64 (log2 x))        6400]
-  [logb.f64      ([x : binary64])                binary64 (logb x)        (from-libm 'logb)      (! :precision binary64 (logb x))        6400]
-  [rint.f64      ([x : binary64])                binary64 (rint x)        (from-libm 'rint)      (! :precision binary64 (rint x))        6400]
-  [round.f64     ([x : binary64])                binary64 (round x)       (from-libm 'round)     (! :precision binary64 (round x))       6400]
-  [sqrt.f64      ([x : binary64])                binary64 (sqrt x)        (from-libm 'sqrt)      (! :precision binary64 (sqrt x))        640]
-  [tanh.f64      ([x : binary64])                binary64 (tanh x)        (from-libm 'tanh)      (! :precision binary64 (tanh x))        6400]
-  [tgamma.f64    ([x : binary64])                binary64 (tgamma x)      (from-libm 'tgamma)    (! :precision binary64 (tgamma x))      6400]
-  [trunc.f64     ([x : binary64])                binary64 (trunc x)       (from-libm 'trunc)     (! :precision binary64 (trunc x))       6400]
-  ; Binary libm operators
-  [pow.f64       ([x : binary64] [y : binary64]) binary64 (pow x y)       (from-libm 'pow)       (! :precision binary64 (pow x y))       6400]
-  [atan2.f64     ([x : binary64] [y : binary64]) binary64 (atan2 x y)     (from-libm 'atan2)     (! :precision binary64 (atan2 x y))     6400]
-  [copysign.f64  ([x : binary64] [y : binary64]) binary64 (copysign x y)  (from-libm 'copysign)  (! :precision binary64 (copysign x y))  6400]
-  [fdim.f64      ([x : binary64] [y : binary64]) binary64 (fdim x y)      (from-libm 'fdim)      (! :precision binary64 (fdim x y))      6400]
-  [fmax.f64      ([x : binary64] [y : binary64]) binary64 (fmax x y)      (from-libm 'fmax)      (! :precision binary64 (fmax x y))      6400]
-  [fmin.f64      ([x : binary64] [y : binary64]) binary64 (fmin x y)      (from-libm 'fmin)      (! :precision binary64 (fmin x y))      6400]
-  [fmod.f64      ([x : binary64] [y : binary64]) binary64 (fmod x y)      (from-libm 'fmod)      (! :precision binary64 (fmod x y))      6400]
-  [remainder.f64 ([x : binary64] [y : binary64]) binary64 (remainder x y) (from-libm 'remainder) (! :precision binary64 (remainder x y)) 6400]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm accelerators ;;;;;;;;;;;;;;;;;;;;;
-
-; ([name     ([var : repr] ...)                             otype    spec                       fl    fpcore                              cost])
-(platform-register-implementations!
- platform
- ([erfc.f64  ([x : binary64])                               binary64 (- 1 (erf x))              (from-libm 'erfc)  (! :precision binary64 (erfc x))    6400]
-  [expm1.f64 ([x : binary64])                               binary64 (- (exp x) 1)              (from-libm 'expm1) (! :precision binary64 (expm1 x))   6400]
-  [log1p.f64 ([x : binary64])                               binary64 (log (+ 1 x))              (from-libm 'log1p) (! :precision binary64 (log1p x))   6400]
-  [hypot.f64 ([x : binary64] [y : binary64])                binary64 (sqrt (+ (* x x) (* y y))) (from-libm 'hypot) (! :precision binary64 (hypot x y)) 6400]
-  [fma.f64   ([x : binary64] [y : binary64] [z : binary64]) binary64 (+ (* x y) z)              (from-libm 'fma)   (! :precision binary64 (fma x y z)) 256]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; additional converters ;;;;;;;;;;;;;;;;;
-
-#;(platform-register-implementation! platform
-                                     (make-operator-impl (binary64->binary32 [x : binary64])
-                                                         binary32
-                                                         #:spec x
-                                                         #:fpcore (! :precision binary32 (cast x))
-                                                         #:impl flsingle
-                                                         #:cost 64))
-
-#;(platform-register-implementation! platform
-                                     (make-operator-impl (binary32->binary64 [x : binary32])
-                                                         binary64
-                                                         #:spec x
-                                                         #:fpcore (! :precision binary64 (cast x))
-                                                         #:impl identity
-                                                         #:cost 64))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; REGISTER PLATFORM ;;;;;;;;;;;;;;;;;;;;;
-
-(module+ main
-  (display-platform platform))
-
-;; Do not run this file during testing
-(module test racket/base
-  )
+(define-operation (binary32->binary64 [x <binary32>]) <binary64>
+  #:spec x #:fpcore (! :precision binary64 (cast x)) #:impl identity #:cost 64)

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -12,8 +12,8 @@
 (define-representation <bool> #:cost 1)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost 1]
-  [FALSE #:spec (FALSE) #:impl (const false) #:cost 1])
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost 1]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost 1])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost 1]
@@ -36,10 +36,10 @@
 
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:cost 32]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:cost 32]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:cost 32]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:cost 32])
+    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32]
+    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32]
+    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32]
+    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 64)
@@ -116,10 +116,10 @@
   
 (parameterize ([fpcore-context '(:precision binary64)])
   (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost 64]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost 64]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost 64]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost 64])
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64])
   
   (define-operation (neg.f64 [x <binary64>]) <binary64>
     #:spec (neg x) #:impl - #:fpcore (- x) #:cost 128)

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -76,7 +76,7 @@
     [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 3200]
     [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 3200]
     [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 3200]
-    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 3200]
+    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 320]
     [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 3200]
     [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
     [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
@@ -156,7 +156,7 @@
     [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 6400]
     [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 6400]
     [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 6400]
-    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 6400]
+    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 640]
     [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 6400]
     [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
     [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -13,8 +13,8 @@
 (define-representation <bool> #:cost move-cost)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost move-cost]
-  [FALSE #:spec (FALSE) #:impl (const false) #:cost move-cost])
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost move-cost]
+  [FALSE #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost move-cost])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost move-cost]
@@ -37,10 +37,10 @@
 
 (parameterize ([fpcore-context '(:precision binary64)])
   (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost fl-move-cost]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost fl-move-cost]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost fl-move-cost]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost fl-move-cost])
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost fl-move-cost]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost fl-move-cost]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost fl-move-cost]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost fl-move-cost])
   
   (define-operation (neg.f64 [x <binary64>]) <binary64>
     #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0.096592)

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -93,4 +93,4 @@
     [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 16.165012])
   
   (define-operation (erfc.f64 [x <binary64>]) <binary64>
-    #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0.816512)
+    #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0.816512))

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -1,7 +1,7 @@
 #lang s-exp "../platform.rkt"
 
 ;;; C/C++ on Linux with reduced libm, meaning no special numeric
-;;; functions. It is also 32-bit only.
+;;; functions. It is also 64-bit only.
 
 (define move-cost    0.02333600000000001)
 (define fl-move-cost (* move-cost 4))

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -1,146 +1,96 @@
-#lang racket
+#lang s-exp "../platform.rkt"
 
-;;; C/C++ on Linux with reduced libm
-;;; We use textbook mathematical operators, i.e.,
-;;; no special numbers functions
-
-(require math/bigfloat
-         math/flonum
-         "../syntax/types.rkt" ; for shift/unshift
-         "../syntax/platform.rkt")
-(provide platform)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; EMPTY PLATFORM ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; C/C++ on Linux with reduced libm, meaning no special numeric
+;;; functions. It is also 32-bit only.
 
 (define move-cost    0.02333600000000001)
 (define fl-move-cost (* move-cost 4))
 
-(define platform (make-empty-platform 'math))
-
-(platform-register-if-cost! platform #:if-cost move-cost)
+(define-if #:cost move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <bool> #:cost move-cost)
 
-(define bool <bool>)
+(define-operations () <bool>
+  [TRUE  #:spec (TRUE)  #:impl (const true)  #:cost move-cost]
+  [FALSE #:spec (FALSE) #:impl (const false) #:cost move-cost])
 
-(platform-register-representation! platform #:repr bool #:cost move-cost)
+(define-operations ([x <bool>] [y <bool>]) <bool>
+  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost move-cost]
+  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost move-cost])
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([TRUE  () bool (TRUE)  (const true)  (! TRUE)  move-cost]
-  [FALSE () bool (FALSE) (const false) (! FALSE) move-cost]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (and-fn . as)
-  (andmap identity as))
-(define (or-fn . as)
-  (ormap identity as))
-
-(platform-register-implementations!
- platform
- ([not ([x : bool])            bool (not x)   not    (not x)   move-cost]
-  [and ([x : bool] [y : bool]) bool (and x y) and-fn (and x y) move-cost]
-  [or  ([x : bool] [y : bool]) bool (or x y)  or-fn  (or x y)  move-cost]))
+(define-operation (not [x <bool>]) <bool>
+  #:spec (not x) #:impl not #:cost move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;
+(define-representation <binary64> #:cost fl-move-cost)
 
-(define binary64 <binary64>)
+(define-operations ([x <binary64>] [y <binary64>]) <bool>
+  [==.f64 #:spec (== x y) #:impl =          #:cost fl-move-cost]
+  [!=.f64 #:spec (!= x y) #:impl (negate =) #:cost fl-move-cost]
+  [<.f64  #:spec (< x y)  #:impl <          #:cost fl-move-cost]
+  [>.f64  #:spec (> x y)  #:impl >          #:cost fl-move-cost]
+  [<=.f64 #:spec (<= x y) #:impl <=         #:cost fl-move-cost]
+  [>=.f64 #:spec (>= x y) #:impl >=         #:cost fl-move-cost])
 
-(platform-register-representation! platform #:repr binary64 #:cost fl-move-cost)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementations!
- platform
- ([PI.f64       () binary64 (PI)       (const pi)        (! :precision binary64 PI)       fl-move-cost]
-  [E.f64        () binary64 (E)        (const (exp 1.0)) (! :precision binary64 E)        fl-move-cost]
-  [INFINITY.f64 () binary64 (INFINITY) (const +inf.0)    (! :precision binary64 INFINITY) fl-move-cost]
-  [NAN.f64      () binary64 (NAN)      (const +nan.0)    (! :precision binary64 NAN)      fl-move-cost]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name   ([var : repr] ...)              otype    spec     fl         fpcore                         cost])
-(platform-register-implementations!
- platform
- ([neg.f64 ([x : binary64])                binary64 (neg x)  -          (! :precision binary64 (- x))   0.096592]
-  [+.f64   ([x : binary64] [y : binary64]) binary64 (+ x y)  +          (! :precision binary64 (+ x y)) 0.164604]
-  [-.f64   ([x : binary64] [y : binary64]) binary64 (- x y)  -          (! :precision binary64 (- x y)) 0.15163999999999997]
-  [*.f64   ([x : binary64] [y : binary64]) binary64 (* x y)  *          (! :precision binary64 (* x y)) 0.20874800000000002]
-  [/.f64   ([x : binary64] [y : binary64]) binary64 (/ x y)  /          (! :precision binary64 (/ x y)) 0.26615199999999994]
-  [==.f64  ([x : binary64] [y : binary64]) bool     (== x y) =          (== x y)                        fl-move-cost]
-  [!=.f64  ([x : binary64] [y : binary64]) bool     (!= x y) (negate =) (!= x y)                        fl-move-cost]
-  [<.f64   ([x : binary64] [y : binary64]) bool     (< x y)  <          (< x y)                         fl-move-cost]
-  [>.f64   ([x : binary64] [y : binary64]) bool     (> x y)  >          (> x y)                         fl-move-cost]
-  [<=.f64  ([x : binary64] [y : binary64]) bool     (<= x y) <=         (<= x y)                        fl-move-cost]
-  [>=.f64  ([x : binary64] [y : binary64]) bool     (>= x y) >=         (>= x y)                        fl-move-cost]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm operators ;;;;;;;;;;;;;;;;;;;;;;;;
-
-; ([name         ([var : repr] ...)              otype    spec            fl    fpcore                                  cost])
-(platform-register-implementations!
- platform
- (; Unary libm operators
-  [fabs.f64      ([x : binary64])                binary64 (fabs x)        (from-libm 'fabs)      (! :precision binary64 (fabs x))        0.10162]
-  [sin.f64       ([x : binary64])                binary64 (sin x)         (from-libm 'sin)       (! :precision binary64 (sin x))         3.318128]
-  [cos.f64       ([x : binary64])                binary64 (cos x)         (from-libm 'cos)       (! :precision binary64 (cos x))         3.32288]
-  [tan.f64       ([x : binary64])                binary64 (tan x)         (from-libm 'tan)       (! :precision binary64 (tan x))         3.710904]
-  [sinh.f64      ([x : binary64])                binary64 (sinh x)        (from-libm 'sinh)      (! :precision binary64 (sinh x))        1.20954]
-  [cosh.f64      ([x : binary64])                binary64 (cosh x)        (from-libm 'cosh)      (! :precision binary64 (cosh x))        0.953896]
-  [acos.f64      ([x : binary64])                binary64 (acos x)        (from-libm 'acos)      (! :precision binary64 (acos x))        0.357748]
-  [acosh.f64     ([x : binary64])                binary64 (acosh x)       (from-libm 'acosh)     (! :precision binary64 (acosh x))       0.659472]
-  [asin.f64      ([x : binary64])                binary64 (asin x)        (from-libm 'asin)      (! :precision binary64 (asin x))        0.389788]
-  [asinh.f64     ([x : binary64])                binary64 (asinh x)       (from-libm 'asinh)     (! :precision binary64 (asinh x))       0.835028]
-  [atan.f64      ([x : binary64])                binary64 (atan x)        (from-libm 'atan)      (! :precision binary64 (atan x))        0.83752]
-  [atanh.f64     ([x : binary64])                binary64 (atanh x)       (from-libm 'atanh)     (! :precision binary64 (atanh x))       0.36238]
-  [cbrt.f64      ([x : binary64])                binary64 (cbrt x)        (from-libm 'cbrt)      (! :precision binary64 (cbrt x))        1.565176]
-  [ceil.f64      ([x : binary64])                binary64 (ceil x)        (from-libm 'ceil)      (! :precision binary64 (ceil x))        0.47299]
-  [erf.f64       ([x : binary64])                binary64 (erf x)         (from-libm 'erf)       (! :precision binary64 (erf x))         0.806436]
-  [exp.f64       ([x : binary64])                binary64 (exp x)         (from-libm 'exp)       (! :precision binary64 (exp x))         1.0806]
-  [exp2.f64      ([x : binary64])                binary64 (exp2 x)        (from-libm 'exp2)      (! :precision binary64 (exp2 x))        0.825484]
-  [floor.f64     ([x : binary64])                binary64 (floor x)       (from-libm 'floor)     (! :precision binary64 (floor x))       0.468568]
-  [lgamma.f64    ([x : binary64])                binary64 (lgamma x)      (from-libm 'lgamma)    (! :precision binary64 (lgamma x))      1.568012]
-  [log.f64       ([x : binary64])                binary64 (log x)         (from-libm 'log)       (! :precision binary64 (log x))         0.505724]
-  [log10.f64     ([x : binary64])                binary64 (log10 x)       (from-libm 'log10)     (! :precision binary64 (log10 x))       0.868856]
-  [log2.f64      ([x : binary64])                binary64 (log2 x)        (from-libm 'log2)      (! :precision binary64 (log2 x))        0.681276]
-  [logb.f64      ([x : binary64])                binary64 (logb x)        (from-libm 'logb)      (! :precision binary64 (logb x))        0.220656]
-  [rint.f64      ([x : binary64])                binary64 (rint x)        (from-libm 'rint)      (! :precision binary64 (rint x))        0.121864]
-  [round.f64     ([x : binary64])                binary64 (round x)       (from-libm 'round)     (! :precision binary64 (round x))       0.658564]
-  [sqrt.f64      ([x : binary64])                binary64 (sqrt x)        (from-libm 'sqrt)      (! :precision binary64 (sqrt x))        0.191872]
-  [tanh.f64      ([x : binary64])                binary64 (tanh x)        (from-libm 'tanh)      (! :precision binary64 (tanh x))        0.824016]
-  [tgamma.f64    ([x : binary64])                binary64 (tgamma x)      (from-libm 'tgamma)    (! :precision binary64 (tgamma x))      1.882576]
-  [trunc.f64     ([x : binary64])                binary64 (trunc x)       (from-libm 'trunc)     (! :precision binary64 (trunc x))       0.463644]
-  ; Binary libm operators
-  [pow.f64       ([x : binary64] [y : binary64]) binary64 (pow x y)       (from-libm 'pow)       (! :precision binary64 (pow x y))       1.52482]
-  [atan2.f64     ([x : binary64] [y : binary64]) binary64 (atan2 x y)     (from-libm 'atan2)     (! :precision binary64 (atan2 x y))     1.492804]
-  [copysign.f64  ([x : binary64] [y : binary64]) binary64 (copysign x y)  (from-libm 'copysign)  (! :precision binary64 (copysign x y))  0.200452]
-  [fdim.f64      ([x : binary64] [y : binary64]) binary64 (fdim x y)      (from-libm 'fdim)      (! :precision binary64 (fdim x y))      0.592576]
-  [fmax.f64      ([x : binary64] [y : binary64]) binary64 (fmax x y)      (from-libm 'fmax)      (! :precision binary64 (fmax x y))      0.3106]
-  [fmin.f64      ([x : binary64] [y : binary64]) binary64 (fmin x y)      (from-libm 'fmin)      (! :precision binary64 (fmin x y))      0.289256]
-  [fmod.f64      ([x : binary64] [y : binary64]) binary64 (fmod x y)      (from-libm 'fmod)      (! :precision binary64 (fmod x y))      94.277144]
-  [remainder.f64 ([x : binary64] [y : binary64]) binary64 (remainder x y) (from-libm 'remainder) (! :precision binary64 (remainder x y)) 16.165012]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; libm accelerators ;;;;;;;;;;;;;;;;;;;;;
-
-(platform-register-implementation! platform
-                                   (make-operator-impl (erfc.f64 [x : binary64])
-                                                       binary64
-                                                       #:spec (- 1 (erf x))
-                                                       #:fpcore (! :precision binary64 (erfc x))
-                                                       #:impl (from-libm 'erfc)
-                                                       #:cost 0.816512))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; REGISTER PLATFORM ;;;;;;;;;;;;;;;;;;;;;
-
-(module+ main
-  (display-platform platform))
-
-;; Do not run this file during testing
-(module test racket/base
-  )
+(parameterize ([fpcore-context '(:precision binary64)])
+  (define-operations () <binary64>
+    [PI.f64   #:spec (PI)       #:impl (const pi)      #:cost fl-move-cost]
+    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:cost fl-move-cost]
+    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:cost fl-move-cost]
+    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:cost fl-move-cost])
+  
+  (define-operation (neg.f64 [x <binary64>]) <binary64>
+    #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0.096592)
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [+.f64 #:spec (+ x y) #:impl + #:cost 0.164604]
+    [-.f64 #:spec (- x y) #:impl - #:cost 0.15163999999999997]
+    [*.f64 #:spec (* x y) #:impl * #:cost 0.20874800000000002]
+    [/.f64 #:spec (/ x y) #:impl / #:cost 0.26615199999999994])
+  
+  (define-operations ([x <binary64>]) <binary64>
+    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0.10162]
+    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 3.318128]
+    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 3.32288]
+    [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 3.710904]
+    [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 1.20954]
+    [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 0.953896]
+    [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 0.357748]
+    [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 0.659472]
+    [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 0.389788]
+    [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 0.835028]
+    [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 0.83752]
+    [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 0.36238]
+    [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 1.565176]
+    [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 0.47299]
+    [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 0.806436]
+    [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 1.0806]
+    [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 0.825484]
+    [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 0.468568]
+    [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 1.568012]
+    [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 0.505724]
+    [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 0.868856]
+    [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 0.681276]
+    [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 0.220656]
+    [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 0.121864]
+    [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 0.658564]
+    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 0.191872]
+    [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 0.824016]
+    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 1.882576]
+    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0.463644])
+  
+  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 1.52482]
+    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 1.492804]
+    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0.200452]
+    [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 0.592576]
+    [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 0.3106]
+    [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 0.289256]
+    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 94.277144]
+    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 16.165012])
+  
+  (define-operation (erfc.f64 [x <binary64>]) <binary64>
+    #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0.816512)

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -27,11 +27,10 @@
 
 (define-representation <binary64> #:cost 1)
 
-(parameterize ([fpcore-context '(:precision binary32)])
-  (define-operations () <binary64>
-    [PI.rkt       #:spec (PI)       #:impl (const pi)       #:fpcore PI       #:cost 1]
-    [INFINITY.rkt #:spec (INFINITY) #:impl (const +inf.0)   #:fpcore INFINITY #:cost 1]
-    [NAN.rkt      #:spec (NAN)      #:impl (const +nan.0)   #:fpcore NAN      #:cost 1]))
+(define-operations () <binary64>
+  [PI.rkt       #:spec (PI)       #:impl (const pi)       #:fpcore PI       #:cost 1]
+  [INFINITY.rkt #:spec (INFINITY) #:impl (const +inf.0)   #:fpcore INFINITY #:cost 1]
+  [NAN.rkt      #:spec (NAN)      #:impl (const +nan.0)   #:fpcore NAN      #:cost 1])
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [=  #:spec (== x y) #:impl =  #:cost 1]

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -86,4 +86,4 @@
   #:spec (/ (log x) (log y)) #:impl log #:cost 1)
 
 (define-operation (flsingle [x <binary64>]) <binary64>
-  #:spec x #:impl flsingle #:cost 1)
+  #:spec x #:impl flsingle #:fpcore (cast x) #:cost 1)

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -12,33 +12,33 @@
 
 (define-representation <bool> #:cost 1)
 
-(define-operators () <bool>
+(define-operations () <bool>
   [true  #:spec (TRUE)  #:impl (const true)  #:fpcore TRUE  #:cost 1]
-  [false #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost 1]))
+  [false #:spec (FALSE) #:impl (const false) #:fpcore FALSE #:cost 1])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
-  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost boolean-move-cost]
-  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost boolean-move-cost])
+  [and #:spec (and x y) #:impl (lambda v (andmap values v)) #:cost 1]
+  [or  #:spec (or x y)  #:impl (lambda v (ormap values v))  #:cost 1])
 
 (define-operation (not [x <bool>]) <bool>
-  #:spec (not x) #:impl not #:cost boolean-move-cost)
+  #:spec (not x) #:impl not #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 1)
 
 (parameterize ([fpcore-context '(:precision binary32)])
-  (define-operators () <binary64>
+  (define-operations () <binary64>
     [PI.rkt       #:spec (PI)       #:impl (const pi)       #:fpcore PI       #:cost 1]
     [INFINITY.rkt #:spec (INFINITY) #:impl (const +inf.0)   #:fpcore INFINITY #:cost 1]
     [NAN.rkt      #:spec (NAN)      #:impl (const +nan.0)   #:fpcore NAN      #:cost 1]))
 
-(define-operators ([x <binary64>] [y <binary64>]) <bool>
+(define-operations ([x <binary64>] [y <binary64>]) <bool>
   [=  #:spec (== x y) #:impl =  #:cost 1]
   [<  #:spec (< x y)  #:impl <  #:cost 1]
   [>  #:spec (> x y)  #:impl >  #:cost 1]
   [<= #:spec (<= x y) #:impl <= #:cost 1]
-  [>= #:spec (>= x y) #:impl >= #:cost 1]))
+  [>= #:spec (>= x y) #:impl >= #:cost 1])
 
 (define ((no-complex fun) . xs)
   (define res (apply fun xs))
@@ -47,7 +47,7 @@
 (define-operation (-/1 [x <binary64>]) <binary64>
   #:spec (neg x) #:impl - #:fpcore (- x) #:cost 1)
 
-(define-operators ([x <binary64>]) <binary64>
+(define-operations ([x <binary64>]) <binary64>
  [acos      #:spec (acos  x) #:impl (no-complex acos)  #:cost 1]
  [acosh     #:spec (acosh x) #:impl (no-complex acosh) #:cost 1]
  [asin      #:spec (asin  x) #:impl (no-complex asin)  #:cost 1]
@@ -57,7 +57,6 @@
  [ceiling   #:spec (ceil  x) #:impl ceiling            #:cost 1]
  [cos       #:spec (cos   x) #:impl cos                #:cost 1]
  [cosh      #:spec (cosh  x) #:impl cosh               #:cost 1]
- [erf       #:spec (erf   x) #:impl (no-complex erf)   #:cost 1]
  [exp       #:spec (exp   x) #:impl exp                #:cost 1]
  [abs       #:spec (fabs  x) #:impl abs                #:cost 1]
  [floor     #:spec (floor x) #:impl floor              #:cost 1]
@@ -70,7 +69,7 @@
  [tanh      #:spec (tanh  x) #:impl tanh               #:cost 1]
  [truncate  #:spec (trunc x) #:impl truncate           #:cost 1])
 
-(define-operators ([x <binary64>] [y <binary64>]) <binary64>
+(define-operations ([x <binary64>] [y <binary64>]) <binary64>
  [+         #:spec (+ x y)         #:impl +                 #:cost 1]
  [-         #:spec (- x y)         #:impl -                 #:cost 1]
  [*         #:spec (* x y)         #:impl *                 #:cost 1]
@@ -81,11 +80,11 @@
  [expt      #:spec (pow x y)       #:impl (no-complex expt) #:cost 1]
  [remainder #:spec (remainder x y) #:impl remainder         #:cost 1])
 
-(define-operator (//1 [x <binary64>]) <binary64>
+(define-operation (//1 [x <binary64>]) <binary64>
   #:spec (/ 1 x) #:impl / #:cost 1)
 
-(define-operator (log/2 [x <binary64>] [y <binary64>]) <binary64>
+(define-operation (log/2 [x <binary64>] [y <binary64>]) <binary64>
   #:spec (/ (log x) (log y)) #:impl log #:cost 1)
 
-(define-operator (flsingle [x <binary64>]) <binary64>
+(define-operation (flsingle [x <binary64>]) <binary64>
   #:spec x #:impl flsingle #:cost 1)

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang s-exp "../platform.rkt"
 
 ;;; Rival correctly-rounded platform
 
@@ -9,12 +9,12 @@
 (define-representation <bool> #:cost 1)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (from-rival)  #:cost 1]
-  [FALSE #:spec (FALSE) #:impl (from-rival)) #:cost 1])
+  [TRUE  #:spec (TRUE)  #:impl (from-rival) #:cost 1]
+  [FALSE #:spec (FALSE) #:impl (from-rival) #:cost 1])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (from-rival) #:cost 1]
-  [or  #:spec (or x y)  #:impl (from-rival)  #:cost 1])
+  [or  #:spec (or x y)  #:impl (from-rival) #:cost 1])
 
 (define-operation (not [x <bool>]) <bool>
   #:spec (not x) #:impl not #:cost 1)
@@ -34,7 +34,7 @@
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
     [PI.f32 #:spec (PI) #:impl (from-rival) #:cost 1]
-    [E.f32  #:spec (E)  #:impl (from-rival) #:cost 1]))
+    [E.f32  #:spec (E)  #:impl (from-rival) #:cost 1])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (from-rival) #:fpcore (- x) #:cost 1)

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -95,7 +95,6 @@
     #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-rival) #:fpcore (hypot x y) #:cost 1)
   
   (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
-
     #:spec (+ (* x y) z) #:impl (from-rival) #:fpcore (fma x y z) #:cost 1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -9,8 +9,8 @@
 (define-representation <bool> #:cost 1)
 
 (define-operations () <bool>
-  [TRUE  #:spec (TRUE)  #:impl (from-rival) #:cost 1]
-  [FALSE #:spec (FALSE) #:impl (from-rival) #:cost 1])
+  [TRUE  #:spec (TRUE)  #:impl (from-rival) #:fpcore TRUE  #:cost 1]
+  [FALSE #:spec (FALSE) #:impl (from-rival) #:fpcore FALSE #:cost 1])
 
 (define-operations ([x <bool>] [y <bool>]) <bool>
   [and #:spec (and x y) #:impl (from-rival) #:cost 1]
@@ -33,8 +33,8 @@
 
 (parameterize ([fpcore-context '(:precision binary32)])
   (define-operations () <binary32>
-    [PI.f32 #:spec (PI) #:impl (from-rival) #:cost 1]
-    [E.f32  #:spec (E)  #:impl (from-rival) #:cost 1])
+    [PI.f32 #:spec (PI) #:impl (from-rival) #:fpcore PI #:cost 1]
+    [E.f32  #:spec (E)  #:impl (from-rival) #:fpcore E  #:cost 1])
   
   (define-operation (neg.f32 [x <binary32>]) <binary32>
     #:spec (neg x) #:impl (from-rival) #:fpcore (- x) #:cost 1)


### PR DESCRIPTION
This PR converts the remaining platforms to `#lang herbie/platform`. For a few of them, like `rival` or `racket`, I made changes to be more in keeping with the intended use case (for `racket`, I only kept functions natively offered by Racket). For `math` I didn't bother cleaning up the costs, even though they are pretty ugly.