### PR TITLE
Normalize if operator

### DIFF
--- a/infra/softposit.rkt
+++ b/infra/softposit.rkt
@@ -7,6 +7,12 @@
          math/flonum
          softposit-rkt)
 
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; utils ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define posit8-max  (ordinal->posit8  (- (expt 2 (- 8 1)) 1)))
@@ -82,7 +88,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; EMPTY PLATFORM ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-if #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; REPRESENTATIONS ;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -158,8 +163,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; POSIT IMPLS ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <posit8>  #:cost 1)
+(define-operation (if.p8 [c <bool>] [t <posit8>] [f <posit8>]) <posit8>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 (define-representation <posit16> #:cost 1)
+(define-operation (if.p16 [c <bool>] [t <posit16>] [f <posit16>]) <posit16>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 (define-representation <posit32> #:cost 1)
+(define-operation (if.p32 [c <bool>] [t <posit32>] [f <posit32>]) <posit32>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 
 (define-operations ([x <posit8>] [y <posit8>]) <bool>
   [==.p8 #:spec (== x y) #:impl posit8=  #:cost 1]

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -37,9 +37,6 @@
         [(? symbol?) ((node-cost-proc node repr))]
         [(? number?) 0] ; specs
         [(approx _ impl) (vector-ref costs impl)]
-        [(list 'if cond ift iff)
-         (define cost-proc (node-cost-proc node repr))
-         (cost-proc (vector-ref costs cond) (vector-ref costs ift) (vector-ref costs iff))]
         [(list (? (negate impl-exists?) impl) args ...) 0] ; specs
         [(list impl args ...)
          (define cost-proc (node-cost-proc node repr))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -79,7 +79,6 @@
                 ([node (in-vector (batch-nodes batch*) num-vars)])
       (match node
         [(literal value (app get-representation repr)) (list (const (real->repr value repr)))]
-        [(list 'if c t f) (list if-proc c t f)]
         [(list op args ...) (cons (impl-info op 'fl) args)])))
 
   (make-progs-interpreter vars instructions (batch-roots batch*)))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -840,10 +840,6 @@
             [(? number?) (platform-repr-cost (*active-platform*) type)]
             [(? symbol?) (platform-repr-cost (*active-platform*) type)]
             [(list '$approx x y) 0]
-            [(list 'if c x y)
-             (match (platform-if-cost (*active-platform*))
-               [`(max ,n) n] ; Not quite right
-               [`(sum ,n) n])]
             [(list op args ...) (impl-info op 'cost)])
           1))
     (values (string->symbol (format "~a.~a" n k))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -51,10 +51,10 @@
 
   (check-equal? (e2->expr '(Var "y")) 'y)
 
-  (check-equal? (e2->expr '(IfTy (Var "y")
-                                 (Num (bigrat (from-string "1") (from-string "2")))
-                                 (Num (bigrat (from-string "0") (from-string "1")))))
-                '(if y 1/2 0))
+  (check-equal? (e2->expr '(Iff64Ty (Var "y")
+                                    (Num (bigrat (from-string "1") (from-string "2")))
+                                    (Num (bigrat (from-string "0") (from-string "1")))))
+                '(if.f64 y 1/2 0))
 
   (check-equal? (e2->expr '(Mulf64Ty (Num (bigrat (from-string "2") (from-string "1")))
                                      (Num (bigrat (from-string "3") (from-string "1")))))
@@ -154,10 +154,10 @@
                                                (Var "z"))))
                 '(*.f32 3/2 (+.f32 4/5 z)))
 
-  (check-equal? (e2->expr '(IfTy (Var "cond")
-                                 (Num (bigrat (from-string "7") (from-string "8")))
-                                 (Num (bigrat (from-string "-2") (from-string "3")))))
-                '(if cond 7/8 -2/3)))
+  (check-equal? (e2->expr '(Iff32Ty (Var "cond")
+                                    (Num (bigrat (from-string "7") (from-string "8")))
+                                    (Num (bigrat (from-string "-2") (from-string "3")))))
+                '(if.f32 cond 7/8 -2/3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Testing API
@@ -262,6 +262,8 @@
                                        (Neqf64Ty . !=.f64)
                                        (NotboolTy . not.bool)
                                        (OrboolTy . or.bool)
+                                       (Iff32Ty . if.f32)
+                                       (Iff64Ty . if.f64)
                                        (Pif32Ty . PI.f32)
                                        (Pif64Ty . PI.f64)
                                        (Powf32Ty . pow.f32)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -337,13 +337,6 @@
   (for ([repr (in-list (all-repr-names))])
     (set! raw-costs (cons (platform-repr-cost pform (get-representation repr)) raw-costs)))
 
-  ;; Add raw if-cost
-  (set! raw-costs
-        (cons (match (platform-if-cost pform)
-                [`(max ,n) n] ; Not quite right (copied from egg-herbie.rkt)
-                [`(sum ,n) n])
-              raw-costs))
-
   ;; Add raw platform-impl-nodes
   (for ([impl (in-list (platform-impls pform))])
     (set! raw-costs (cons (impl-info impl 'cost) raw-costs)))
@@ -354,14 +347,6 @@
     `(datatype MTy
                ,@(num-typed-nodes pform min-cost)
                ,@(var-typed-nodes pform min-cost)
-               (IfTy MTy
-                     MTy
-                     MTy
-                     :cost
-                     ,(normalize-cost (match (platform-if-cost pform)
-                                        [`(max ,n) n] ; Not quite right (copied from egg-herbie.rkt)
-                                        [`(sum ,n) n])
-                                      min-cost))
                (Approx M MTy)
                ,@(platform-impl-nodes pform min-cost)))
   (egglog-program-add! typed-graph curr-program)
@@ -401,11 +386,6 @@
 
   (for ([curr-expr (num-lifting-rules)])
     (egglog-program-add! curr-expr curr-program))
-
-  (for ([curr-expr (if-lowering-rules)])
-    (egglog-program-add! curr-expr curr-program))
-
-  (egglog-program-add! (if-lifting-rule) curr-program)
 
   (egglog-program-add! (approx-lifting-rule) curr-program)
 
@@ -531,33 +511,6 @@
            :ruleset
            lifting)))
 
-(define (if-lowering-rules)
-  (for/list ([repr (in-list (all-repr-names))])
-    `(rule ((= e (If ifc ift iff)) (= tifc (lower ifc "bool"))
-                                   (= tift (lower ift ,(symbol->string repr)))
-                                   (= tiff (lower iff ,(symbol->string repr))))
-           ((let t0 ,(symbol->string repr)
-              )
-            (let et0 (IfTy
-                      tifc
-                      tift
-                      tiff)
-              )
-            (union (lower e t0) et0))
-           :ruleset
-           lowering)))
-
-(define (if-lifting-rule)
-  `(rule ((= e (IfTy ifc ift iff)) (= sifc (lift ifc)) (= sift (lift ift)) (= siff (lift iff)))
-         ((let se (If
-                   sifc
-                   sift
-                   siff)
-            )
-          (union (lift e) se))
-         :ruleset
-         lifting))
-
 (define (approx-lifting-rule)
   `(rule ((= e (Approx spec impl))) ((union (lift e) spec)) :ruleset lifting))
 
@@ -634,7 +587,6 @@
          (bigrat (from-string ,(number->string (numerator (literal-value expr))))
                  (from-string ,(number->string (denominator (literal-value expr))))))]
       [(? symbol?) expr]
-      [`(if ,cond ,ift ,iff) `(IfTy ,(loop cond repr) ,(loop ift repr) ,(loop iff repr))]
       [(list op args ...)
        `(,(hash-ref (id->e2) op) ,@(for/list ([arg (in-list args)]
                                               [itype (in-list (impl-info op 'itype))])
@@ -647,7 +599,6 @@
        `(Num (bigrat (from-string ,(number->string (numerator expr)))
                      (from-string ,(number->string (denominator expr)))))]
       [(? symbol?) expr]
-      [`(if ,cond ,ift ,iff) `(If ,(loop cond) ,(loop ift) ,(loop iff))]
       [(list op args ...) `(,(hash-ref (id->e1) op) ,@(map loop args))])))
 
 (define (expr->e1-expr expr)
@@ -657,7 +608,6 @@
        `(Num (bigrat (from-string ,(number->string (numerator expr)))
                      (from-string ,(number->string (denominator expr)))))]
       [(? symbol?) `(Var ,(symbol->string expr))]
-      [`(if ,cond ,ift ,iff) `(If ,(loop cond) ,(loop ift) ,(loop iff))]
       [(list op args ...) `(,(hash-ref (id->e1) op) ,@(map loop args))])))
 
 (define (egglog-rewrite-rules rules tag)
@@ -739,8 +689,6 @@
          `(Num (bigrat (from-string ,(number->string (numerator node)))
                        (from-string ,(number->string (denominator node)))))]
         [(? symbol?) #f]
-        [`(if ,cond ,ift ,iff)
-         (list (if spec? 'If 'IfTy) (remap cond spec?) (remap ift spec?) (remap iff spec?))]
         [(approx spec impl) `(Approx ,(remap spec #t) ,(remap impl #f))]
         [(list impl args ...)
          `(,(hash-ref (if spec?
@@ -1097,9 +1045,5 @@
       [`(,(? egglog-num? num) (bigrat (from-string ,n) (from-string ,d)))
        (/ (string->number n) (string->number d))]
       [`(,(? egglog-var? var) ,v) (string->symbol v)]
-      [`(IfTy ,cond ,ift ,iff)
-       `(if ,(loop cond)
-            ,(loop ift)
-            ,(loop iff))]
       [`(Approx ,spec ,impl) (approx (e1->expr spec) (loop impl))] ;;; todo approx bug or not?
       [`(,impl ,args ...) `(,(hash-ref (e2->id) impl) ,@(map loop args))])))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -33,7 +33,6 @@
     [(? symbol?) (context-lookup ctx expr)]
     [(approx _ impl) (repr-of impl ctx)]
     [(hole precision spec) (get-representation precision)]
-    [(list 'if cond ift iff) (repr-of ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))
 
 ; Index inside (batch-nodes batch) -> type
@@ -44,7 +43,6 @@
     [(? symbol?) (context-lookup ctx node)]
     [(approx _ impl) (repr-of-node batch impl ctx)]
     [(hole precision spec) (get-representation precision)]
-    [(list 'if cond ift iff) (repr-of-node batch ift ctx)]
     [(list op args ...) (impl-info op 'otype)]))
 
 (define (all-subexpressions expr #:reverse? [reverse? #f])
@@ -86,7 +84,6 @@
     [(? symbol?) #t]
     [(? literal?) #t]
     [(approx spec impl) (and (spec-prog? spec) (impl-prog? impl))]
-    [(list 'if cond ift iff) (and (impl-prog? cond) (impl-prog? ift) (impl-prog? iff))]
     [(list (? impl-exists?) args ...) (andmap impl-prog? args)]
     [_ #f]))
 

--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -4,11 +4,16 @@
 
 (require math/flonum)
 
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 (define 64bit-move-cost   0.125)
 (define 32bit-move-cost   0.125)
 (define boolean-move-cost 0.100)
 
-(define-if #:cost boolean-move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -28,6 +33,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary32> #:cost 32bit-move-cost)
+
+(define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
+  #:spec (if c t f) #:impl if-impl
+  #:cost boolean-move-cost #:aggregate if-cost)
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 32bit-move-cost]
@@ -101,6 +110,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 64bit-move-cost)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost boolean-move-cost #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <binary64>
   [+.f64 #:spec (+ x y) #:impl + #:cost 0.200]

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -4,11 +4,16 @@
 
 (require math/flonum)
 
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 (define 64bit-move-cost   0.125)
 (define 32bit-move-cost   0.125)
 (define boolean-move-cost 0.100)
 
-(define-if #:cost boolean-move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -28,6 +33,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary32> #:cost 32bit-move-cost)
+
+(define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
+  #:spec (if c t f) #:impl if-impl
+  #:cost boolean-move-cost #:aggregate if-cost)
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 32bit-move-cost]
@@ -110,6 +119,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 64bit-move-cost)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost boolean-move-cost #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 64bit-move-cost]

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -5,7 +5,12 @@
 
 (require math/flonum)
 
-(define-if #:cost 0)
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -25,6 +30,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary32> #:cost 0)
+
+(define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 0 #:aggregate if-cost)
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 0]
@@ -105,6 +114,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 0)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 0 #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 0]

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -5,7 +5,12 @@
 
 (require math/flonum)
 
-(define-if #:cost 1)
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -25,6 +30,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary32> #:cost 32)
+
+(define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 128]
@@ -105,6 +114,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 64)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 256]

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -3,10 +3,15 @@
 ;;; C/C++ on Linux with reduced libm, meaning no special numeric
 ;;; functions. It is also 64-bit only.
 
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 (define move-cost    0.02333600000000001)
 (define fl-move-cost (* move-cost 4))
 
-(define-if #:cost move-cost)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,6 +31,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost fl-move-cost)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost move-cost #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost fl-move-cost]

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -6,7 +6,12 @@
 (require math/flonum
          math/base)
 
-(define-if #:cost 1)
+(define (if-impl c t f)
+  (if c t f))
+
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,6 +31,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 1)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl if-impl
+  #:cost 1 #:aggregate if-cost)
 
 (define-operations () <binary64>
   [PI.rkt       #:spec (PI)       #:impl (const pi)       #:fpcore PI       #:cost 1]

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -2,7 +2,9 @@
 
 ;;; Rival correctly-rounded platform
 
-(define-if #:cost 1)
+(define (if-cost c t f)
+  (+ c (max t f)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BOOLEAN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -22,6 +24,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 32 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary32> #:cost 1)
+
+(define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
+  #:spec (if c t f) #:impl (from-rival) #:cost 1 #:aggregate if-cost)
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl (from-rival) #:cost 1]
@@ -100,6 +105,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation <binary64> #:cost 1)
+
+(define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
+  #:spec (if c t f) #:impl (from-rival) #:cost 1 #:aggregate if-cost)
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl (from-rival) #:cost 1]

--- a/src/syntax/platforms-language.rkt
+++ b/src/syntax/platforms-language.rkt
@@ -5,8 +5,7 @@
          "types.rkt"
          "generators.rkt")
 
-(provide define-if
-         define-representation
+(provide define-representation
          define-operation
          define-operations
          fpcore-context
@@ -17,9 +16,6 @@
          (all-from-out "types.rkt"))
 
 (define platform-being-defined (make-parameter #f))
-
-(define-syntax-rule (define-if #:cost cost)
-  (platform-register-if-cost! (platform-being-defined) #:cost cost))
 
 (define-syntax-rule (define-representation repr #:cost cost)
   (platform-register-representation! (platform-being-defined) #:repr repr #:cost cost))


### PR DESCRIPTION
Platforms no longer required dedicated conditional cost rules. Instead, each
platform defines simple helpers for conditional execution that are used in its
operation declarations. These functions implement the `if` behaviour and cost
aggregation directly in the platform modules, eliminating cross-phase
dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687fbb1622a88331a22d0c5b51a30951