### PR TITLE
Remove name field from platform struct

### DIFF
--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -3,6 +3,7 @@
 (require racket/runtime-path)
 (require "../utils/common.rkt"
          "../utils/errors.rkt"
+         "../config.rkt"
          "../core/rules.rkt"
          "matcher.rkt"
          "types.rkt"
@@ -25,7 +26,6 @@
          ;; Operator sets
          (contract-out ;; Platforms
           [platform? (-> any/c boolean?)]
-          [platform-name (-> platform? any/c)]
           [platform-if-cost (-> platform? any/c)]
           [platform-reprs (-> platform? (listof representation?))]
           [platform-impls (-> platform? (listof symbol?))]
@@ -54,14 +54,12 @@
 ;;;
 ;;; A small API is provided for platforms for querying the supported
 ;;; operators, operator implementations, and representation conversions.
-(struct platform (name [if-cost #:mutable] representations implementations representation-costs)
+(struct platform ([if-cost #:mutable] representations implementations representation-costs)
   #:name $platform
   #:constructor-name create-platform
   #:methods gen:custom-write
   [(define (write-proc p port mode)
-     (if (platform-name p)
-         (fprintf port "#<platform:~a>" (platform-name p))
-         (fprintf port "#<platform>")))])
+     (fprintf port "#<platform>"))])
 
 ;; Active platform
 (define *active-platform* (make-parameter #f))
@@ -72,11 +70,11 @@
                [representations (hash-copy (platform-representations platform))]
                [implementations (hash-copy (platform-implementations platform))]))
 
-(define (make-empty-platform name)
+(define (make-empty-platform)
   (define reprs (make-hash))
   (define repr-costs (make-hash))
   (define impls (make-hash))
-  (create-platform name #f reprs impls repr-costs))
+  (create-platform #f reprs impls repr-costs))
 
 (define (platform-register-if-cost! platform #:cost cost)
   (set-platform-if-cost! platform (platform/parse-if-cost cost)))
@@ -88,14 +86,14 @@
   (when (hash-has-key? reprs (representation-name repr))
     (raise-herbie-error "Duplicate representation ~a in platform ~a"
                         (representation-name repr)
-                        (platform-name platform)))
+                        (*platform-name*)))
   ; Update tables
   (hash-set! reprs (representation-name repr) repr)
   (hash-set! repr-costs (representation-name repr) cost))
 
 (define (platform-register-implementation! platform impl)
   (unless impl
-    (raise-herbie-error "Platform ~a missing implementation" (platform-name platform)))
+    (raise-herbie-error "Platform ~a missing implementation" (*platform-name*)))
   ; Reprs check
   (define reprs (platform-representations platform))
   (define otype (context-repr (operator-impl-ctx impl)))
@@ -103,7 +101,7 @@
   (define impl-reprs (map representation-name (remove-duplicates (cons otype itype))))
   (unless (andmap (curry hash-has-key? reprs) impl-reprs)
     (raise-herbie-error "Platform ~a missing representation of ~a implementation"
-                        (platform-name platform)
+                        (*platform-name*)
                         (operator-impl-name impl)))
   ; Cost check
   (define impl-cost (operator-impl-cost impl))
@@ -114,7 +112,7 @@
   (when (hash-has-key? impls (operator-impl-name impl))
     (raise-herbie-error "Impl ~a is already registered in platform ~a"
                         (operator-impl-name impl)
-                        (platform-name platform)))
+                        (*platform-name*)))
   ; Update table
   (hash-set! impls (operator-impl-name impl) impl))
 
@@ -151,7 +149,7 @@
       (raise-herbie-error "Could not find support for ~a representation: ~a in a platform ~a"
                           name
                           (string-join (map ~s (hash-keys reprs)) ", ")
-                          (platform-name platform))))
+                          (*platform-name*))))
 
 (define (repr-exists? name)
   (define platform (*active-platform*))
@@ -199,10 +197,7 @@
     (hash-ref impls
               impl-name
               (lambda ()
-                (error 'impl-info
-                       "unknown impl '~a in platform ~a"
-                       impl-name
-                       (platform-name (*active-platform*))))))
+                (error 'impl-info "unknown impl '~a in platform ~a" impl-name (*platform-name*)))))
   (case field
     [(name) (operator-impl-name impl)]
     [(vars) (context-vars (operator-impl-ctx impl))]
@@ -377,7 +372,7 @@
   (define repr-costs (platform-representation-costs platform))
   (define if-cost (platform-if-cost platform))
 
-  (printf "Platform: ~a;\n          if-cost: ~a;\n\n" (platform-name platform) if-cost)
+  (printf "Platform;\n          if-cost: ~a;\n\n" if-cost)
 
   (printf "Representations:\n")
   (define reprs-data

--- a/src/syntax/platforms-language.rkt
+++ b/src/syntax/platforms-language.rkt
@@ -42,7 +42,7 @@
   (with-syntax ([local-platform (datum->syntax stx 'platform)])
     (syntax-case stx ()
       [(_ content ...)
-       #'(#%module-begin (define local-platform (make-empty-platform 'platform))
+       #'(#%module-begin (define local-platform (make-empty-platform))
                          (define old-platform-being-defined (platform-being-defined))
                          (platform-being-defined local-platform)
                          content ...


### PR DESCRIPTION
The platform struct stored a name but Herbie already tracks the active
platform name via the `*platform-name*` parameter. This commit drops the
field entirely and updates all helpers accordingly. Error messages now
consult `*platform-name*` while debug output simply prints `#<platform>`.

Platform modules now call `make-empty-platform` with no arguments and the
`display-platform` routine no longer shows a platform name. These updates
are purely structural and keep existing behaviour intact.

------
https://chatgpt.com/codex/tasks/task_e_68805b4883b08331bdbcdc77f9578dd3