### PR TITLE
Refactor platforms to use `#:fpcore`

### DIFF
--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -34,23 +34,23 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 0]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(parameterize ([fpcore-context '(:precision binary32)])
-  (define-operations () <binary32>
+(define-operations () <binary32> #:fpcore (:precision binary32)
     [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 0]
     [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 0]
     [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 0]
     [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 0])
+
+(define-operation (neg.f32 [x <binary32>]) <binary32>
+  #:spec (neg x) #:impl (compose flsingle -)
+  #:fpcore (! :precision binary32 (- x)) #:cost 0)
   
-  (define-operation (neg.f32 [x <binary32>]) <binary32>
-    #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 0)
-  
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
     [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0]
     [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0]
     [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0]
     [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0])
-  
-  (define-operations ([x <binary32>]) <binary32>
+
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
     [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0]
     [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 0]
     [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 0]
@@ -81,7 +81,7 @@
     [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 0]
     [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0])
   
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
     [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 0]
     [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 0]
     [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0]
@@ -91,16 +91,18 @@
     [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 0]
     [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 0])
   
-  (define-operations ([x <binary32>]) <binary32>
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
     [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0]
     [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0]
     [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 0])
   
-  (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf) #:fpcore (hypot x y) #:cost 0)
-  
-  (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
-    #:spec (+ (* x y) z) #:impl (from-libm 'fmaf) #:fpcore (fma x y z) #:cost 0))
+(define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
+  #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf)
+  #:fpcore (! :precision binary32 (hypot x y)) #:cost 0)
+
+(define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
+  #:spec (+ (* x y) z) #:impl (from-libm 'fmaf)
+  #:fpcore (! :precision binary32 (fma x y z)) #:cost 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -114,23 +116,23 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 0]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(parameterize ([fpcore-context '(:precision binary64)])
-  (define-operations () <binary64>
+(define-operations () <binary64> #:fpcore (:precision binary64)
     [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 0]
     [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 0]
     [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 0]
     [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 0])
-  
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
     [+.f64 #:spec (+ x y) #:impl + #:cost 0]
     [-.f64 #:spec (- x y) #:impl - #:cost 0]
     [*.f64 #:spec (* x y) #:impl * #:cost 0]
     [/.f64 #:spec (/ x y) #:impl / #:cost 0])
 
-  (define-operation (neg.f64 [x <binary64>]) <binary64>
-    #:spec (neg x) #:impl - #:fpcore (- x) #:cost 0)
+ (define-operation (neg.f64 [x <binary64>]) <binary64>
+   #:spec (neg x) #:impl -
+   #:fpcore (! :precision binary64 (- x)) #:cost 0)
   
-  (define-operations ([x <binary64>]) <binary64>
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
     [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0]
     [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 0]
     [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 0]
@@ -161,7 +163,7 @@
     [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 0]
     [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0])
   
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
     [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 0]
     [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 0]
     [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0]
@@ -171,16 +173,18 @@
     [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 0]
     [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 0])
   
-  (define-operations ([x <binary64>]) <binary64>
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
     [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0]
     [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0]
     [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 0])
   
-  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot) #:fpcore (hypot x y) #:cost 0)
-  
-  (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
-    #:spec (+ (* x y) z) #:impl (from-libm 'fma) #:fpcore (fma x y z) #:cost 0))
+ (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+   #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot)
+   #:fpcore (! :precision binary64 (hypot x y)) #:cost 0)
+
+ (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+   #:spec (+ (* x y) z) #:impl (from-libm 'fma)
+   #:fpcore (! :precision binary64 (fma x y z)) #:cost 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -35,66 +35,66 @@
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 0])
 
 (define-operations () <binary32> #:fpcore (:precision binary32)
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 0]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 0]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 0]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 0])
+  [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 0]
+  [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 0]
+  [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 0]
+  [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 0])
 
 (define-operation (neg.f32 [x <binary32>]) <binary32>
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 0)
   
 (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0]
-    [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0]
-    [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0]
-    [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0])
+  [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0]
+  [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0]
+  [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0]
+  [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0])
 
 (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0]
-    [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 0]
-    [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 0]
-    [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 0]
-    [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 0]
-    [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 0]
-    [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 0]
-    [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 0]
-    [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 0]
-    [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 0]
-    [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 0]
-    [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 0]
-    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 0]
-    [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 0]
-    [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 0]
-    [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 0]
-    [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 0]
-    [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 0]
-    [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 0]
-    [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 0]
-    [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 0]
-    [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 0]
-    [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 0]
-    [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 0]
-    [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 0]
-    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 0]
-    [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 0]
-    [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 0]
-    [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0])
+  [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0]
+  [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 0]
+  [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 0]
+  [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 0]
+  [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 0]
+  [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 0]
+  [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 0]
+  [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 0]
+  [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 0]
+  [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 0]
+  [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 0]
+  [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 0]
+  [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 0]
+  [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 0]
+  [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 0]
+  [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 0]
+  [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 0]
+  [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 0]
+  [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 0]
+  [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 0]
+  [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 0]
+  [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 0]
+  [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 0]
+  [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 0]
+  [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 0]
+  [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 0]
+  [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 0]
+  [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 0]
+  [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0])
   
 (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 0]
-    [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 0]
-    [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0]
-    [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 0]
-    [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 0]
-    [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 0]
-    [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 0]
-    [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 0])
+  [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 0]
+  [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 0]
+  [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0]
+  [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 0]
+  [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 0]
+  [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 0]
+  [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 0]
+  [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 0])
   
 (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0]
-    [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0]
-    [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 0])
+  [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0]
+  [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0]
+  [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 0])
   
 (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
   #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf)
@@ -117,67 +117,67 @@
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 0])
 
 (define-operations () <binary64> #:fpcore (:precision binary64)
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 0]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 0]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 0]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 0])
+  [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 0]
+  [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 0]
+  [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 0]
+  [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 0])
 
  (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [+.f64 #:spec (+ x y) #:impl + #:cost 0]
-    [-.f64 #:spec (- x y) #:impl - #:cost 0]
-    [*.f64 #:spec (* x y) #:impl * #:cost 0]
-    [/.f64 #:spec (/ x y) #:impl / #:cost 0])
+   [+.f64 #:spec (+ x y) #:impl + #:cost 0]
+   [-.f64 #:spec (- x y) #:impl - #:cost 0]
+   [*.f64 #:spec (* x y) #:impl * #:cost 0]
+   [/.f64 #:spec (/ x y) #:impl / #:cost 0])
 
  (define-operation (neg.f64 [x <binary64>]) <binary64>
    #:spec (neg x) #:impl -
    #:fpcore (! :precision binary64 (- x)) #:cost 0)
   
  (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0]
-    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 0]
-    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 0]
-    [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 0]
-    [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 0]
-    [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 0]
-    [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 0]
-    [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 0]
-    [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 0]
-    [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 0]
-    [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 0]
-    [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 0]
-    [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 0]
-    [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 0]
-    [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 0]
-    [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 0]
-    [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 0]
-    [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 0]
-    [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 0]
-    [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 0]
-    [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 0]
-    [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 0]
-    [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 0]
-    [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 0]
-    [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 0]
-    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 0]
-    [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 0]
-    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 0]
-    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0])
+   [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0]
+   [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 0]
+   [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 0]
+   [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 0]
+   [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 0]
+   [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 0]
+   [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 0]
+   [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 0]
+   [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 0]
+   [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 0]
+   [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 0]
+   [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 0]
+   [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 0]
+   [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 0]
+   [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 0]
+   [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 0]
+   [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 0]
+   [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 0]
+   [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 0]
+   [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 0]
+   [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 0]
+   [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 0]
+   [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 0]
+   [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 0]
+   [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 0]
+   [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 0]
+   [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 0]
+   [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 0]
+   [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0])
   
  (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 0]
-    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 0]
-    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0]
-    [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 0]
-    [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 0]
-    [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 0]
-    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 0]
-    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 0])
+   [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 0]
+   [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 0]
+   [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0]
+   [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 0]
+   [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 0]
+   [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 0]
+   [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 0]
+   [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 0])
   
  (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0]
-    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0]
-    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 0])
-  
+   [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0]
+   [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0]
+   [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 0])
+
  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot)
    #:fpcore (! :precision binary64 (hypot x y)) #:cost 0)

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -35,67 +35,67 @@
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 128])
 
 (define-operations () <binary32> #:fpcore (:precision binary32)
-    [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32]
-    [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32]
-    [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32]
-    [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32])
+  [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32]
+  [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32]
+  [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32]
+  [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32])
 
 (define-operation (neg.f32 [x <binary32>]) <binary32>
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 64)
-  
- (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 64]
-    [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 64]
-    [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 128]
-    [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 320])
 
- (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 64]
-    [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 3200]
-    [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 3200]
-    [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 3200]
-    [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 3200]
-    [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 3200]
-    [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 3200]
-    [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 3200]
-    [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 3200]
-    [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 3200]
-    [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 3200]
-    [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 3200]
-    [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 3200]
-    [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 3200]
-    [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 3200]
-    [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 3200]
-    [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 3200]
-    [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 3200]
-    [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 3200]
-    [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 3200]
-    [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 3200]
-    [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 3200]
-    [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 3200]
-    [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 3200]
-    [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 3200]
-    [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 320]
-    [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 3200]
-    [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
-    [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
-  
- (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 3200]
-    [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 3200]
-    [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 3200]
-    [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 3200]
-    [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 3200]
-    [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 3200]
-    [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 3200]
-    [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 3200])
-  
- (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
-    [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 3200]
-    [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 3200]
-    [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 3200])
-  
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 64]
+  [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 64]
+  [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 128]
+  [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 320])
+
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 64]
+  [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 3200]
+  [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 3200]
+  [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 3200]
+  [sinh.f32   #:spec (sinh x)   #:impl (from-libm 'sinhf)   #:cost 3200]
+  [cosh.f32   #:spec (cosh x)   #:impl (from-libm 'coshf)   #:cost 3200]
+  [acos.f32   #:spec (acos x)   #:impl (from-libm 'acosf)   #:cost 3200]
+  [acosh.f32  #:spec (acosh x)  #:impl (from-libm 'acoshf)  #:cost 3200]
+  [asin.f32   #:spec (asin x)   #:impl (from-libm 'asinf)   #:cost 3200]
+  [asinh.f32  #:spec (asinh x)  #:impl (from-libm 'asinhf)  #:cost 3200]
+  [atan.f32   #:spec (atan x)   #:impl (from-libm 'atanf)   #:cost 3200]
+  [atanh.f32  #:spec (atanh x)  #:impl (from-libm 'atanhf)  #:cost 3200]
+  [cbrt.f32   #:spec (cbrt x)   #:impl (from-libm 'cbrtf)   #:cost 3200]
+  [ceil.f32   #:spec (ceil x)   #:impl (from-libm 'ceilf)   #:cost 3200]
+  [erf.f32    #:spec (erf x)    #:impl (from-libm 'erff)    #:cost 3200]
+  [exp.f32    #:spec (exp x)    #:impl (from-libm 'expf)    #:cost 3200]
+  [exp2.f32   #:spec (exp2 x)   #:impl (from-libm 'exp2f)   #:cost 3200]
+  [floor.f32  #:spec (floor x)  #:impl (from-libm 'floorf)  #:cost 3200]
+  [lgamma.f32 #:spec (lgamma x) #:impl (from-libm 'lgammaf) #:cost 3200]
+  [log.f32    #:spec (log x)    #:impl (from-libm 'logf)    #:cost 3200]
+  [log10.f32  #:spec (log10 x)  #:impl (from-libm 'log10f)  #:cost 3200]
+  [log2.f32   #:spec (log2 x)   #:impl (from-libm 'log2f)   #:cost 3200]
+  [logb.f32   #:spec (logb x)   #:impl (from-libm 'logbf)   #:cost 3200]
+  [rint.f32   #:spec (rint x)   #:impl (from-libm 'rintf)   #:cost 3200]
+  [round.f32  #:spec (round x)  #:impl (from-libm 'roundf)  #:cost 3200]
+  [sqrt.f32   #:spec (sqrt x)   #:impl (from-libm 'sqrtf)   #:cost 320]
+  [tanh.f32   #:spec (tanh x)   #:impl (from-libm 'tanhf)   #:cost 3200]
+  [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
+  [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
+
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 3200]
+  [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 3200]
+  [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 3200]
+  [fdim.f32      #:spec (fdim x y)      #:impl (from-libm 'fdimf)      #:cost 3200]
+  [fmax.f32      #:spec (fmax x y)      #:impl (from-libm 'fmaxf)      #:cost 3200]
+  [fmin.f32      #:spec (fmin x y)      #:impl (from-libm 'fminf)      #:cost 3200]
+  [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 3200]
+  [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 3200])
+
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 3200]
+  [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 3200]
+  [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 3200])
+
 (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
   #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf)
   #:fpcore (! :precision binary32 (hypot x y)) #:cost 3200)
@@ -115,76 +115,76 @@
   [>.f64  #:spec (> x y)  #:impl >          #:cost 256]
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 256]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 256])
-  
+
 (define-operations () <binary64> #:fpcore (:precision binary64)
-    [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64]
-    [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64]
-    [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64]
-    [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64])
+  [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64]
+  [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64]
+  [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64]
+  [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64])
 
- (define-operation (neg.f64 [x <binary64>]) <binary64>
-   #:spec (neg x) #:impl -
-   #:fpcore (! :precision binary64 (- x)) #:cost 128)
-  
- (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [+.f64 #:spec (+ x y) #:impl + #:cost 128]
-    [-.f64 #:spec (- x y) #:impl - #:cost 128]
-    [*.f64 #:spec (* x y) #:impl * #:cost 256]
-    [/.f64 #:spec (/ x y) #:impl / #:cost 640])
+(define-operation (neg.f64 [x <binary64>]) <binary64>
+  #:spec (neg x) #:impl -
+  #:fpcore (! :precision binary64 (- x)) #:cost 128)
 
- (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 128]
-    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 6400]
-    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 6400]
-    [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 6400]
-    [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 6400]
-    [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 6400]
-    [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 6400]
-    [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 6400]
-    [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 6400]
-    [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 6400]
-    [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 6400]
-    [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 6400]
-    [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 6400]
-    [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 6400]
-    [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 6400]
-    [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 6400]
-    [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 6400]
-    [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 6400]
-    [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 6400]
-    [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 6400]
-    [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 6400]
-    [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 6400]
-    [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 6400]
-    [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 6400]
-    [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 6400]
-    [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 640]
-    [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 6400]
-    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
-    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])
-  
- (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 6400]
-    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 6400]
-    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 6400]
-    [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 6400]
-    [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 6400]
-    [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 6400]
-    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 6400]
-    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 6400])
-  
- (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
-    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 6400]
-    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 6400]
-    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 6400])
-  
- (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
-   #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot)
-   #:fpcore (! :precision binary64 (hypot x y)) #:cost 6400)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [+.f64 #:spec (+ x y) #:impl + #:cost 128]
+  [-.f64 #:spec (- x y) #:impl - #:cost 128]
+  [*.f64 #:spec (* x y) #:impl * #:cost 256]
+  [/.f64 #:spec (/ x y) #:impl / #:cost 640])
 
- (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
-   #:spec (+ (* x y) z) #:impl (from-libm 'fma)
-   #:fpcore (! :precision binary64 (fma x y z)) #:cost 256)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 128]
+  [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 6400]
+  [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 6400]
+  [tan.f64    #:spec (tan x)    #:impl (from-libm 'tan)       #:cost 6400]
+  [sinh.f64   #:spec (sinh x)   #:impl (from-libm 'sinh)      #:cost 6400]
+  [cosh.f64   #:spec (cosh x)   #:impl (from-libm 'cosh)      #:cost 6400]
+  [acos.f64   #:spec (acos x)   #:impl (from-libm 'acos)      #:cost 6400]
+  [acosh.f64  #:spec (acosh x)  #:impl (from-libm 'acosh)     #:cost 6400]
+  [asin.f64   #:spec (asin x)   #:impl (from-libm 'asin)      #:cost 6400]
+  [asinh.f64  #:spec (asinh x)  #:impl (from-libm 'asinh)     #:cost 6400]
+  [atan.f64   #:spec (atan x)   #:impl (from-libm 'atan)      #:cost 6400]
+  [atanh.f64  #:spec (atanh x)  #:impl (from-libm 'atanh)     #:cost 6400]
+  [cbrt.f64   #:spec (cbrt x)   #:impl (from-libm 'cbrt)      #:cost 6400]
+  [ceil.f64   #:spec (ceil x)   #:impl (from-libm 'ceil)      #:cost 6400]
+  [erf.f64    #:spec (erf x)    #:impl (from-libm 'erf)       #:cost 6400]
+  [exp.f64    #:spec (exp x)    #:impl (from-libm 'exp)       #:cost 6400]
+  [exp2.f64   #:spec (exp2 x)   #:impl (from-libm 'exp2)      #:cost 6400]
+  [floor.f64  #:spec (floor x)  #:impl (from-libm 'floor)     #:cost 6400]
+  [lgamma.f64 #:spec (lgamma x) #:impl (from-libm 'lgamma)    #:cost 6400]
+  [log.f64    #:spec (log x)    #:impl (from-libm 'log)       #:cost 6400]
+  [log10.f64  #:spec (log10 x)  #:impl (from-libm 'log10)     #:cost 6400]
+  [log2.f64   #:spec (log2 x)   #:impl (from-libm 'log2)      #:cost 6400]
+  [logb.f64   #:spec (logb x)   #:impl (from-libm 'logb)      #:cost 6400]
+  [rint.f64   #:spec (rint x)   #:impl (from-libm 'rint)      #:cost 6400]
+  [round.f64  #:spec (round x)  #:impl (from-libm 'round)     #:cost 6400]
+  [sqrt.f64   #:spec (sqrt x)   #:impl (from-libm 'sqrt)      #:cost 640]
+  [tanh.f64   #:spec (tanh x)   #:impl (from-libm 'tanh)      #:cost 6400]
+  [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
+  [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])
+
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 6400]
+  [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 6400]
+  [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 6400]
+  [fdim.f64      #:spec (fdim x y)      #:impl (from-libm 'fdim)      #:cost 6400]
+  [fmax.f64      #:spec (fmax x y)      #:impl (from-libm 'fmax)      #:cost 6400]
+  [fmin.f64      #:spec (fmin x y)      #:impl (from-libm 'fmin)      #:cost 6400]
+  [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 6400]
+  [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 6400])
+
+(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 6400]
+  [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 6400]
+  [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 6400])
+
+(define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+  #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot)
+  #:fpcore (! :precision binary64 (hypot x y)) #:cost 6400)
+
+(define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+  #:spec (+ (* x y) z) #:impl (from-libm 'fma)
+  #:fpcore (! :precision binary64 (fma x y z)) #:cost 256)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -34,23 +34,23 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 128]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 128])
 
-(parameterize ([fpcore-context '(:precision binary32)])
-  (define-operations () <binary32>
+(define-operations () <binary32> #:fpcore (:precision binary32)
     [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32]
     [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32]
     [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32]
     [NAN.f32      #:spec (NAN)      #:impl (const +nan.0)              #:fpcore NAN      #:cost 32])
+
+(define-operation (neg.f32 [x <binary32>]) <binary32>
+  #:spec (neg x) #:impl (compose flsingle -)
+  #:fpcore (! :precision binary32 (- x)) #:cost 64)
   
-  (define-operation (neg.f32 [x <binary32>]) <binary32>
-    #:spec (neg x) #:impl (compose flsingle -) #:fpcore (- x) #:cost 64)
-  
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+ (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
     [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 64]
     [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 64]
     [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 128]
     [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 320])
-  
-  (define-operations ([x <binary32>]) <binary32>
+
+ (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
     [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 64]
     [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 3200]
     [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 3200]
@@ -81,7 +81,7 @@
     [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
     [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
   
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
+ (define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
     [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 3200]
     [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 3200]
     [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 3200]
@@ -91,16 +91,18 @@
     [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 3200]
     [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 3200])
   
-  (define-operations ([x <binary32>]) <binary32>
+ (define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
     [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 3200]
     [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 3200]
     [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 3200])
   
-  (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf) #:fpcore (hypot x y) #:cost 3200)
-  
-  (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
-    #:spec (+ (* x y) z) #:impl (from-libm 'fmaf) #:fpcore (fma x y z) #:cost 128))
+(define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
+  #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypotf)
+  #:fpcore (! :precision binary32 (hypot x y)) #:cost 3200)
+
+(define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
+  #:spec (+ (* x y) z) #:impl (from-libm 'fmaf)
+  #:fpcore (! :precision binary32 (fma x y z)) #:cost 128)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -114,23 +116,23 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 256]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 256])
   
-(parameterize ([fpcore-context '(:precision binary64)])
-  (define-operations () <binary64>
+(define-operations () <binary64> #:fpcore (:precision binary64)
     [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64]
     [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64]
     [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64]
     [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 64])
+
+ (define-operation (neg.f64 [x <binary64>]) <binary64>
+   #:spec (neg x) #:impl -
+   #:fpcore (! :precision binary64 (- x)) #:cost 128)
   
-  (define-operation (neg.f64 [x <binary64>]) <binary64>
-    #:spec (neg x) #:impl - #:fpcore (- x) #:cost 128)
-  
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
     [+.f64 #:spec (+ x y) #:impl + #:cost 128]
     [-.f64 #:spec (- x y) #:impl - #:cost 128]
     [*.f64 #:spec (* x y) #:impl * #:cost 256]
     [/.f64 #:spec (/ x y) #:impl / #:cost 640])
 
-  (define-operations ([x <binary64>]) <binary64>
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
     [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 128]
     [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 6400]
     [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 6400]
@@ -161,7 +163,7 @@
     [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
     [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])
   
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
     [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 6400]
     [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 6400]
     [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 6400]
@@ -171,16 +173,18 @@
     [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 6400]
     [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 6400])
   
-  (define-operations ([x <binary64>]) <binary64>
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
     [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 6400]
     [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 6400]
     [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 6400])
   
-  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot) #:fpcore (hypot x y) #:cost 6400)
-  
-  (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
-    #:spec (+ (* x y) z) #:impl (from-libm 'fma) #:fpcore (fma x y z) #:cost 256))
+ (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+   #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-libm 'hypot)
+   #:fpcore (! :precision binary64 (hypot x y)) #:cost 6400)
+
+ (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+   #:spec (+ (* x y) z) #:impl (from-libm 'fma)
+   #:fpcore (! :precision binary64 (fma x y z)) #:cost 256)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This PR replaces `parameterize` blocks in `herbie10` and `herbie20` with the `#:fpcore` argument of `define-operations`. This refactor mirrors the style of the existing C platform and removes all references to `fpcore-context`.

https://chatgpt.com/codex/tasks/task_e_68800d0a50148331be8215167f39625b