### PR TITLE
Switch softposit and rival platforms to #:fpcore

### DIFF
--- a/infra/softposit.rkt
+++ b/infra/softposit.rkt
@@ -168,16 +168,15 @@
   [<=.p8 #:spec (<= x y) #:impl posit8<= #:cost 1]
   [>=.p8 #:spec (>= x y) #:impl posit8>= #:cost 1])
 
-(parameterize ([fpcore-context '(:precision posit8)])
-  (define-operations ([x <posit8>]) <posit8>
-    [neg.p8  #:spec (neg x)  #:impl posit8-neg  #:fpcore (- x) #:cost 1]
-    [sqrt.p8 #:spec (sqrt x) #:impl posit8-sqrt #:cost 1])
+(define-operations ([x <posit8>]) <posit8> #:fpcore (:precision posit8)
+  [neg.p8  #:spec (neg x)  #:impl posit8-neg  #:fpcore (- x) #:cost 1]
+  [sqrt.p8 #:spec (sqrt x) #:impl posit8-sqrt #:cost 1])
 
-  (define-operations ([x <posit8>] [y <posit8>]) <posit8>
-    [+.p8 #:spec (+ x y) #:impl posit8-add #:cost 1]
-    [-.p8 #:spec (- x y) #:impl posit8-sub #:cost 1]
-    [*.p8 #:spec (* x y) #:impl posit8-mul #:cost 1]
-    [/.p8 #:spec (/ x y) #:impl posit8-div #:cost 1]))
+(define-operations ([x <posit8>] [y <posit8>]) <posit8> #:fpcore (:precision posit8)
+  [+.p8 #:spec (+ x y) #:impl posit8-add #:cost 1]
+  [-.p8 #:spec (- x y) #:impl posit8-sub #:cost 1]
+  [*.p8 #:spec (* x y) #:impl posit8-mul #:cost 1]
+  [/.p8 #:spec (/ x y) #:impl posit8-div #:cost 1])
 
 (define-operations ([x <posit16>] [y <posit16>]) <bool>
   [==.p16 #:spec (== x y) #:impl posit16=  #:cost 1]
@@ -186,16 +185,15 @@
   [<=.p16 #:spec (<= x y) #:impl posit16<= #:cost 1]
   [>=.p16 #:spec (>= x y) #:impl posit16>= #:cost 1])
 
-(parameterize ([fpcore-context '(:precision posit16)])
-  (define-operations ([x <posit16>]) <posit16>
-    [neg.p16  #:spec (neg x)  #:impl posit16-neg  #:fpcore (- x) #:cost 1]
-    [sqrt.p16 #:spec (sqrt x) #:impl posit16-sqrt #:cost 1])
+(define-operations ([x <posit16>]) <posit16> #:fpcore (:precision posit16)
+  [neg.p16  #:spec (neg x)  #:impl posit16-neg  #:fpcore (- x) #:cost 1]
+  [sqrt.p16 #:spec (sqrt x) #:impl posit16-sqrt #:cost 1])
 
-  (define-operations ([x <posit16>] [y <posit16>]) <posit16>
-    [+.p16 #:spec (+ x y) #:impl posit16-add #:cost 1]
-    [-.p16 #:spec (- x y) #:impl posit16-sub #:cost 1]
-    [*.p16 #:spec (* x y) #:impl posit16-mul #:cost 1]
-    [/.p16 #:spec (/ x y) #:impl posit16-div #:cost 1]))
+(define-operations ([x <posit16>] [y <posit16>]) <posit16> #:fpcore (:precision posit16)
+  [+.p16 #:spec (+ x y) #:impl posit16-add #:cost 1]
+  [-.p16 #:spec (- x y) #:impl posit16-sub #:cost 1]
+  [*.p16 #:spec (* x y) #:impl posit16-mul #:cost 1]
+  [/.p16 #:spec (/ x y) #:impl posit16-div #:cost 1])
 
 (define-operations ([x <posit32>] [y <posit32>]) <bool>
   [==.p32 #:spec (== x y) #:impl posit32=  #:cost 1]
@@ -204,16 +202,15 @@
   [<=.p32 #:spec (<= x y) #:impl posit32<= #:cost 1]
   [>=.p32 #:spec (>= x y) #:impl posit32>= #:cost 1])
 
-(parameterize ([fpcore-context '(:precision posit32)])
-  (define-operations ([x <posit32>]) <posit32>
-    [neg.p32  #:spec (neg x)  #:impl posit32-neg  #:fpcore (- x) #:cost 1]
-    [sqrt.p32 #:spec (sqrt x) #:impl posit32-sqrt #:cost 1])
+(define-operations ([x <posit32>]) <posit32> #:fpcore (:precision posit32)
+  [neg.p32  #:spec (neg x)  #:impl posit32-neg  #:fpcore (- x) #:cost 1]
+  [sqrt.p32 #:spec (sqrt x) #:impl posit32-sqrt #:cost 1])
 
-  (define-operations ([x <posit32>] [y <posit32>]) <posit32>
-    [+.p32 #:spec (+ x y) #:impl posit32-add #:cost 1]
-    [-.p32 #:spec (- x y) #:impl posit32-sub #:cost 1]
-    [*.p32 #:spec (* x y) #:impl posit32-mul #:cost 1]
-    [/.p32 #:spec (/ x y) #:impl posit32-div #:cost 1]))
+(define-operations ([x <posit32>] [y <posit32>]) <posit32> #:fpcore (:precision posit32)
+  [+.p32 #:spec (+ x y) #:impl posit32-add #:cost 1]
+  [-.p32 #:spec (- x y) #:impl posit32-sub #:cost 1]
+  [*.p32 #:spec (* x y) #:impl posit32-mul #:cost 1]
+  [/.p32 #:spec (/ x y) #:impl posit32-div #:cost 1])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; QUIRE OPERATIONS ;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -221,20 +218,17 @@
 (define-representation <quire16> #:cost 1)
 (define-representation <quire32> #:cost 1)
 
-(parameterize ([fpcore-context '(:precision quire8)])
-  (define-operations ([x <quire8>] [y <posit8>] [z <posit8>]) <quire8>
-    [quire8-mul-add #:spec (+ x (* y z)) #:impl quire8-fdp-add #:fpcore (fdp x y z) #:cost 1]
-    [quire8-mul-sub #:spec (- x (* y z)) #:impl quire8-fdp-sub #:fpcore (fds x y z) #:cost 1]))
+(define-operations ([x <quire8>] [y <posit8>] [z <posit8>]) <quire8> #:fpcore (:precision quire8)
+  [quire8-mul-add #:spec (+ x (* y z)) #:impl quire8-fdp-add #:fpcore (fdp x y z) #:cost 1]
+  [quire8-mul-sub #:spec (- x (* y z)) #:impl quire8-fdp-sub #:fpcore (fds x y z) #:cost 1])
 
-(parameterize ([fpcore-context '(:precision quire16)])
-  (define-operations ([x <quire16>] [y <posit16>] [z <posit16>]) <quire16>
-    [quire16-mul-add #:spec (+ x (* y z)) #:impl quire16-fdp-add #:fpcore (fdp x y z) #:cost 1]
-    [quire16-mul-sub #:spec (- x (* y z)) #:impl quire16-fdp-sub #:fpcore (fds x y z) #:cost 1]))
+(define-operations ([x <quire16>] [y <posit16>] [z <posit16>]) <quire16> #:fpcore (:precision quire16)
+  [quire16-mul-add #:spec (+ x (* y z)) #:impl quire16-fdp-add #:fpcore (fdp x y z) #:cost 1]
+  [quire16-mul-sub #:spec (- x (* y z)) #:impl quire16-fdp-sub #:fpcore (fds x y z) #:cost 1])
 
-(parameterize ([fpcore-context '(:precision quire32)])
-  (define-operations ([x <quire32>] [y <posit32>] [z <posit32>]) <quire32>
-    [quire32-mul-add #:spec (+ x (* y z)) #:impl quire32-fdp-add #:fpcore (fdp x y z) #:cost 1]
-    [quire32-mul-sub #:spec (- x (* y z)) #:impl quire32-fdp-sub #:fpcore (fds x y z) #:cost 1]))
+(define-operations ([x <quire32>] [y <posit32>] [z <posit32>]) <quire32> #:fpcore (:precision quire32)
+  [quire32-mul-add #:spec (+ x (* y z)) #:impl quire32-fdp-add #:fpcore (fdp x y z) #:cost 1]
+  [quire32-mul-sub #:spec (- x (* y z)) #:impl quire32-fdp-sub #:fpcore (fds x y z) #:cost 1])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CONVERTERS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -31,71 +31,70 @@
   [<=.f32 #:spec (<= x y) #:impl (from-rival) #:cost 1]
   [>=.f32 #:spec (>= x y) #:impl (from-rival) #:cost 1])
 
-(parameterize ([fpcore-context '(:precision binary32)])
-  (define-operations () <binary32>
-    [PI.f32 #:spec (PI) #:impl (from-rival) #:fpcore PI #:cost 1]
-    [E.f32  #:spec (E)  #:impl (from-rival) #:fpcore E  #:cost 1])
-  
-  (define-operation (neg.f32 [x <binary32>]) <binary32>
-    #:spec (neg x) #:impl (from-rival) #:fpcore (- x) #:cost 1)
-  
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
-    [+.f32 #:spec (+ x y) #:impl (from-rival) #:cost 1]
-    [-.f32 #:spec (- x y) #:impl (from-rival) #:cost 1]
-    [*.f32 #:spec (* x y) #:impl (from-rival) #:cost 1]
-    [/.f32 #:spec (/ x y) #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary32>]) <binary32>
-    [fabs.f32   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
-    [sin.f32    #:spec (sin x)    #:impl (from-rival) #:cost 1]
-    [cos.f32    #:spec (cos x)    #:impl (from-rival) #:cost 1]
-    [tan.f32    #:spec (tan x)    #:impl (from-rival) #:cost 1]
-    [sinh.f32   #:spec (sinh x)   #:impl (from-rival) #:cost 1]
-    [cosh.f32   #:spec (cosh x)   #:impl (from-rival) #:cost 1]
-    [acos.f32   #:spec (acos x)   #:impl (from-rival) #:cost 1]
-    [acosh.f32  #:spec (acosh x)  #:impl (from-rival) #:cost 1]
-    [asin.f32   #:spec (asin x)   #:impl (from-rival) #:cost 1]
-    [asinh.f32  #:spec (asinh x)  #:impl (from-rival) #:cost 1]
-    [atan.f32   #:spec (atan x)   #:impl (from-rival) #:cost 1]
-    [atanh.f32  #:spec (atanh x)  #:impl (from-rival) #:cost 1]
-    [cbrt.f32   #:spec (cbrt x)   #:impl (from-rival) #:cost 1]
-    [ceil.f32   #:spec (ceil x)   #:impl (from-rival) #:cost 1]
-    [erf.f32    #:spec (erf x)    #:impl (from-rival) #:cost 1]
-    [exp.f32    #:spec (exp x)    #:impl (from-rival) #:cost 1]
-    [exp2.f32   #:spec (exp2 x)   #:impl (from-rival) #:cost 1]
-    [floor.f32  #:spec (floor x)  #:impl (from-rival) #:cost 1]
-    [lgamma.f32 #:spec (lgamma x) #:impl (from-rival) #:cost 1]
-    [log.f32    #:spec (log x)    #:impl (from-rival) #:cost 1]
-    [log10.f32  #:spec (log10 x)  #:impl (from-rival) #:cost 1]
-    [log2.f32   #:spec (log2 x)   #:impl (from-rival) #:cost 1]
-    [logb.f32   #:spec (logb x)   #:impl (from-rival) #:cost 1]
-    [rint.f32   #:spec (rint x)   #:impl (from-rival) #:cost 1]
-    [round.f32  #:spec (round x)  #:impl (from-rival) #:cost 1]
-    [sqrt.f32   #:spec (sqrt x)   #:impl (from-rival) #:cost 1]
-    [tanh.f32   #:spec (tanh x)   #:impl (from-rival) #:cost 1]
-    [tgamma.f32 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
-    [trunc.f32  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary32>] [y <binary32>]) <binary32>
-    [pow.f32       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
-    [atan2.f32     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
-    [copysign.f32  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
-    [fdim.f32      #:spec (fdim x y)      #:impl (from-rival) #:cost 1]
-    [fmax.f32      #:spec (fmax x y)      #:impl (from-rival) #:cost 1]
-    [fmin.f32      #:spec (fmin x y)      #:impl (from-rival) #:cost 1]
-    [fmod.f32      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
-    [remainder.f32 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary32>]) <binary32>
-    [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
-    [expm1.f32 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
-    [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])
-  
-  (define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-rival) #:fpcore (hypot x y) #:cost 1)
-  
-  (define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
-    #:spec (+ (* x y) z) #:impl (from-rival) #:fpcore (fma x y z) #:cost 1))
+(define-operations () <binary32> #:fpcore (:precision binary32)
+  [PI.f32 #:spec (PI) #:impl (from-rival) #:fpcore PI #:cost 1]
+  [E.f32  #:spec (E)  #:impl (from-rival) #:fpcore E  #:cost 1])
+
+(define-operation (neg.f32 [x <binary32>]) <binary32>
+  #:spec (neg x) #:impl (from-rival) #:fpcore (! :precision binary32 (- x)) #:cost 1)
+
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [+.f32 #:spec (+ x y) #:impl (from-rival) #:cost 1]
+  [-.f32 #:spec (- x y) #:impl (from-rival) #:cost 1]
+  [*.f32 #:spec (* x y) #:impl (from-rival) #:cost 1]
+  [/.f32 #:spec (/ x y) #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [fabs.f32   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
+  [sin.f32    #:spec (sin x)    #:impl (from-rival) #:cost 1]
+  [cos.f32    #:spec (cos x)    #:impl (from-rival) #:cost 1]
+  [tan.f32    #:spec (tan x)    #:impl (from-rival) #:cost 1]
+  [sinh.f32   #:spec (sinh x)   #:impl (from-rival) #:cost 1]
+  [cosh.f32   #:spec (cosh x)   #:impl (from-rival) #:cost 1]
+  [acos.f32   #:spec (acos x)   #:impl (from-rival) #:cost 1]
+  [acosh.f32  #:spec (acosh x)  #:impl (from-rival) #:cost 1]
+  [asin.f32   #:spec (asin x)   #:impl (from-rival) #:cost 1]
+  [asinh.f32  #:spec (asinh x)  #:impl (from-rival) #:cost 1]
+  [atan.f32   #:spec (atan x)   #:impl (from-rival) #:cost 1]
+  [atanh.f32  #:spec (atanh x)  #:impl (from-rival) #:cost 1]
+  [cbrt.f32   #:spec (cbrt x)   #:impl (from-rival) #:cost 1]
+  [ceil.f32   #:spec (ceil x)   #:impl (from-rival) #:cost 1]
+  [erf.f32    #:spec (erf x)    #:impl (from-rival) #:cost 1]
+  [exp.f32    #:spec (exp x)    #:impl (from-rival) #:cost 1]
+  [exp2.f32   #:spec (exp2 x)   #:impl (from-rival) #:cost 1]
+  [floor.f32  #:spec (floor x)  #:impl (from-rival) #:cost 1]
+  [lgamma.f32 #:spec (lgamma x) #:impl (from-rival) #:cost 1]
+  [log.f32    #:spec (log x)    #:impl (from-rival) #:cost 1]
+  [log10.f32  #:spec (log10 x)  #:impl (from-rival) #:cost 1]
+  [log2.f32   #:spec (log2 x)   #:impl (from-rival) #:cost 1]
+  [logb.f32   #:spec (logb x)   #:impl (from-rival) #:cost 1]
+  [rint.f32   #:spec (rint x)   #:impl (from-rival) #:cost 1]
+  [round.f32  #:spec (round x)  #:impl (from-rival) #:cost 1]
+  [sqrt.f32   #:spec (sqrt x)   #:impl (from-rival) #:cost 1]
+  [tanh.f32   #:spec (tanh x)   #:impl (from-rival) #:cost 1]
+  [tgamma.f32 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
+  [trunc.f32  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [pow.f32       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
+  [atan2.f32     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
+  [copysign.f32  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
+  [fdim.f32      #:spec (fdim x y)      #:impl (from-rival) #:cost 1]
+  [fmax.f32      #:spec (fmax x y)      #:impl (from-rival) #:cost 1]
+  [fmin.f32      #:spec (fmin x y)      #:impl (from-rival) #:cost 1]
+  [fmod.f32      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
+  [remainder.f32 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+  [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
+  [expm1.f32 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
+  [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])
+
+(define-operation (hypot.f32 [x <binary32>] [y <binary32>]) <binary32>
+  #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-rival) #:fpcore (! :precision binary32 (hypot x y)) #:cost 1)
+
+(define-operation (fma.f32 [x <binary32>] [y <binary32>] [z <binary32>]) <binary32>
+  #:spec (+ (* x y) z) #:impl (from-rival) #:fpcore (! :precision binary32 (fma x y z)) #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BINARY 64 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -109,73 +108,72 @@
   [<=.f64 #:spec (<= x y) #:impl (from-rival) #:cost 1]
   [>=.f64 #:spec (>= x y) #:impl (from-rival) #:cost 1])
 
-(parameterize ([fpcore-context '(:precision binary64)])
-  (define-operations () <binary64>
-    [PI.f64   #:spec (PI)       #:impl (from-rival) #:cost 1]
-    [E.f64    #:spec (E)        #:impl (from-rival) #:cost 1]
-    [INFINITY #:spec (INFINITY) #:impl (from-rival) #:cost 1]
-    [NAN.f64  #:spec (NAN)      #:impl (from-rival) #:cost 1])
-  
-  (define-operation (neg.f64 [x <binary64>]) <binary64>
-    #:spec (neg x) #:impl (from-rival) #:fpcore (- x) #:cost 1)
-  
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
-    [+.f64 #:spec (+ x y) #:impl (from-rival) #:cost 1]
-    [-.f64 #:spec (- x y) #:impl (from-rival) #:cost 1]
-    [*.f64 #:spec (* x y) #:impl (from-rival) #:cost 1]
-    [/.f64 #:spec (/ x y) #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary64>]) <binary64>
-    [fabs.f64   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
-    [sin.f64    #:spec (sin x)    #:impl (from-rival) #:cost 1]
-    [cos.f64    #:spec (cos x)    #:impl (from-rival) #:cost 1]
-    [tan.f64    #:spec (tan x)    #:impl (from-rival) #:cost 1]
-    [sinh.f64   #:spec (sinh x)   #:impl (from-rival) #:cost 1]
-    [cosh.f64   #:spec (cosh x)   #:impl (from-rival) #:cost 1]
-    [acos.f64   #:spec (acos x)   #:impl (from-rival) #:cost 1]
-    [acosh.f64  #:spec (acosh x)  #:impl (from-rival) #:cost 1]
-    [asin.f64   #:spec (asin x)   #:impl (from-rival) #:cost 1]
-    [asinh.f64  #:spec (asinh x)  #:impl (from-rival) #:cost 1]
-    [atan.f64   #:spec (atan x)   #:impl (from-rival) #:cost 1]
-    [atanh.f64  #:spec (atanh x)  #:impl (from-rival) #:cost 1]
-    [cbrt.f64   #:spec (cbrt x)   #:impl (from-rival) #:cost 1]
-    [ceil.f64   #:spec (ceil x)   #:impl (from-rival) #:cost 1]
-    [erf.f64    #:spec (erf x)    #:impl (from-rival) #:cost 1]
-    [exp.f64    #:spec (exp x)    #:impl (from-rival) #:cost 1]
-    [exp2.f64   #:spec (exp2 x)   #:impl (from-rival) #:cost 1]
-    [floor.f64  #:spec (floor x)  #:impl (from-rival) #:cost 1]
-    [lgamma.f64 #:spec (lgamma x) #:impl (from-rival) #:cost 1]
-    [log.f64    #:spec (log x)    #:impl (from-rival) #:cost 1]
-    [log10.f64  #:spec (log10 x)  #:impl (from-rival) #:cost 1]
-    [log2.f64   #:spec (log2 x)   #:impl (from-rival) #:cost 1]
-    [logb.f64   #:spec (logb x)   #:impl (from-rival) #:cost 1]
-    [rint.f64   #:spec (rint x)   #:impl (from-rival) #:cost 1]
-    [round.f64  #:spec (round x)  #:impl (from-rival) #:cost 1]
-    [sqrt.f64   #:spec (sqrt x)   #:impl (from-rival) #:cost 1]
-    [tanh.f64   #:spec (tanh x)   #:impl (from-rival) #:cost 1]
-    [tgamma.f64 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
-    [trunc.f64  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary64>] [y <binary64>]) <binary64>
-    [pow.f64       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
-    [atan2.f64     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
-    [copysign.f64  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
-    [fdim.f64      #:spec (fdim x y)      #:impl (from-rival) #:cost 1]
-    [fmax.f64      #:spec (fmax x y)      #:impl (from-rival) #:cost 1]
-    [fmin.f64      #:spec (fmin x y)      #:impl (from-rival) #:cost 1]
-    [fmod.f64      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
-    [remainder.f64 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
-  
-  (define-operations ([x <binary64>]) <binary64>
-    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
-    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
-    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])
-  
-  (define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
-    #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-rival) #:fpcore (hypot x y) #:cost 1)
-  
-  (define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
-    #:spec (+ (* x y) z) #:impl (from-rival) #:fpcore (fma x y z) #:cost 1))
+(define-operations () <binary64> #:fpcore (:precision binary64)
+  [PI.f64   #:spec (PI)       #:impl (from-rival) #:cost 1]
+  [E.f64    #:spec (E)        #:impl (from-rival) #:cost 1]
+  [INFINITY #:spec (INFINITY) #:impl (from-rival) #:cost 1]
+  [NAN.f64  #:spec (NAN)      #:impl (from-rival) #:cost 1])
+
+(define-operation (neg.f64 [x <binary64>]) <binary64>
+  #:spec (neg x) #:impl (from-rival) #:fpcore (! :precision binary64 (- x)) #:cost 1)
+
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [+.f64 #:spec (+ x y) #:impl (from-rival) #:cost 1]
+  [-.f64 #:spec (- x y) #:impl (from-rival) #:cost 1]
+  [*.f64 #:spec (* x y) #:impl (from-rival) #:cost 1]
+  [/.f64 #:spec (/ x y) #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [fabs.f64   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
+  [sin.f64    #:spec (sin x)    #:impl (from-rival) #:cost 1]
+  [cos.f64    #:spec (cos x)    #:impl (from-rival) #:cost 1]
+  [tan.f64    #:spec (tan x)    #:impl (from-rival) #:cost 1]
+  [sinh.f64   #:spec (sinh x)   #:impl (from-rival) #:cost 1]
+  [cosh.f64   #:spec (cosh x)   #:impl (from-rival) #:cost 1]
+  [acos.f64   #:spec (acos x)   #:impl (from-rival) #:cost 1]
+  [acosh.f64  #:spec (acosh x)  #:impl (from-rival) #:cost 1]
+  [asin.f64   #:spec (asin x)   #:impl (from-rival) #:cost 1]
+  [asinh.f64  #:spec (asinh x)  #:impl (from-rival) #:cost 1]
+  [atan.f64   #:spec (atan x)   #:impl (from-rival) #:cost 1]
+  [atanh.f64  #:spec (atanh x)  #:impl (from-rival) #:cost 1]
+  [cbrt.f64   #:spec (cbrt x)   #:impl (from-rival) #:cost 1]
+  [ceil.f64   #:spec (ceil x)   #:impl (from-rival) #:cost 1]
+  [erf.f64    #:spec (erf x)    #:impl (from-rival) #:cost 1]
+  [exp.f64    #:spec (exp x)    #:impl (from-rival) #:cost 1]
+  [exp2.f64   #:spec (exp2 x)   #:impl (from-rival) #:cost 1]
+  [floor.f64  #:spec (floor x)  #:impl (from-rival) #:cost 1]
+  [lgamma.f64 #:spec (lgamma x) #:impl (from-rival) #:cost 1]
+  [log.f64    #:spec (log x)    #:impl (from-rival) #:cost 1]
+  [log10.f64  #:spec (log10 x)  #:impl (from-rival) #:cost 1]
+  [log2.f64   #:spec (log2 x)   #:impl (from-rival) #:cost 1]
+  [logb.f64   #:spec (logb x)   #:impl (from-rival) #:cost 1]
+  [rint.f64   #:spec (rint x)   #:impl (from-rival) #:cost 1]
+  [round.f64  #:spec (round x)  #:impl (from-rival) #:cost 1]
+  [sqrt.f64   #:spec (sqrt x)   #:impl (from-rival) #:cost 1]
+  [tanh.f64   #:spec (tanh x)   #:impl (from-rival) #:cost 1]
+  [tgamma.f64 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
+  [trunc.f64  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [pow.f64       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
+  [atan2.f64     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
+  [copysign.f64  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
+  [fdim.f64      #:spec (fdim x y)      #:impl (from-rival) #:cost 1]
+  [fmax.f64      #:spec (fmax x y)      #:impl (from-rival) #:cost 1]
+  [fmin.f64      #:spec (fmin x y)      #:impl (from-rival) #:cost 1]
+  [fmod.f64      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
+  [remainder.f64 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
+
+(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+  [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
+  [expm1.f64 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
+  [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])
+
+(define-operation (hypot.f64 [x <binary64>] [y <binary64>]) <binary64>
+  #:spec (sqrt (+ (* x x) (* y y))) #:impl (from-rival) #:fpcore (! :precision binary64 (hypot x y)) #:cost 1)
+
+(define-operation (fma.f64 [x <binary64>] [y <binary64>] [z <binary64>]) <binary64>
+  #:spec (+ (* x y) z) #:impl (from-rival) #:fpcore (! :precision binary64 (fma x y z)) #:cost 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CASTS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
## Summary
- migrate the `rival` and `softposit` platform definitions to use `#:fpcore`
- remove direct uses of `fpcore-context`

All other behavior is unchanged.

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`

------
https://chatgpt.com/codex/tasks/task_e_688014db40608331ac945a8df1fbe531