### PR TITLE
Document representations and generators

### DIFF
--- a/www/doc.html
+++ b/www/doc.html
@@ -37,13 +37,13 @@
     <li><a href="doc/latest/options.html">Command-line flags</a>: modifying Herbie's behavior.</li>
     <li><a href="doc/latest/error.html">What is error?</a>: how Herbie measures floating-point error.</li>
     <li><a href="doc/latest/faq.html">Warnings and Errors</a>: troubleshooting Herbie.</li>
-    <li><a href="doc/latest/platforms.html">Platforms</a>: how to write a new Herbie compilation target.</li>
     <li><a href="doc/latest/release-notes.html">Release Notes</a>: the biggest and latest changes to Herbie.</li>
   </ul>
 
-  <h2>Internal Documentation</h2>
+  <h2>Developer Documentation</h2>
   <ul>
-    <li><a href="doc/latest/plugins.html">Plugins</a>: teaching Herbie about new input formats.</li>
+    <li><a href="doc/latest/platforms.html">Platforms</a>: how to write a new Herbie compilation target.</li>
+    <li><a href="doc/latest/plugins.html">Other APIs</a>: advanced APIs for compilation targets.</li>
     <li><a href="doc/latest/api-endpoints.html">HTTP API</a>: Herbie's HTTP endpoints</li>
     <li><a href="doc/latest/diagrams.html">Diagrams</a>: miscellaneous figures related to Herbie</li>
   </ul>

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -45,8 +45,8 @@
   reprentations of <code>real</code> and correspond to single- and
   double-precision IEEE-754 arithmetic. There's also
   a <code>&lt;bool&gt;</code> representation for booleans. It's
-  possible to define new representations, but that's out of scope for
-  this page.</p>
+  possible to define new representations, described
+  on <a href="plugins.html">another page</a>.</p>
 
   <p><dfn>Operations</dfn> are the floating-point analog of functions
   and represent the actual floating-point operation the compilation

--- a/www/doc/2.2/plugins.html
+++ b/www/doc/2.2/plugins.html
@@ -96,7 +96,7 @@
   (inclusive) and 2<sup><var>width</var></sup> (exclusive). Ordinals
   must be in real-number order; that is, if <code>(repr->bf x)</code>
   is less than <code>(repr->bf y)</code>, then <code>(repr->ordinal
-  x)</code> should be less than <code>(ordinal->bf y)</code>.</p>
+  x)</code> should be less than <code>(repr->ordinal y)</code>.</p>
 
   <p>The <code>#:special</code> function should return true for NaN
   values (or whatever your representation calls values that don't

--- a/www/doc/2.2/plugins.html
+++ b/www/doc/2.2/plugins.html
@@ -2,14 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Herbie Plugins</title>
+  <title>Herbie Other APIs</title>
   <link rel='stylesheet' type='text/css' href='../../main.css'>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="text/javascript" src="toc.js"></script>
 </head>
 <body>
   <header>
-    <h1>Plugins</h1>
+    <h1>Other Herbie APIs</h1>
     <a href="../../"><img class="logo" src="../../logo-car.png" /></a>
     <nav>
       <ul>
@@ -20,419 +20,128 @@
     </nav>
   </header>
 
-  <p><a href="../../">Herbie</a> plugins define new functions, add
-  rewrite rules, and number representations. Users install plugins
-  separately, and Herbie then automatically loads and uses them.</p>
-  
-  <h2>Posit arithmetic</h2>
+  <p><a href="../../">Herbie</a> <a href="platforms.html">platforms</a>
+  are the main way to customize Herbie's behavior. The typical
+  platform just defines the set of representations and operations that
+  available to Herbie when compiling. However, platform files can
+  technically contain arbitrary Racket code, and thus can call other
+  Herbie APIs, including importing external libraries, defining new
+  representations, and so on. This page documents such APIs. Note that
+  a level of comfort with Racket is assumed.</p>
 
-  <p>The <kbd>softposit-herbie</kbd> plugin implements support
-  for <a href="https://posithub.org/">posit</a> arithmetic. Install it
-  with:</p>
+  <p>Please note that all of the APIs on this page are considered
+  unstable and may change version to version. If you run into issues,
+  please
+  <a href="https://github.com/uwplse/herbie/issues">file a
+  bug</a>.</p>
 
-  <pre class="shell">raco pkg install --auto softposit-herbie</pre>
+  <h2>Defining representations</h2>
 
-  <p>This plugin uses the SoftPosit library, only supported on Linux.
-  Even then is reported to misbehave on some machines. The plugin
-  supports arithmetic operations, <code>sqrt</code>, and quires.</p>
+  <p><dfn>Representations</dfn> what Herbie calls different number
+  formats. They play a central role
+  in <a href="platforms.html">platforms</a>. Concretely, a
+  representation is a set of Racket values that represent both real
+  numbers and bit patterns.</p>
 
-  <p>Once <kbd>softposit-herbie</kbd> is installed,
-  specify <code>:precision posit16</code> to inform Herbie that it
-  should assume the core's inputs and outputs are posit numbers. Other
-  posit sizes (with 8 or 32 bits) and also quires (for 8, 16, and 32
-  bit posits) are available, but are poorly supported.</p>
+  <p>Specifically, a representation value needs to be convertible to
+  Racket <a href="https://docs.racket-lang.org/math/bigfloat.html"><code>bigfloat</code></a>
+  values (which are basically MPFR floats) and also
+  to <em>ordinals</em>, meaning integers between 0 and
+  2<sup><var>w</var></sup> for some bit width <var>w</var>.</p>
 
+  <p>Create representations with <code>make-representation</code>:</p>
 
-  <h2 id="complex">Generic floating-point numbers</h2>
+  <code>
+  <table>
+    <tr><td colspan=2>(<b>make-representation</b></td></tr>
+    <tr><td></td><td>#:name <var>name</var></td></tr>
+    <tr><td></td><td>#:total-bits <var>width</var></td></tr>
+    <tr><td></td><td>#:bf->repr <var>bf->repr</var></td></tr>
+    <tr><td></td><td>#:repr->bf <var>repr->bf</var></td></tr>
+    <tr><td></td><td>#:ordinal->repr <var>ordinal->repr</var></td></tr>
+    <tr><td></td><td>#:repr->ordinal <var>repr->ordinal</var></td></tr>
+    <tr><td></td><td>#:special-value? <var>special?</var>)</td></tr>
+  </table>
+  </code>
 
-  <p>The <kbd>float-herbie</kbd> plugin implements support for any IEEE-754
-    binary floating-point number. To install, check out the
-    <a href="https://github.com/bksaiki/float-herbie">source code</a>
-    and run
-  </p>
+  <p>The <code>#:name</code> should be either a symbol, or a list
+  containing symbols and integers. The <code>#:total-bits<code> value
+  should be a positive integer. The <code>#:total-bits</code>
+  parameter determines the total ordinal range your format takes up,
+  not just its significand range, so for example for double-precision
+  floats you need a <code>#:total-bits</code> of 64.</p>
 
-  <pre class="shell">raco pkg install</pre>
+  <p>The <code>#:bf->repr</code> and <code>#:repr->bf</code> values
+  should be that convert between representation values and Racket
+  bigfloats. The <code>repr->bf</code> function should use as large a
+  bigfloat precision as needed to exactly represent the value, while
+  the <code>bf->repr</code> function should round as per the current
+  value of
+  the <a href="https://docs.racket-lang.org/math/bigfloat.html#%28def._%28%28lib._math%2Fbigfloat..rkt%29._bf-rounding-mode%29%29">bf-rounding-mode</a>
+  parameter.</p>
 
-  <p>
-    at the top-level directory of the repository.
-    Once <kbd>float-herbie</kbd> is installed,
-    specify <code>:precision (float <i>ex</i> <i>nb</i>)</code>
-    to inform Herbie that it should assume the core's inputs and outputs are
-    floating-point numbers with <i>ex</i> exponent bits and <i>nb</i> total bits
-    (sign bit + mantissa bits + exponent bits).
-  </p>
+  <p>All non-NaN bigfloat values should result in non-NaN
+  representation values. For example, <code>(bf->repr (bf
+  "1e1000000"))</code> should yield the largest real value in the
+  representation. Infinite values, as in <code>(bf->repr
+  +inf.bf)</code>, should be interpreted as really large real values,
+  not as infinite values. For example,
+  the <a href="https://posithub.org/">posit</a> format has an
+  "infinite" value, but it behaves more like a NaN, so converting
+  bigfloat infinity to a posit should yield its largest real value
+  instead.</p>
 
-  <h2 id="complex">Generic fixed-point numbers</h2>
+  <p>The <code>#:ordinal->repr</code> and <code>#:repr->ordinal</code>
+  functions represent ordinals as Racket integers between 0
+  (inclusive) and 2<sup><var>width</var></sup> (exclusive). Ordinals
+  must be in real-number order; that is, if <code>(repr->bf x)</code>
+  is less than <code>(repr->bf y)</code>, then <code>(repr->ordinal
+  x)</code> should be less than <code>(ordinal->bf y)</code>.</p>
 
-  <p>The <kbd>fixedpoint-herbie</kbd> plugin implements support for any fixed-point number.
-    To install, check out the
-    <a href="https://github.com/bksaiki/fixedpoint-herbie">source code</a>
-    and run
-  </p>
+  <p>The <code>#:special</code> function should return true for NaN
+  values (or whatever your representation calls values that don't
+  represent any real number) and false for all other values. Special
+  values can be anywhere in the ordinal range, and you can have as
+  many or as few of them as you want.</p>
 
-  <pre class="shell">raco pkg install</pre>
+  <p><code>make-representation</code> returns a representation object,
+  which you can then use
+  in <a href="platforms.html"><code>define-representation</code>
+  and <code>define-operation</code></a>.</p>
 
-  <p>
-    at the top-level directory of the repository.
-    Once <kbd>fixedpoint-herbie</kbd> is installed,
-    specify <code>:precision (fixed <i>nb</i> <i>sc</i>)</code>
-    to inform Herbie that it should assume the core's inputs and outputs are
-    signed fixed-point numbers with <i>nb</i> total bits and a scaling factor of
-    2<sup><i>sc</i></sup> (integer formats have a scaling factor of 2<sup>0</sup>).
-    This plugin also supports unsigned fixed-point numbers specified by
-    <code>:precision (ufixed <i>nb</i> <i>sc</i>)</code> and provides
-    simpler aliases for integer formats with <code>:precision (integer <i>nb</i>)</code>
-    and <code>:precision (uinteger <i>nb</i>)</code>.
-  </p>
-  
-  <h2>Developing plugins</h2>
+  <h2>Defining Generators</h2>
 
-  <p>The following is a guide to creating a Herbie plugin.
-  Plugins are considered experimental and may change considerably
-  between releases.
-  If you run into issues, please 
-  <a href="https://github.com/uwplse/herbie/issues">file a bug</a>.
-  Be sure to check out the <a href="https://github.com/herbie-fp/herbie/tree/main/src/reprs">
-  built-in plugins</a> in the Herbie repository before getting started.</p>
+  <p><dfn>Generators</dfn> are helper functions for generating
+  implementations in <code>define-operation</code>. For
+  example, <a href="platforms.html"><code>from-libm</code>
+  and <code>from-rival</code></a> are generators.</p>
 
-  <p><b>First Steps</b><br>
+  <p>To define a generator, use <code>define-generator</code>:</p>
 
-  All plugins are implemented as Racket packages. The easiest way to
-  initialize a new Racket package is to run
+  <code><table>
+  <tr><td colspan=2>(<b>define-generator</b> ((from-<var>foo</var> <var>args</var> ...) spec ctx)</td></tr>
+  <tr><td></td><td><var>body</var> ...)</td></tr>
+  </table></code>
 
-  <pre class="shell">raco pkg new <var>pkg-name</var></pre>
+  <p>Here, <code>from-<var>foo</var></code> is the name of your
+  generator, and <var>args</var> are any additional arguments the
+  generator takes. For example, <code>from-libm</code> takes one
+  argument, the symbol name.</p>
 
-  in a new folder. Make sure the folder name is the same as the package name!
-  This will initialize a Racket package with all the necessary files.
-  Read the official Racket documentation on the
-  <a href="https://docs.racket-lang.org/pkg/getting-started.html#%28part._how-to-create%29">
-  raco</a> tool for more information.</p>
+  <p>Then, inside the <var>body</var>, you can use those arguments as
+  well as <code>spec</code> and <code>ctx</code>, to construct an
+  actual implementation function.</p>
 
-  <p>A single entry needs to be added to the package manifest stored
-  in <code>info.rkt</code>: add <code>(define herbie-plugin
-  '<var>name</var>)</code> to the bottom of the file
-  where <var>name</var> is a unique symbol that doesn't conflict with
-  other Herbie plugins, like the package name.</p>
+  <p>The specification <code>spec</code> is a Racket tree made up of
+  lists and symbols and numbers.</p>
 
-  <p>Next, edit the <code>main.rkt</code> file by erasing everything except the
-  language specifier on the first line, and add the line <code>(require herbie/plugin)</code>.
-  This gives the package access to the Herbie plugin interface.
-  Optionally add the following for debugging purposes
-  <code>(eprintf "Loading <var>pkg-name</var> support...\n")</code>
-  directly after the <code>require</code> statement.</p>
-
-  <p>Finally, run the following in the folder containing <code>info.rkt</code>
-  and <code>main.rkt</code>:
-
-  <pre class="shell">raco pkg install</pre>
-
-  This should install your package and check it for errors.
-  Everything is now set up.
-  If you added the debugging line in <code>main.rkt</code>, you should see the string
-  when you run Herbie.
-  Of course, your plugin is empty and doesn't yet add any useful features.
-  </p>
-
-  <p><b>Adding Features</b><br>
-  
-  Now that you have an empty plugin, you can begin adding new functions, rewrite
-  rules, and number representatons.
-  The procedures exported by the Herbie plugin interface can be roughly divided into
-  two categories: unique and parameterized.
-  Whether or not you use the unique or parameterized half of the interface
-  (or maybe both!) depends entirely on the number representation a feature is being
-  implemented for.
-  First, identify if your number representation is unique or parameterized.
-  For example, if you are adding features for <code>double</code> precision
-  (or rather <code>binary64</code>), the representation is unique.
-  If you are adding features for a generic floating point format, say
-  <code>(float <i>ebits</i> <i>nbits</i>)</code>, then the representation is parameterized.</p>
-
-  <p><b>Plugin Interface (Unique)</b><br>
-
-  The following are the signatures and descriptions of the
-  plugin procedures for unique representations.
-  These procedures are required to be at the top-level of
-  <code>main.rkt</code> rather than inside a function.</p>
-
-  <dl>
-    <dt>
-      <code>(<b>define-type</b> <i>name</i> (<i>exact?</i> <i>inexact?</i>)
-                         <i>exact->inexact</i> <i>inexact->exact</i>)</code>
-    </dt>
-    <dd>Adds a new type with the unique identifier <code><i>name</i></code>.
-      The arguments <code><i>exact?</i></code> and <code><i>inexact?</i></code>
-      return true if a value is an exact or high-precision approximate representation.
-      For Herbie's <code>real</code> type, <code><i>exact?</i></code> is implemented
-      with <code>real?</code> and <code><i>inexact?</i></code> is implemented
-      with <code>bigfloat?</code>. The procedures <code><i>exact->inexact</i></code> and
-      <code><i>inexact->exact</i></code> convert between <code><i>exact?</i></code>
-      and <code><i>inexact?</i></code> values.
-    </dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>define-representation</b> (<i>name</i> <i>type</i> <i>repr?</i>)</td>
-                     <td><i>bigfloat->repr</i></td></tr>
-        <tr><td></td><td><i>repr->bigfloat</i></td></tr>
-        <tr><td></td><td><i>ordinal->repr</i></td></tr>
-        <tr><td></td><td><i>repr->ordinal</i></td></tr>
-        <tr><td></td><td><i>width</i></td></tr>
-        <tr><td></td><td><i>special?</i>)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Adds a new representation with the unique identifier <code><i>name</i></code>.
-      The representation will inherit all rewrite rules defined for <code><i>type</i></code>.
-      By default, Herbie defines two types: <code>real</code> and <code>bool</code>.
-      Your representation will most likely inherit from <code>real</code>.
-      The <code><i>width</i></code> argument should be the bitwidth of the representation,
-      e.g. 64 for <code>binary64</code>.
-      The argument <code><i>repr?</i></code> is a procedure that accepts any argument and returns
-      true if the argument is a value in the representation, e.g. an integer representation
-      should use Racket's <code>integer?</code>, while <code><i>special?</i></code> takes a
-      value in the representation and returns true if it is not finite, e.g. NaN or infinity.<br><br>
-
-      The other four arguments are single-argument procedures that implement different conversions.
-      The first two convert between a value in your representation and a Racket
-      <a href="https://docs.racket-lang.org/math/bigfloat.html">bigfloat</a>
-      (you need to import <code>math/bigfloat</code>).
-      The last two convert between a value in your representation and its corresponding ordinal value.
-      Ordinal values for any representation must be within the interval [0, 2<sup><i>width</i></sup> - 1].
-      Check Racket's definition of
-      <a href="https://docs.racket-lang.org/math/flonum.html?q=ordinal#%28def._%28%28lib._math%2Fflonum..rkt%29._flonum-~3eordinal%29%29">
-      ordinals</a> for floats.
-      Note that those ordinal values can be negative.
-    </dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>define-operator</b> (<i>name</i> <i>itype-names ...</i>)</td><td> otype-name</td></tr>
-        <tr><td></td><td>[bf <i>bf-fn</i>]</td></tr>
-        <tr><td></td><td>[ival <i>ival-fn</i>])
-      </table>
-      </code>
-    </dt>
-    <dd>Adds a new operator. Operators describe pure mathematical functions,
-      i.e. <code>+</code> or <code>sin</code>.
-      The parameters <code><i>itype-names</i></code> and <code><i>otype-name</i></code>
-      are the input type(s) and output type names.
-      For example, <code>+</code> takes two <code>real</code> inputs and produces
-      one <code>real</code> output.
-      The <code><i>bf-fn</i></code> argument is the
-      <a href="https://docs.racket-lang.org/math/bigfloat.html">bigfloat</a> implementation of your operator.
-      The <code><i>ival-fn</i></code> argument is the <a href="https://github.com/herbie-fp/rival">Rival</a>
-      implementation of your operator. This is optional but improves the quality of Herbie's output.
-      If you don't want to implement this, set <code><i>ival-fn</i></code> to <code>false</code>.
-      To define operators with an unknown number of arguments, e.g. comparators,
-      add the attribute <code>[itype <i>itype</i>]</code>.
-      This will override the input type names defined by <code><i>itype-names</i></code>.
-      See the bottom of this section for support for constants.
-    </dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>define-operator-impl</b> (<i>op</i> <i>name</i> <i>irepr-names ...</i>)</td><td><i>orepr-name</i></td></tr>
-        <tr><td></td><td>[fl <i>fl-fn</i>]</td></tr>
-        <tr><td></td><td>...)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Implements <code><i>op</i></code> with input representation(s) <code><i>irepr-names</i></code>
-      and output representation <code><i>orepr-name</i></code>.
-      The field <code><i>name</i></code> must be unique.
-      For example, Herbie implements <code>+.f64</code> and <code>+.f32</code>
-      for double- and single-precision floats.
-      The argument <code><i>fl-fn</i></code> is the actual procedure that does the computation.
-      Like <code>define-operator</code>, the input representations can be
-      overridden with <code>[itype <i>irepr</i>]</code>.
-      By default, the attributes <code>bf</code> and <code>ival</code>
-      are inherited from <code><i>op</i></code> but can be overridden as previously
-      described.
-      See the bottom of this section for support for constant implementations.
-    </dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>define-ruleset</b> <i>name</i> (<i>groups ...</i>)</td>
-            <td>#:type ([<i>var</i> <i>repr</i>] ...)</td></tr>
-        <tr><td></td><td>[<i>rule-name</i> <i>match</i> <i>replace</i>]</td></tr>
-        <tr><td></td><td>...)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Defines a set of rewrite rules.
-      The <code><i>name</i></code> of the ruleset as well as each <code><i>rule-name</i></code>
-      must be a unique symbol.
-      Each ruleset must be marked with a set of <code><i>groups</i></code>
-      (read <a href="options.html#heading-3">here</a> on ruleset groups).
-      Each rewrite rule takes the form <code>match ⇝ replace</code> where Herbie's rewriter
-      will replace <code>match</code> with <code>replace</code> (not vice-versa).
-      Each <code><i>match</i></code> and <code><i>replace</i></code> is an expression whose operators are
-      the names of operator implementations rather than pure mathematical operators.
-      Any variable must be listed in the type information with its associated representation.
-      See the <code>softposit-herbie</code> plugin for a more concrete example.
-    </dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>define-ruleset*</b> <i>name</i> (<i>groups ...</i>)</td>
-            <td>#:type ([<i>var</i> <i>type</i>] ...)</td></tr>
-        <tr><td></td><td>[<i>rule-name</i> <i>match</i> <i>replace</i>]</td></tr>
-        <tr><td></td><td>...)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Like <code>define-ruleset</code>, but it defines a ruleset for every representation that
-      inherits from <code><i>type</i></code>.
-      Currently, every <code><i>type</i></code> must be the same, e.g.
-      all <code>real</code>, for this procedure to function correctly.
-      Unlike <code>define-ruleset</code>, <code><i>match</i></code> and <code><i>replace</i></code>
-      contain the names of operators rather than operator implementations.
-    </dd>
-  </dl>
-
-  <p>Procedures for declaring constants are not a part of the plugin interface.
-    Instead, constants and constant implementations are defined as
-      zero-argument operators and operator implementations.
-    The fields <code><i>fl-fn</i></code>, <code><i>bf-fn</i></code>,
-      and <code><i>ival-fn</i></code> should be implemented with zero-argument
-      procedures (thunks).
-    Similar to operator and operator implementations, constants describe pure
-      mathematical values like <code>π</code> or <code>e</code> while constant
-      implementations define an approximation of those constants in a particular
-      representation.
-  </p>
-
-  <p><b>Plugin Interface (Parameterized)</b><br>
-
-  Defining operators, constants, and representations for parameterized functions requires
-  a <i>generator</i> procedure for just-in-time loading of features for a particular
-  representation.
-  When Herbie encounters a representation it does not recognize (not explicitly defined
-  using <code>define-representation</code>) it queries a list of generators in case the
-  representation requires just-in-time loading.
-  </p>
-
-  <p>The following procedure handles represention objects:</p>
-
-  <dl>
-    <dt><code>(<b>get-representation</b> name)</code></dt>
-    <dd>Takes a representation name and returns a representation object.
-      Do not call this function before the associated representation has been registered!
-    </dd>
-  </dl>
-
-  <p>The following procedures handle generators:</p>
-
-  <dl>
-    <dt><code>(<b>register-generator!</b> gen)</code></dt>
-    <dd>Adds a representation generator procedure to Herbie's set of generators.
-      Representation generator procedures take the name of a representation and
-      return the associated representation object if it successfully created the
-      operators, constants, and rules for that representation.
-      In the case that your plugin does not register the requested representation,
-      the generator procedure need not do anything and should just return
-      <code>false</code>.
-    </dd>
-  </dl>
-
-  <dl>
-    <dt><code>(<b>register-conversion-generator!</b> gen)</code></dt>
-    <dd>Adds a conversion generator procedure to Herbie's set of generators.
-      Conversion generator procedures take the names of two representations
-      and returns <code>true</code> if it successfully registered conversion(s)
-      between the two representations.
-      Conversions are one-argument operator implementations of the <code>cast</code>
-        operator that have one representation as an input representation and
-        a different representation as an output representation.
-      User-defined conversions are <i>OPTIONAL</i> for multi-precision optimization,
-        since Herbie can synthesize these by default.
-      However Herbie's implementations are often slow since they are
-        representation-agnostic and work for any two representations.
-      In the case that your plugin does not register the requested conversion(s),
-      the generator procedure need not do anything and should just return
-      <code>false</code>.
-    </dd>
-  </dl>
-
-  <p>
-    To actually add representations, operators, etc. within a generator procedure,
-    you must use a set of alternate procedures.
-  </p>
-
-  <dl>
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>register-representation!</b> </td><td> <i>name</i></td></tr>
-        <tr><td></td><td><i>type</i></td></tr>
-        <tr><td></td><td><i>repr?</i></td></tr>
-        <tr><td></td><td><i>bigfloat->repr</i></td></tr>
-        <tr><td></td><td><i>repr->bigfloat</i></td></tr>
-        <tr><td></td><td><i>ordinal->repr</i></td></tr>
-        <tr><td></td><td><i>repr->ordinal</i></td></tr>
-        <tr><td></td><td><i>width</i></td></tr>
-        <tr><td></td><td><i>special?</i>)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Like <code>define-representation</code>, but used within generators.</dd>
-
-    <dt>
-      <code>
-      <table>
-        <tr><td>(<b>register-representation-alias!</b> </td><td> <i>name</i> <i>repr</i>)</td></tr>
-      </table>
-      </code>
-    </dt>
-    <dd>Adds an alias <i>name</i> for an existing representation <i>repr</i>.
-      If two representations are equivalent, e.g. <i>(float 8 32)</i> and <i>binary32</i>,
-      this procedure can be used to declare the two representations equivalent.
-    </dd>
-
-    <dt>
-      <code>(<b>register-operator!</b> <i>op</i> <i>name</i> <i>itype-names</i>
-        <i>otype-name</i> <i>attribs</i>)</code>
-    </dt>
-    <dd>Like <code>define-operator</code>, but used within generators.
-      The argument <code><i>itype-names</i></code> is a list of the input types
-      while the argument <code><i>attribs</i></code> are the same attributes for
-      <code>define-operator</code>, e.g. <code>bf</code>.
-      In this case, <code><i>attribs</i></code> is an association:
-      <code>(list (cons 'bf <i>bf-fn</i>) ...)</code>.
-    </dd>
-
-    <dt>
-      <code>(<b>register-operator-impl!</b> <i>op</i> <i>name</i> <i>ireprs</i>
-        <i>orepr</i> <i>attribs</i>)</code>
-    </dt>
-    <dd>Like <code>define-operator-impl</code>, but used within generators.
-      Unlike <code>define-operator-impl</code>, this procedure takes representation
-        objects rather than representation names for <code><i>ireprs</i></code>
-        and <code><i>orepr</i></code>.
-      Use <code>get-representation</code> to produce these objects.
-      See <code>register-operator!</code> for a description of <code><i>attribs</i></code>.
-    </dd>
-
-    <dt><code>(<b>register-ruleset!</b> <i>name</i> <i>groups</i>
-        <i>var-repr-names</i> <i>rules</i>)</code>
-    </dt>    
-    <dd>Like <code>define-ruleset</code>, but used within generators.
-      In this case, <code><i>groups</i></code> is a list of rule groups;
-        <code><i>var-repr-names</i></code> is an association
-        pairing each variable in the ruleset with its representation, e.g.
-        <code>(list (cons 'x '(float 5 16)) ...)</code>;
-        and <code><i>rules</i></code> is a list of rules of the following
-        form <code>(list (list <i>rule-name</i> <i>match</i> <i>replace</i>) ...)</code>.
-    </dd>
-
-  </dl>
+  <p>The signature <code>ctx</code> is "context" object; you can
+  access its <code>context-repr</code> to get the operation's output
+  representation, its <code>context-vars</code> to access its variable
+  names (as a list of symbols), and its <code>context-var-reprs</code>
+  to access its input representations (as a parallel list of
+  representations). The <code>context-lookup<code> function can be
+  used to look up a input argument's representation by name.</p>
 
 </body>
 </html>


### PR DESCRIPTION
This replaces the old `plugins.html`, which described a bunch of obsolete APIs, with a brand new page that just covers representations and generators.