### PR TITLE
Fix loading of platforms from absolute paths

### DIFF
--- a/src/platform.rkt
+++ b/src/platform.rkt
@@ -3,4 +3,4 @@
 (require "syntax/platforms-language.rkt")
 (provide (all-from-out "syntax/platforms-language.rkt"))
 (module reader syntax/module-reader
-  "syntax/platforms-language.rkt")
+  herbie/syntax/platforms-language)

--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;; C/C++ on Windows platform with a full libm
 

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;; C/C++ platform with a full libm
 

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;; Herbie 1.0 platform. Based on the C Windows platform, but with
 ;; every operation having cost 0, so as to emulate no-pareto mode.

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;; Herbie 2.0 platform. Based on the C Windows platform, but with
 ;; every operation having heuristic costs from Herbie 2.0.

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;;; C/C++ on Linux with reduced libm, meaning no special numeric
 ;;; functions. It is also 64-bit only.

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;;; Racket platform, focusing on racket/base and math/base.
 ;;; Therefore only one data type, <binary64>, is supported.

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../platform.rkt"
+#lang s-exp "../syntax/platforms-language.rkt"
 
 ;;; Rival correctly-rounded platform
 

--- a/src/syntax/load-platform.rkt
+++ b/src/syntax/load-platform.rkt
@@ -32,7 +32,7 @@
 (define platforms (make-hash))
 
 (define (activate-platform! name)
-  (define path (hash-ref default-platforms name name))
+  (define path (hash-ref default-platforms name (string->path name)))
   (define platform (hash-ref! platforms name (lambda () (dynamic-require path 'platform))))
 
   (unless platform


### PR DESCRIPTION
@LooneyLiberator discovered that passing an absolute path to Herbie, as in `--platform /foo/bar/baz`, doesn't work. This PR fixes it. Don't ask why.