### PR TITLE
Improve indentation and styling of FPCore output

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -497,7 +497,7 @@
            ,(test-name test)
            :precision
            ,(test-output-repr-name test)
-           ,@(if (eq? (test-pre test) '(TRUE))
+           ,@(if (equal? (test-pre test) '(TRUE))
                  '()
                  `(:pre ,(prog->fpcore (test-pre test) (test-context test))))
            ,@(if (equal? (test-spec test) empty)

--- a/src/api/shell.rkt
+++ b/src/api/shell.rkt
@@ -38,7 +38,8 @@
        (fprintf p ";; ~a in ~a\n" (if type "Error" "Crash") name)]
       ["timeout" (fprintf p ";; ~a times out in ~as\n" (/ (*timeout*) 1000) name)]
       ["success" (void)])
-    (pretty-print (job-result->fpcore res) p 1)))
+    (displayln (fpcore->string (job-result->fpcore res)) p)
+    (newline)))
 
 (define (run-improve input output #:threads [threads #f])
   (define seed (get-seed))
@@ -71,7 +72,7 @@
           [idx (in-naturals)])
       (define result (job-wait (job-start 'improve test #:seed seed)))
       (match (hash-ref result 'status)
-        ["success" (pretty-print (job-result->fpcore result) (current-output-port) 1)]
+        ["success" (displayln (fpcore->string (job-result->fpcore result)))]
         ["failure"
          (match-define (list 'exn type msg url locs traceback) (hash-ref result 'backend))
          (printf "; ~a\n" msg)

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -82,21 +82,6 @@
     [(list op args ...) (ormap list? args)]
     [_ #f]))
 
-(define (fpcore->string core)
-  (define-values (ident args props expr)
-    (match core
-      [(list 'FPCore name (list args ...) props ... expr) (values name args props expr)]
-      [(list 'FPCore (list args ...) props ... expr) (values #f args props expr)]))
-  (define props* ; make sure each property (name, value) gets put on the same line
-    (for/list ([(prop name)
-                (in-dict (apply dict-set* '() props))]) ; how to make a list of pairs from a list
-      (format "~a ~a" prop name)))
-  (define top
-    (if ident
-        (format "FPCore ~a ~a" ident args)
-        (format "FPCore ~a" args)))
-  (pretty-format `(,top ,@props* ,expr) #:mode 'display))
-
 (define (doc-url page)
   (format "https://herbie.uwplse.org/doc/~a/~a" *herbie-version* page))
 

--- a/src/utils/common.rkt
+++ b/src/utils/common.rkt
@@ -19,6 +19,7 @@
          prop-dict/c
          props->dict
          dict->props
+         fpcore->string
          (all-from-out "../config.rkt"))
 
 (module+ test
@@ -152,3 +153,21 @@
   (apply append
          (for/list ([(k v) (in-dict prop-dict)])
            (list k v))))
+
+(define (fpcore->string core)
+  (define-values (ident args props expr)
+    (match core
+      [(list 'FPCore name (list args ...) props ... expr) (values name args props expr)]
+      [(list 'FPCore (list args ...) props ... expr) (values #f args props expr)]))
+  (define props* ; make sure each property (name, value) gets put on the same line
+    (for/list ([(prop name) (in-dict (props->dict props))])
+      (format "~a ~a" prop (pretty-format name (- 69 (string-length (~a prop)))
+                                          #:mode 'write))))
+  (define top
+    (if ident
+        (format "FPCore ~a ~a" ident args)
+        (format "FPCore ~a" args)))
+  (format "(~a\n  ~a\n  ~a)"
+          top
+          (string-join props*  "\n  ")
+          (pretty-format expr 70 #:mode 'write)))


### PR DESCRIPTION
This updates the FPCore output of the `shell` and `improve` commands from this:

```
(FPCore
  (x)
  :name
  "..."
  ...)
```

to the proper

```
(FPCore (x)
  :name "..."
  ...)
```

It even pretty-prints indentation properly and handles string escaping the way it's supposed to.