### PR TITLE
Adjust ordinal range to signed integers

### DIFF
--- a/infra/softposit.rkt
+++ b/infra/softposit.rkt
@@ -89,8 +89,8 @@
   (make-representation #:name 'posit8
                        #:bf->repr (compose double->posit8* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit8->double)
-                       #:ordinal->repr (shift 7 ordinal->posit8)
-                       #:repr->ordinal (unshift 7 posit8->ordinal)
+                       #:ordinal->repr ordinal->posit8
+                       #:repr->ordinal posit8->ordinal
                        #:total-bits 8
                        #:special-value? (curry posit8= (posit8-nar))))
 
@@ -98,8 +98,8 @@
   (make-representation #:name 'posit16
                        #:bf->repr (compose double->posit16* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit16->double)
-                       #:ordinal->repr (shift 15 ordinal->posit16)
-                       #:repr->ordinal (unshift 15 posit16->ordinal)
+                       #:ordinal->repr ordinal->posit16
+                       #:repr->ordinal posit16->ordinal
                        #:total-bits 16
                        #:special-value? (curry posit16= (posit16-nar))))
 
@@ -107,8 +107,8 @@
   (make-representation #:name 'posit32
                        #:bf->repr (compose double->posit32* bigfloat->flonum)
                        #:repr->bf (compose bf-inf->nan posit32->double)
-                       #:ordinal->repr (shift 31 ordinal->posit32)
-                       #:repr->ordinal (unshift 31 posit32->ordinal)
+                       #:ordinal->repr ordinal->posit32
+                       #:repr->ordinal posit32->ordinal
                        #:total-bits 32
                        #:special-value? (curry posit32= (posit32-nar))))
 

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -91,7 +91,7 @@
 
 ;; Does not use make-representation to define a repr of bool
 (define <bool>
-  (representation 'bool 'bool identity identity (curry = 0) (lambda (x) (if x 1 0)) 1 (const #f)))
+  (representation 'bool 'bool identity identity (curry = 0) (lambda (x) (if x 0 -1)) 1 (const #f)))
 
 (define <binary32>
   (make-representation #:name 'binary32
@@ -99,8 +99,8 @@
                        #:repr->bf (lambda (x)
                                     (parameterize ([bf-precision 24])
                                       (bf x)))
-                       #:ordinal->repr (shift 31 ordinal->float32)
-                       #:repr->ordinal (unshift 31 float32->ordinal)
+                       #:ordinal->repr ordinal->float32
+                       #:repr->ordinal float32->ordinal
                        #:total-bits 32
                        #:special-value? nan?))
 
@@ -110,8 +110,8 @@
                        #:repr->bf (lambda (x)
                                     (parameterize ([bf-precision 53])
                                       (bf x)))
-                       #:ordinal->repr (shift 63 ordinal->flonum)
-                       #:repr->ordinal (unshift 63 flonum->ordinal)
+                       #:ordinal->repr ordinal->flonum
+                       #:repr->ordinal flonum->ordinal
                        #:total-bits 64
                        #:special-value? nan?))
 

--- a/src/utils/float.rkt
+++ b/src/utils/float.rkt
@@ -50,7 +50,8 @@
   (real->double-flonum (log x 2)))
 
 (define (random-generate repr)
-  ((representation-ordinal->repr repr) (random-bits (representation-total-bits repr))))
+  (define bits (sub1 (representation-total-bits repr)))
+  ((representation-ordinal->repr repr) (random-integer (- (expt 2 bits)) (expt 2 bits))))
 
 (define (=/total x1 x2 repr)
   (define ->ordinal (representation-repr->ordinal repr))

--- a/www/doc/2.2/plugins.html
+++ b/www/doc/2.2/plugins.html
@@ -46,8 +46,9 @@
   <p>Specifically, a representation value needs to be convertible to
   Racket <a href="https://docs.racket-lang.org/math/bigfloat.html"><code>bigfloat</code></a>
   values (which are basically MPFR floats) and also
-  to <em>ordinals</em>, meaning integers between 0 and
-  2<sup><var>w</var></sup> for some bit width <var>w</var>.</p>
+  to <em>ordinals</em>, meaning integers between
+  -2<sup><var>w</var>&minus;1</sup> and
+  2<sup><var>w</var>&minus;1</sup>&minus;1 for some bit width <var>w</var>.</p>
 
   <p>Create representations with <code>make-representation</code>:</p>
 
@@ -92,8 +93,9 @@
   instead.</p>
 
   <p>The <code>#:ordinal->repr</code> and <code>#:repr->ordinal</code>
-  functions represent ordinals as Racket integers between 0
-  (inclusive) and 2<sup><var>width</var></sup> (exclusive). Ordinals
+  functions represent ordinals as Racket integers between
+  -2<sup><var>width</var>&minus;1</sup> (inclusive) and
+  2<sup><var>width</var>&minus;1</sup> (exclusive). Ordinals
   must be in real-number order; that is, if <code>(repr->bf x)</code>
   is less than <code>(repr->bf y)</code>, then <code>(repr->ordinal
   x)</code> should be less than <code>(repr->ordinal y)</code>.</p>


### PR DESCRIPTION
## Summary
- drop `shift` and `unshift` from representation definitions
- generate random ordinals using signed range
- map boolean ordinals to `-1` and `0`
- document signed ordinal range

Ordinals now range from `-2^(tb-1)` to `2^(tb-1)-1`, the standard signed
integer range. Sampling and representation definitions were updated
accordingly.

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`

------
https://chatgpt.com/codex/tasks/task_e_6887fd1711988331890a2a75a0268298