### PR TITLE
Pass on a number of documentation files

### DIFF
--- a/www/doc.html
+++ b/www/doc.html
@@ -22,12 +22,12 @@
   <h2>Tutorials</h2>
   
   <ul>
-    <li><a href="doc/latest/tutorial.html">Herbie tutorial</a>: how to use Herbie.</li>
     <li><a href="doc/latest/installing.html">Installing Herbie</a>: getting Herbie up and running.</li>
-    <li><a href="doc/latest/docker.html">Installing with Docker</a>: an alternate installation method for Docker users.</li>
+    <li><a href="doc/latest/tutorial.html">Herbie tutorial</a>: how to use Herbie.</li>
     <li><a href="doc/latest/using-web.html">The browser UI</a>: a guide to running Herbie from your browser.</li>
     <li><a href="doc/latest/using-cli.html">Shell and batch mode</a>: a guide to running Herbie from the command line.</li>
     <li><a href="doc/latest/report.html">Reports</a>: understanding Herbie's output.</li>
+    <li><a href="doc/latest/docker.html">Installing with Docker</a>: an alternate installation method for Docker users.</li>
   </ul>
 
   <h2>Documentation</h2>

--- a/www/doc/2.2/docker.html
+++ b/www/doc/2.2/docker.html
@@ -50,38 +50,31 @@
   
   <p>This will download the Herbie image and then run
   its <a href="options.html">shell tool</a>.</p>
-  
-  <p>Herbie in Docker is more limited; for example, it will not
-  recognize plugins installed outside the Docker container.</p>
 
   <h2>Running the web interface</h2>
 
-  <p>
-    You can run the Herbie web server locally with
+  <p>You can run the Herbie web server locally with
 
   <pre class="shell">docker run -it --rm -p 8000:80 uwplse/herbie</pre>
 
-    and access the server at <a href="http://localhost:8000">http://localhost:8000</a>.
-    </p>
-    <p>
-      (Herbie's Docker image binds to port 80 by
-    default; this command uses the <code>-p &lt;hostport&gt;:80</code> option to expose Herbie on port 8000.)
-  </p>
+  and access the server
+  at <a href="http://localhost:8000">http://localhost:8000</a>.</p>
 
-  <p>
-    If you are using the <code>--log</code>
-    or <code>--save-session</code> flags for the web shell,
-    you will also need to mount the relevant directories into the
-    Docker container using the <code>-v</code> Docker option, as in
-    the examples below.
-  </p>
+  <p>(Herbie's Docker image binds to the container's port 80 by
+  default; this command uses the <code>-p 8000:80</code> option to
+  expose that container port as the host's port 8000.)</p>
+
+  <p>If you are using the <code>--log</code>
+  or <code>--save-session</code> flags for the web shell, you will
+  also need to mount the relevant directories into the Docker
+  container using the <code>-v</code> Docker option, as in the
+  examples below.</p>
 
   <h2>Generating files and reports</h2>
 
-  <p>
-    To use Herbie in <a href="using-cli.html">batch mode</a>, you will
-    need to mount the input in the Docker container. Do that with:
-  </p>
+  <p>To use Herbie in <a href="using-cli.html">batch mode</a>, you
+  will need to mount the input in the Docker container. Do that
+  with:</p>
   
   <pre class="shell">docker run -it --rm \
     -v <var>in-dir</var>:/in \
@@ -89,17 +82,13 @@
     -u $USER \
     uwplse/herbie improve /in/<var>in-file</var> /out/<var>out-file</var></pre>
 
-  <p>
-    In this command, you are asking Herbie to read input
-    from <var>in-file</var> in <var>in-dir</var>, and write output
-    to <var>out-file</var> in <var>out-dir</var>. The command looks
-    the same if you want Herbie to read input from a directory;
-    just leave <var>in-file</var> blank.
-  </p>
+  <p>In this command, you are asking Herbie to read input
+  from <var>in-file</var> in <var>in-dir</var>, and write output
+  to <var>out-file</var> in <var>out-dir</var>. The command looks the
+  same if you want Herbie to read input from a directory; just
+  leave <var>in-file</var> blank.</p>
 
-  <p>
-    To generate reports from Herbie, you can run:
-  </p>
+  <p>To generate reports from Herbie, you can run:</p>
 
   <pre class="shell">docker run -it --rm \
     -v <var>in-dir</var>:/in \
@@ -107,38 +96,48 @@
     -u $USER \
     uwplse/herbie report /in/<var>in-file</var> /out/</pre>
 
-  <p>
-    As before, the input and output directories must be mounted inside
-    the Docker container. Note that both here and above, the user is
-    set to the current user. This is to ensure that the files Herbie creates
-    have the correct permissions set.
-  </p>
+  <p>As before, the input and output directories must be mounted inside
+  the Docker container. Note that both here and above, the user is
+  set to the current user. This is to ensure that the files Herbie creates
+  have the correct permissions set.</p>
+
+  <h2>Loading custom platforms</h2>
+
+  <p>If you'd like to write and use <a href="platforms.html">custom
+  platforms</a> with Herbie in Docker, you'll need to mount the
+  platform directory as well:</p>
+
+  <pre class="shell">docker run -it --rm \
+    -v <var>platform-dir</var>:/platform \
+    -u $USER \
+    uwplse/herbie shell \
+    --platform /platform/<var>platform.rkt</var></pre>
+
+  <p>You can use custom platforms for the web interface or in batch
+  mode using a similar approach.</p>
 
   <h2>Building the Docker image</h2>
 
-  <p>This section is primarily of interest for the Herbie developers.</p>
+  <p>This section is primarily of interest the Herbie developers.</p>
 
-  <p>
-    Clone the repo and confirm that Herbie builds correctly
-    with <code>make install</code>.
-  </p>
+  <p>Clone the repo and confirm that Herbie builds correctly
+  with <code>make install</code>. Next, examine the Dockerfile and
+  Makefile together. The Dockerfile should follow a process exactly
+  like the Makefile, except a clean initial environment is
+  assumed.</p>
 
-  <p>
-    Next, examine the Dockerfile and Makefile together. The Dockerfile
-    should follow a process exactly like the Makefile, except a clean
-    initial environment is assumed. The build may be split into 2 or
-    more stages to limit the size of the resulting image. Each stage
-    consists of a <code>FROM</code> command and a series of further
-    commands to build up the desired environment, and later stages can
-    refer to earlier stages by name&mdash;for example, <code>COPY
-    --from=earlier-stage ...</code> can copy files compiled in earlier
-    images. You may need to do things like bumping the version of Rust
-    used for binary compilation or the version of Racket used in
-    production, or adjusting paths to match the newest version of the
-    repo.
-  </p>
+  <p>The build is split into 2 or more stages to limit the size of the
+  resulting image. Each stage consists of a <code>FROM</code> command
+  and a series of further commands to build up the desired
+  environment, and later stages can refer to earlier stages by
+  name&mdash;for example, <code>COPY --from=earlier-stage ...</code>
+  can copy files compiled in earlier images.</p>
 
-  <p>Once you are ready to build, run this command from the repository root:</p>
+  <p>Before building the official image, bump the version of Rust used
+  for binary compilation and the version of Racket used in production,
+  and adjusting paths to match the newest version of the repo.</p>
+
+  <p>Once you are ready, run this from the repository root:</p>
 
   <pre class="shell">docker build -t uwplse/herbie:test .</pre>
 
@@ -149,7 +148,8 @@
 
   <p>The web demo should now be visible at <code>http://localhost:8000</code>.</p>
   
-  <p>To open a shell in a running container for testing, first get the container ID with:</p>
+  <p>To open a shell in a running container for testing, first get the
+  container ID with:</p>
 
   <pre class="shell">docker ps</pre>
 
@@ -157,7 +157,7 @@
 
   <pre class="shell">docker exec -it &lt;CONTAINER ID&gt; sh</pre>
   
-  <p>The code and egg-herbie binaries should be
+  <p>The code and <code>egg-herbie</code> binaries should be
   under <code>/src</code>.</p>
 
 </body>

--- a/www/doc/2.2/error.html
+++ b/www/doc/2.2/error.html
@@ -42,8 +42,8 @@ considering.</p>
 typically use floating-point numbers. Because there are infinitely
 many real numbers, but only finitely many floating-point numbers, some
 real numbers can't be accurately represented. This means that every
-time you do an operation, the true result typically has to
-be <em>rounded</em> to a representable one.</p>
+time you do an operation, the true result will be <em>rounded</em> to
+a representable one.</p>
 
 <p>Take an extreme example: the code <code>1e100 + 1</code>, which
 increments a huge number in IEEE 754 double-precision floating-point.
@@ -74,16 +74,15 @@ possible floating-point numbers, from largest to smallest. In that
 list, compare the floating-point value you computed to the one closest
 to the true answer. If they are the same, that's called 0 bits of
 error; if they are one apart, that's called one bit of error; three
-apart is two bits of error; and so on.</p>
+apart is two bits of error; seven apart is three bits; and so on.</p>
 
 <p>In general, if the two floating-point values are <var>n</var> items
 apart, Herbie says they have <code>log2(n + 1)</code> bits of error.
 Values like <code>0</code> and <code>-0</code> are treated as having 0
-bits of error, and <code>NaN</code> is considered to have the maximum
-number of bits of error against non-<code>NaN</code> values. While
-there's all sorts of theoretical justifications, Herbie mainly uses
-this error metric because we've found it to give the best
-results. </p>
+bits of error, and NaN is considered to have the maximum number of
+bits of error against non-NaN values. While there's all sorts of
+theoretical justifications, Herbie mainly uses this error metric
+because we've found it to give the best results. </p>
 
 <p>On a single input, the best way to interpret the "bits of error"
 metric is that it tells you roughly how many bits of the answer,
@@ -93,8 +92,8 @@ because it's four out of 64. But with 40 or 50 bits of error, you're
 getting less accuracy out of the computation than even a
 single-precision floating-point value. And it's even possible to have
 something like 58 or 60 bits of error, in which case even the sign and
-exponent bits (which in double-precision floating-point occupy the top
-12 bits of the number) are incorrect.</p>
+exponent bits (which in double-precision floating-point the the most
+significant 12 bits) are incorrect.</p>
 
 <h2>Percentage accuracy</h2>
 
@@ -108,9 +107,9 @@ input. But usually you're interested in the error of a computation
 across many possible inputs. Herbie therefore averages the accuracy
 percentage across many randomly-sampled valid inputs.</p>
 
-<p>Typically, inputs points are either very accurate or not accurate
-at all. So when computing percentage accuracy, Herbie's averaging a
-lot of points with near-100% accuracy and a lot of points with near-0%
+<p>Typically, input points are either very accurate or not accurate at
+all. So when computing percentage accuracy, Herbie's averaging a lot
+of points with near-100% accuracy and a lot of points with near-0%
 accuracy. In that sense, you can think of percentage accuracy as
 measuring mostly what percentage <em>of inputs</em> are accurate. If
 Herbie says your computation is 75% accurate what it's really saying
@@ -118,9 +117,8 @@ is that about a quarter of inputs produce usable outputs.</p>
 
 <h2>Valid inputs</h2>
 
-<p>Since percentage accuracy averages over many points, it depends on
-what points it is averaging over, and how is samples among them.
-Herbie samples among <em>valid</em> inputs, uniformly distributed.</p>
+<p>When Herbie computes this average, it's over <em>valid</em>,
+uniformly distributed input points.</p>
 
 <p>Herbie considers an input valid if it is a floating-point value in
 the appropriate precision and its true, real-number output 1) exists;
@@ -128,20 +126,21 @@ the appropriate precision and its true, real-number output 1) exists;
 dive into each requirement.</p>
 
 <ol>
-  <li>An output can fail to exist for an input if that input does
-    something like divide by zero or take the square root of a
-    negative number. Then that input is invalid.</li>
-  <li>An input can fail to satisfy the user's precondition.
-    Preconditions can be basically anything, but most often they
-    specify a range of inputs. For example, if the precondition
+  <li>An output can fail to exist for an input if something like a
+    division by zero or square root of a negative number
+    happens <em>even with exact, real-number computation</em>. Then
+    there's no exact answer to compare against and the point is
+    considered invalid.</li>
+  <li>An input can fail to satisfy the user's precondition, which are
+    usually a range of inputs. For example, if the precondition
     is <code>(&lt; 1 x 2)</code>, then the input <code>x = 3</code> is
     invalid.</li>
   <li>Finally, and most rarely, Herbie can fail to compute the output
     for a particular input. For example, the computation <code>(/ (exp
     1e9) (exp 1e9))</code>, which divides two identical but gargantuan
     numbers, does have an exact real-number answer (one), but Herbie
-    can't compute that exact answer because the intermediate steps are
-    too large. This input is also invalid, but you'll
+    can't compute that exact answer because the intermediate values
+    are too large. This input is also invalid, but you'll
     get <a href="faq.html#ground-truth">a warning</a> if this
     happens.</li>
 </ol>
@@ -149,19 +148,17 @@ dive into each requirement.</p>
 <p>Herbie's percentage accuracy metric only averages over valid
 points. This means that when you change your precondition, you change
 which points are valid, and that can change the percentage accuracy
-reported by Herbie. This is useful: if you know there's a rare error,
-but Herbie thinks error is low, you can change your precondition to
-focus on the points of interest.</p>
+reported by Herbie. This is useful: if you've observed a
+floating-point error, you can tailor your precondition to focus on
+inputs near the one you've observed.</p>
 
-<p>Some inputs are valid in surprising ways. For example, consider the
-expression <code>(exp x)</code> for <code>x = 1e100</code>. The true
-real-number result is a very large but finite number; but that real
-number, whatever it is, rounds to infinity in double-precision
-floating point. Herbie does consider this input valid, but infinite
-values are a little odd in floating-point so you might find this
-surprising. For this reason, Herbie
-issues <a href="faq.html#inf-points">a warning</a> if too many outputs
-are infinite.</p>
+<p>Infinite outputs can be valid. For example, consider <code>(exp
+x)</code> for <code>x = 1e100</code>. The true real-number result is
+some very large finite number. That real number, whatever it is,
+rounds to infinity in double-precision floating point. Herbie thus
+considers this input valid. Since you might find this surprising,
+Herbie issues <a href="faq.html#inf-points">a warning</a> if too many
+outputs are infinite.</p>
 
 <h2>Sampling inputs</h2>
 
@@ -172,10 +169,9 @@ uniformly distributed.</p>
 
 <p>For example, there are as many floating-point values between 1 and
 2 as there are between one and one half, because floating-point values
-use an exponential encoding. But that means that if you're looking at
-a computation where the input comes from the interval <kbd>[0.5,
-2]</kbd>, Herbie will weigh the first third of that range twice as
-high as the other two thirds.</p>
+use an exponential encoding. But that means that, in the
+interval <kbd>[0.5, 2]</kbd>, Herbie will sample from the first third
+of that range twice as often as from the other two thirds.</p>
 
 <p>This can produce unintuitive results, especially for intervals that
 cross 0. For example, in the interval <kbd>[0, 1]</kbd>, the second
@@ -183,7 +179,10 @@ half of that interval (from one half to one) has a tiny proportion of
 the weight (in double-precision floating-point, about 0.1%). If Herbie
 can improve accuracy by a little bit between zero and one half, while
 dramatically reducing accuracy between one half and one, it will think
-that that's an accuracy improvement. You might disagree.</p>
+that that's an accuracy improvement. For this reason, Herbie prompts
+you to add a minimum absolute value for ranges that cross zero. Even a
+trivial minimum absolute value, like <code>1e-10</code>, can
+dramatically improve Herbie's results.</p>
 
 <p>Unfortunately, there's no way for Herbie to intuit exactly what you
 mean, so understanding this error distribution is essential to

--- a/www/doc/2.2/faq.html
+++ b/www/doc/2.2/faq.html
@@ -2,14 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Herbie FAQ</title>
+  <title>Herbie Warnings and Errors</title>
   <link rel='stylesheet' type='text/css' href='../../main.css'>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="text/javascript" src="toc.js"></script>
 </head>
 <body>
   <header>
-    <h1>Common Errors and Warnings</h1>
+    <h1>Common Warnings and Errors</h1>
     <a href="../../"><img class="logo" src="../../logo-car.png" /></a>
     <nav>
       <ul>
@@ -20,56 +20,13 @@
     </nav>
   </header>
 
-  <p><a href="../../">Herbie</a> automatically transforms floating
-  point expressions into more accurate forms. This page troubleshoots
-  common Herbie errors, warnings, and known issues.</p>
-
-
-  <h2>Common errors</h2>
-
-  <p>
-    Herbie error messages refer to this second for additional
-    information and debugging tips.
-  </p>
-
-  <h3 id="invalid-syntax">Invalid syntax</h3>
-
-  <p>
-    This error means you mis-formatted Herbie's input. Common errors
-    include misspelled function names and parenthesized expressions
-    that should not be parenthesized. For example, in
-    <code>(- (exp (x)) 1)</code>, the expression <code>x</code> is a
-    variable so shouldn't be parenthesized. <code>(- (exp x) 1)</code>
-    would be the correct way to write that expression.
-    The <a href="input.html">input format</a> documentation has more
-    details on Herbie's syntax.
-  </p>
-
-  <h3 id="sample-valid-points">Cannot sample enough valid points</h3>
-
-  <p>This error occurs when Herbie is unable to find enough valid
-  points. For example, the expression <code>(acos (+ 1000 x))</code>
-  is invalid unless <code>(&lt;= -1001 x -999)</code>, a rather narrow
-  range. The simplest fix is to increase
-  the <a href="options.html"><code>--num-analysis</code> flag</a>.
-  Specifying the range of valid points as
-  a <a href="input.html#preconditions">precondition</a> can also help.
-  </p>
-
-  <h3 id="no-valid-values">No valid values</h3>
-
-  <p>This error indicates that your input has no valid inputs, usually
-  due to an overly restriction precondition. For example, the
-  precondition <code>(&lt 3 x 2)</code> excludes all inputs. The
-  solution is to fix the precondition or input program.</p>
+  <p><a href="../../">Herbie</a> issues a variety of warnings and
+  errors when something unexpected happens during compilation.</p>
 
 
   <h2>Common warnings</h2>
 
-  <p>Herbie warnings refer to this section for explanations and common
-  actions to take.</p>
-  
-  <h3 id="inf-points">Infinite outputs for <var>N</var>% of points.</h3>
+  <h3 id="inf-points"><var>N</var>% of points produce a very large (infinite) output.</h3>
   
   <p>
     Sometimes, an input to your expression produces an output so large
@@ -77,7 +34,7 @@
     example, <code>(exp 1000)</code> is over 10<sup>434</sup>, so it's
     much larger than the largest floating-point value. Herbie raises
     this warning when too many inputs (more than 20% of them) are this
-    large, because that usually indicates you should set a more
+    large. When you see this warning, you should usually set a more
     restrictive precondition.
   </p>
 
@@ -86,58 +43,65 @@
   <p>
     Herbie raises this warning when some inputs require more than
     10,000 bits to compute an exact ground truth. For example, to
-    compute <code>(/ (exp x) (exp x))</code> for very
-    large <code>x</code>, absurdly large numbers would be required.
-    Herbie discards such inputs and raises this warning. If you see
-    this warning, you should add a restrictive precondition, such
-    as <code>:pre (&lt; -100 x 100)</code>, to prevent large inputs.
+    compute <code>(/ (exp x) (exp x))</code> for <code>x =
+    1e100</code>, absurdly large numbers would be required. Herbie
+    discards these inputs and raises this warning. When you see this
+    warning, you should usually set a more restrictive precondition.
   </p>
 
   <h3 id="value-to-string">Could not uniquely print <var>val</var></h3>
 
   <p>
     Herbie will raise this warning when it needs more than 10,000 bits
-    to produce a string representation for a given value. This is
-    likely the result of a bug in a third-party plugin.
-  </p>
-
-  <h3 id="unsound-rules">Unsound rule application detected</h3>
-  
-  <p>
-    Herbie uses a set of algebraic rewrite rules in order to simplify
-    expressions, but these rules can sometimes lead to a
-    contradiction. Herbie will automatically compensate for this, and
-    in most cases nothing needs to be done. However, Herbie may have
-    failed to simplify the output.
+    to produce a unique decimal representation for a given value. This
+    is likely the result of a bug in a custom platform, likely in
+    a <a href="plugins.html">representation definition</a>. The
+    platform needs to be fixed.
   </p>
 
   <h3 id="unused-variable">Unused variable <var>var</var></h3>
   
   <p>
-    The input FPCore contains a variable that is not
-      used in the body expression.
+    The input FPCore contains a variable that is not used in the body
+    expression. You should remove the unused variable.
   </p>
 
-  <h3 id="strange-variable">Strange variable <var>var</var></h3>
+  <h3 id="strange-variable">Unusual variable <var>var</var></h3>
   
   <p>
-    The input expression contains a variable that is similar in name
-      to named constants, e.g. <var>e</var> instead of <var>E</var>.
+    The input expression contains a variable that is named similar to
+    some named constant, like <var>e</var> instead of <var>E</var>.
+    You should use a different variable name.
   </p>
 
-  <h2>Known bugs</h2>
+  <h2>Common errors</h2>
 
-  <p>Bugs that cannot be directly fixed are documented in this section.</p>
+  <h3 id="invalid-syntax">Invalid syntax</h3>
 
-  <h3 id="chrome-missing-report">Missing reports chart on Chrome</h3>
-
-  <p>
-    When using Chrome to view web pages on your local machine, Herbie
-    reports cannot draw the arrow chart due to security restrictions.
-    <a href="http://www.chrome-allow-file-access-from-file.com/">Run
-    Chrome with <code>--allow-file-access-from-files</code></a> to fix
-    this error.
+  <p>This error means you mis-formatted Herbie's input. Common errors
+  include misspelled function names and parenthesized expressions that
+  should not be parenthesized. For example, in <code>(- (exp (x))
+  1)</code>, the expression <code>x</code> is a variable so shouldn't
+  be parenthesized; <code>(- (exp x) 1)</code> is correct. Follow
+  the <a href="input.html">input format</a> more carefully.
   </p>
+
+  <h3 id="sample-valid-points">Cannot sample enough valid points</h3>
+
+  <p>This error occurs when Herbie is unable to find enough valid
+  points. For example, the expression <code>(acos (+ 1000 x))</code>
+  is invalid unless <code>(&lt;= -1001 x -999)</code>, a rather narrow
+  range. You can specify a more restrictive precondition or pass a
+  larger value for
+  the <a href="options.html"><code>--num-analysis</code> flag</a>.
+  </p>
+
+  <h3 id="no-valid-values">No valid values</h3>
+
+  <p>This error indicates that your input has no valid inputs, usually
+  due to an overly restriction precondition. For example, the
+  precondition <code>(&lt 3 x 2)</code> excludes all inputs. You
+  should fix either the precondition or the input program.</p>
 
 </body>
 </html>

--- a/www/doc/2.2/input.html
+++ b/www/doc/2.2/input.html
@@ -29,7 +29,8 @@
 
   <h2>Math format</h2>
 
-  <p>The Herbie web shell takes input in a subset of
+  <p>The Herbie web shell takes input in standard math syntax. More
+  specifically, it uses a subset of
   the <a href="https://mathjs.org/docs/expressions/syntax.html">math.js
   syntax</a>. The web shell automatically checks for syntax errors,
   and provides a graphical user interface for specifying the input

--- a/www/doc/2.2/installing.html
+++ b/www/doc/2.2/installing.html
@@ -23,26 +23,26 @@
   </header>
 
   <p>
-    <a href="../../">Herbie</a> supports Linux, macOS, and Windows.
-    To start, install <a href="https://racket-lang.org">Racket</a>,
-    which Herbie is written in. Then install Herbie, either from a
-    package, from source, or via a <a href="docker.html">Docker
-    image</a>.
+    <a href="../../">Herbie</a> supports Linux, macOS, and Windows. To
+    start, install <a href="https://racket-lang.org">Racket</a>. Then
+    install Herbie, either from a package, from source, or via
+    a <a href="docker.html">Docker image</a>.
   </p>
 
   <h2>Installing Racket</h2>
 
   <p>
     Install Racket either using
-    the <a href="http://download.racket-lang.org/racket-v8.13.html">official
-      installer</a> or distro-provided packages. Versions as old as 8.7
+    the <a href="http://download.racket-lang.org/">official
+    installer</a> or distro-provided packages. Versions as old as 8.10
     are supported, but more recent versions are faster.
   </p>
 
   <p>
     On Linux, we recommend against installing Racket via Snap. If you
-    must install Racket from Snap, locate Herbie and all other
-    packages in your home directory or another allow-listed directory.
+    must install Racket from Snap, install from source and store that
+    source directory in your home directory or another allow-listed
+    directory.
   </p>
 
   <p>
@@ -50,59 +50,49 @@
   </p>
 
   <pre class="shell">racket
-Welcome to Racket v8.13 [cs].
+Welcome to Racket v8.17 [cs].
 > (exit)</pre>
 
   <h2>Installing Herbie from a package</h2>
 
-  <p>
-    Herbie can be installed from a binary package on Windows and Linux
-    for x86-64, and on macOS on either x86-64 or ARM. If you are on a
-    more obscure platform, please install from source instead.</p>
+  <p>Herbie can be installed as a binary package on x86 Windows and
+  Linux and on x86 or ARM macOS. If you are on a more obscure
+  platform, please install from source instead.</p>
 
-  <p>First install Racket. Then install Herbie from a package
-  with:</p>
+  <p>After installing Racket, install Herbie from a package with:</p>
 
   <pre class="shell">raco pkg install --auto herbie</pre>
 
   <p>Then check that Herbie works by running:</p>
 
   <pre class="shell">racket -l herbie -- --version
-Herbie 2.1</pre>
+Herbie 2.2</pre>
 
   <p>If you'd like, you can run Herbie with the <code>herbie</code>
   command by adding the following directory to your PATH (example
-  paths for Racket 8.13):</p>
+  paths for Racket 8.17):</p>
 
   <ul>
-    <li>On Windows, <code>AppData\Roaming\Racket\8.13\bin</code> in your user folder.</li>
-    <li>On macOS, <code>Library/Racket/8.13/bin</code> in your home folder.</li>
-    <li>On Linux, <code>.local/share/racket/8.13/bin</code> in your home directory.</li>
+    <li>On Windows, <code>AppData\Roaming\Racket\8.17\bin</code> in your user folder.</li>
+    <li>On macOS, <code>Library/Racket/8.17/bin</code> in your home folder.</li>
+    <li>On Linux, <code>.local/share/racket/8.17/bin</code> in your home directory.</li>
   </ul>
 
-  <p>
-    Please note that the path of the binary will be different on Linux
-    if you have opted (against recommendation) to use Snap. Once
-    Herbie is installed and working correctly, check out
-    the <a href="tutorial.html">tutorial</a>.
-  </p>
-
-  <!-- End of copy -->
+  <p>Once Herbie is installed and working correctly, check out
+  the <a href="tutorial.html">tutorial</a>.</p>
 
   <h2>Installing Herbie from source</h2>
   
-  <p>
-    Installing Herbie from source is best if you plan to develop
-    Herbie or Herbie <a href="plugins.html">plugins</a>, or if you use
-    a more obscure hardware/OS combination. The instructions assume a
-    standard Unix userland; on Windows, you may have to install tools
-    like Make separately, or use WSL.
+  <p>Installing Herbie from source is best if you are a Herbie
+  developer, or if you use a more obscure hardware/OS combination. The
+  instructions assume a standard Unix userland; on Windows, you may
+  have to install tools like Make separately, or use WSL.
   </p>
 
   <p>
-    Install Racket. Then install Rust,
-    using <a href="https://rustup.rs/">rustup</a> or via some other
-    means. Versions as old as 1.60.0 are supported.
+    Install Racket as described above. Then install Rust 1.60.0 or
+    later using <a href="https://rustup.rs/">rustup</a> or some other
+    means.
   </p>
 
   <p>
@@ -110,14 +100,12 @@ Herbie 2.1</pre>
     <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
   </p>
 
-  <pre class="shell">git clone https://github.com/uwplse/herbie</pre>
+  <pre class="shell">git clone https://github.com/herbie-fp/herbie</pre>
 
-  <p>
-    Change to the <code>herbie</code> directory;
-    you should see a <code>README.md</code> file, a directory named <code>src</code>,
-    a directory named <code>bench/</code>, and a few other directories.
-    Install Herbie with:
-  </p>
+  <p>Change to the <code>herbie</code> directory; you should see
+  a <code>README.md</code> file, a directory named <code>src</code>, a
+  directory named <code>bench/</code>, and a few other files and
+  directories. Install Herbie with:</p>
 
   <pre class="shell">make install</pre>
 
@@ -125,28 +113,20 @@ Herbie 2.1</pre>
   for faster startup. Check that Herbie works by running:</p>
 
   <pre class="shell">racket -l herbie -- --version
-Herbie 2.1</pre>
+Herbie 2.2</pre>
 
-  <p>
-    You can also follow the install-from-package instructions to
-    add <code>herbie</code> to your path, if you'd like.' Once Herbie
-    is installed and working correctly, check out
-    the <a href="tutorial.html">tutorial</a>.
-  </p>
+  <p>You can add <code>herbie</code> to your path, as described in the
+  package-install instructions. Once Herbie is installed and working
+  correctly, check out the <a href="tutorial.html">tutorial</a>.</p>
 
   <h2>Installing Herbie with Docker</h2>
 
-  <p>
-    <a href="https://docker.com">Docker</a> is a container manager,
-    which is sort of like a virtual machine. Herbie in Docker is more
-    limited; we do not recommend using Herbie through Docker without
-    prior Docker experience.
-  </p>
+  <p><a href="https://docker.com">Docker</a> is a container manager,
+  which is sort of like a virtual machine. We do not recommend using
+  Herbie in Docker without prior Docker experience.</p>
 
-  <p>
-    The <a href="docker.html">Docker documentation</a> describes how
-    to install and run the official <code>uwplse/herbie</code> image.
-  </p>
+  <p>The <a href="docker.html">Docker documentation</a> describes how
+  to install and run our <code>uwplse/herbie</code> image.</p>
 
 </body>
 

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -70,7 +70,9 @@
   that representation from memory and the cost of an operation is the
   time it takes to execute that operation. However, in principle,
   platforms can use cost to represent another metric like area or
-  latency. Only relative costs matter.</p>
+  latency. Only relative costs matter. If you're not sure, just
+  putting "<code>1</code>" for all the costs is not a bad place to
+  start.</p>
   
   <h2>Defining a Platform</h2>
 

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -92,7 +92,11 @@
   can do. If necessary, it can define new representations.</p>
   
   <p>Herbie's <a href="https://github.com/herbie-fp/herbie/tree/main/src/platforms">built-in
-  platforms</a> are good example platforms to study or modify.</p>
+  platforms</a> are good example platforms to study or modify. If you
+  use them as an example, you'll need to change the <code>#lang</code>
+  line at the top of the file to be <code>herbie/platforms</code>; the
+  built-in platforms are different because they are built in to Herbie
+  and can't assume Herbie is installed.</p>
 
   <h2>Defining Representations</h2>
 

--- a/www/doc/2.2/using-cli.html
+++ b/www/doc/2.2/using-cli.html
@@ -26,34 +26,29 @@
 
   <h2 id="interactive">The Herbie shell</h2>
 
-  <p>
-    The Herbie shell lets you interact with Herbie: you type in input
-    expressions and Herbie prints their more accurate versions. Run
-    the Herbie shell with this command:
-  </p>
+  <p>The Herbie shell lets you interact with Herbie: you type in input
+  expressions and Herbie prints their more accurate versions. Run the
+  Herbie shell with this command:</p>
 
   <pre class="shell">racket -l herbie shell
-Herbie 2.1 with seed 2098242187
+Starting Herbie 2.2 with seed 2098242187
 Find help on https://herbie.uwplse.org/, exit with Ctrl-D
 <strong>herbie&gt;</strong> </pre>
 
 
-  <p>
-    Herbie prints a seed, which you can <a href="options.html">use to
-    reproduce</a> a Herbie run, and links you to documentation. Then,
-    it waits for inputs, which you can type directly into your
-    terminal in <a href="input.html">FPCore format</a>:
-</p>
+  <p>Herbie prints a seed, which you can <a href="options.html">use to
+  reproduce</a> a Herbie run, and links you to documentation. Then, it
+  waits for inputs, which you can type directly into your terminal
+  in <a href="input.html">FPCore format</a>:</p>
 
   <pre><strong>herbie&gt;</strong> (FPCore (x) (- (+ 1 x) x))
-(FPCore
-  (x)
+(FPCore (x)
   <var>...</var>
-  1)</pre>
+  1.0)</pre>
 
-  <p>Herbie suggests that <code>1</code> is more accurate than the
+  <p>Herbie suggests that <code>1.0</code> is more accurate than the
   original expression <code>(- (+ 1 x) x)</code>. The
-  the <var>...</var> elides 
+  the <var>...</var> elides
   <a href="input.html#properties">additional information</a> provided
   by Herbie.</p>
 
@@ -61,31 +56,34 @@ Find help on https://herbie.uwplse.org/, exit with Ctrl-D
 
   <h2 id="batch">Batch processing FPCores</h2>
 
-  <p>
-    Alternatively, you can run Herbie on a file with multiple
-    expressions in it, writing Herbie's versions of each to a file.
-    This mode is intended for use by scripts.
-  </p>
+  <p>Alternatively, you can run Herbie on a file with multiple
+  expressions in it, writing Herbie's versions of each to a file. This
+  mode is intended for use by scripts.</p>
 
   <pre class="shell">racket -l herbie improve bench/tutorial.fpcore out.fpcore
-Starting Herbie on 3 problems (seed: 1551571787)...
-  1/3	[   0.882s]   30→ 0	Cancel like terms
-Warning: 24.7% of points produce a very large (infinite) output.
-You may want to add a precondition.
-See <a href="https://herbie.uwplse.org/doc/2.0/faq.html#inf-points">&lt;https://herbie.uwplse.org/doc/2.0/faq.html#inf-points&gt;</a> for more.
-  2/3	[   1.721s]   29→ 0	Expanding a square
-  3/3	[   2.426s]    0→ 0	Commute and associate</pre>
+Starting Herbie 2.2 with seed 1551571787...
+Warning: 24.7% of points produce a very large (infinite) output. You may want to add a precondition.
+See <a href="https://herbie.uwplse.org/doc/2.0/faq.html#inf-points">&lt;https://herbie.uwplse.org/doc/2.0/faq.html#inf-points&gt;</a> for more.</pre>
 
-  <p>
-    The output file <code>out.fpcore</code> contains more accurate
-    versions of each program:
-  </p>
+  <p>The output file <code>out.fpcore</code> contains more accurate
+  versions of each program:</p>
 
   <pre>;; seed: 1551571787
 
-(FPCore (x) <var>...</var> 1)
-(FPCore (x) <var>...</var> (* x (- x -2)))
-(FPCore (x y z) <var>...</var> 0)</pre>
+(FPCore (x)
+  :name "Cancel like terms"
+  <var>...</var>
+  1.0)
+
+(FPCore (x)
+  :name "Expanding a square"
+  <var>...</var>
+  (* x (- x -2.0)))
+
+(FPCore (x y z)
+  :name "Commute and associate"
+  <var>...</var>
+  0.0)</pre>
 
   <p>
     Note that output file is in the same order as the input file. For

--- a/www/doc/2.2/using-web.html
+++ b/www/doc/2.2/using-web.html
@@ -20,30 +20,27 @@
     </nav>
   </header>
 
-  <p>
-    <a href="../../">Herbie</a> rewrites floating point expressions to
-    make them more accurate. Herbie can be used
-    from <a href="using-cli.html">the command-line</a> or from the
-    browser; this page is about using Herbie from the browser.</p>
+  <p><a href="../../">Herbie</a> rewrites floating point expressions
+  to make them more accurate. Herbie can be used
+  from <a href="using-cli.html">the command-line</a> or from the
+  browser; this page is about using Herbie from the browser.</p>
 
 
   <h2 id="interactive">The Herbie web shell</h2>
 
-  <p>
-    The Herbie web shell lets you interact with Herbie through your
-    browser, featuring a convenient input format. The web shell is the
-    friendliest and easiest way to use Herbie. Run the Herbie web
-    shell with this command:
-  </p>
+  <p>The Herbie web shell lets you interact with Herbie through your
+  browser, featuring a convenient input format. The web shell is the
+  friendliest and easiest way to use Herbie.</p>
+
+  <p>Start the Herbie web shell by running:</p>
 
   <pre class="shell">racket -l herbie web</pre>
 
-  <p>After a few seconds, the web shell will rev up and direct your
+  <p>After a few seconds, the web shell will start up and direct your
   browser to Herbie:</p>
   
   <pre class="shell">racket -l herbie web
-Herbie 2.1 with seed 1003430182
-Find help on https://herbie.uwplse.org/, exit with Ctrl-C
+Starting Herbie 2.2 with seed 1003430182
 Your Web application is running at http://localhost:8000/.
 Stop this program at any time to terminate the Web Server.</pre>
 
@@ -52,72 +49,59 @@ Stop this program at any time to terminate the Web Server.</pre>
   </figure>
 
   <p>You can type an input expressions in
-    <a href="input.html">standard mathematical syntax</a>. After typing in an 
-    expression, you will be asked to specify the range of values for each input 
-    variable that Herbie should consider when trying to improve the expression. 
-    Hit the "Improve with Herbie" button once you're done to run Herbie.
-  </p>
+  <a href="input.html">standard mathematical syntax</a>. After typing
+  in an expression, you will be asked to specify the range of values
+  for each input variable. Once you're done, hit the "Improve with
+  Herbie" button to run Herbie.</p>
   
-  <p>
-    The web shell reports Herbie's progress and redirects to a
-    <a href="report.html">report</a> once Herbie is done.
-  </p>
+  <p>The web shell reports Herbie's progress and redirects to a
+  <a href="report.html">report</a> once Herbie is done.</p>
 
-  <p>
-    The web shell can also automatically save the generated reports,
-    and has <a href="options.html">many other options</a> you might
-    want to explore.
-  </p>
+  <p>The web shell can also automatically save the generated reports,
+  and has <a href="options.html">many other options</a> you might want
+  to explore.</p>
 
 
   <h2 id="batch">Batch report generation</h2>
 
   <p>A <a href="report.html">report</a> can also be generated directly
-  from a file of input expressions in <a href="input.html">FPCore format</a>:</p>
+  from an input file in <a href="input.html">FPCore format</a>:</p>
   
   <pre class="shell">racket -l herbie report bench/tutorial.fpcore output/ 
-Starting Herbie on 3 problems (seed: 770126425)...
-Warning: 25.0% of points produce a very large (infinite) output. 
-You may want to add a precondition.
+Starting Herbie 2.2 with seed 770126425...
+Warning: 25.0% of points produce a very large (infinite) output. You may want to add a precondition.
 See <a href="faq.html#inf-points">https://herbie.uwplse.org/doc/latest/faq.html#inf-points</a> for 
 more.
   1/3   [   0.703s]   29→ 0     Expanding a square
   2/3   [   1.611s]    0→ 0     Commute and associate
   3/3   [   0.353s]   30→ 0     Cancel like terms</pre>
 
-  <p>
-    This command generates a report from the input expressions
-    in <code>bench/tutorial.fpcore</code> and saves the report in the
-    directory <code>output/</code>. It's best if that directory
-    doesn't exist before running this command, because otherwise
-    Herbie may overwrite files in that directory.
-  </p>
+  <p>This command generates a report from the input expressions
+  in <code>bench/tutorial.fpcore</code> and saves the report in the
+  directory <code>output/</code>. It's best if that directory doesn't
+  exist before running this command, because otherwise Herbie may
+  overwrite files in that directory.</p>
 
-  <p>
-    Occasionally you may also see Herbie emit warnings as shown above.
-    All of Herbie's warnings are listed, with explanations, in
-    the <a href="faq.html">FAQ</a>.
-  </p>
+  <p>Occasionally Herbie will emit warnings, just like in the example
+  above. All of Herbie's warnings
+  are <a href="faq.html">documented</a>, with explanations and
+  suggested fixes.</p>
 
-  <p>
-    The report Herbie generates is in HTML format so you'll need to
-    start a web server. If you have Python installed, that's
-    particularly convenient:
-  </p>
+  <p>The report Herbie generates is in HTML format so you'll need to
+  start a web server. If you have Python installed, that's
+  particularly convenient:</p>
 
   <pre class="shell">python3 -m http.server -d output</pre>
 
-  <p>
-    Then go to <a href="http://localhost:8000/">localhost:8000</a> in
-    your favorite browser. The report summarizes Herbie's results for
-    all expression in your input file, and you can click on individual
-    expressions to see Herbie's output for them.
-  </p>
+  <p>Then go to <a href="http://localhost:8000/">localhost:8000</a> in
+  your favorite browser. The report summarizes Herbie's results for
+  all expression in your input file, and you can click on individual
+  expressions to see Herbie's output for them.</p>
 
-  <p>Batch report generation is the most informative way to run Herbie
-  on a large collection of inputs. Like the web shell, it can be
-  customized through <a href="options.html">command-line options</a>,
-  including parallelizing Herbie with multiple threads.</p>
+  <p>Batch report generation is the best way to run Herbie on a large
+  collection of inputs. Like the web shell, it can be customized
+  through <a href="options.html">command-line options</a>, including
+  parallelizing Herbie with multiple threads.</p>
 
 
 </body>


### PR DESCRIPTION
This PR cleans up `error.html`, `faq.html`, `install.html`, `using-web.html`, and `using-cli.html`.