### PR TITLE
Unify cost and aggregate handling

### DIFF
--- a/infra/softposit.rkt
+++ b/infra/softposit.rkt
@@ -159,15 +159,15 @@
 (define-representation <posit8>  #:cost 1)
 (define-operation (if.p8 [c <bool>] [t <posit8>] [f <posit8>]) <posit8>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 (define-representation <posit16> #:cost 1)
 (define-operation (if.p16 [c <bool>] [t <posit16>] [f <posit16>]) <posit16>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 (define-representation <posit32> #:cost 1)
 (define-operation (if.p32 [c <bool>] [t <posit32>] [f <posit32>]) <posit32>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 
 (define-operations ([x <posit8>] [y <posit8>]) <bool>
   [==.p8 #:spec (== x y) #:impl posit8=  #:cost 1]

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -311,7 +311,9 @@
   (batchref input-batch idx))
 
 (define (normalize-cost c min-cost)
-  (exact-round (* (/ c min-cost) 100)))
+  (if (= min-cost 0)
+      c
+      (exact-round (* (/ c min-cost) 100))))
 
 (define (prelude curr-program #:mixed-egraph? [mixed-egraph? #t])
   (define pform (*active-platform*))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -311,9 +311,7 @@
   (batchref input-batch idx))
 
 (define (normalize-cost c min-cost)
-  (if (= min-cost 0)
-      c
-      (exact-round (* (/ c min-cost) 100))))
+  (exact-round (* (/ c min-cost) 100)))
 
 (define (prelude curr-program #:mixed-egraph? [mixed-egraph? #t])
   (define pform (*active-platform*))
@@ -335,7 +333,8 @@
   (for ([impl (in-list (platform-impls pform))])
     (set! raw-costs (cons (impl-info impl 'cost) raw-costs)))
 
-  (define min-cost (apply min raw-costs))
+  (define nonzero-costs (filter (negate zero?) raw-costs))
+  (define min-cost (if (empty? nonzero-costs) 1 (apply min nonzero-costs)))
 
   (define typed-graph
     `(datatype MTy

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -334,7 +334,10 @@
     (set! raw-costs (cons (impl-info impl 'cost) raw-costs)))
 
   (define nonzero-costs (filter (negate zero?) raw-costs))
-  (define min-cost (if (empty? nonzero-costs) 1 (apply min nonzero-costs)))
+  (define min-cost
+    (if (empty? nonzero-costs)
+        1
+        (apply min nonzero-costs)))
 
   (define typed-graph
     `(datatype MTy

--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -30,7 +30,7 @@
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
   #:spec (if c t f) #:impl if-impl
-  #:cost boolean-move-cost #:aggregate if-cost)
+  #:cost (if-cost boolean-move-cost))
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 32bit-move-cost]
@@ -107,7 +107,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost boolean-move-cost #:aggregate if-cost)
+  #:cost (if-cost boolean-move-cost))
 
 (define-operations ([x <binary64>] [y <binary64>]) <binary64>
   [+.f64 #:spec (+ x y) #:impl + #:cost 0.200]

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -30,7 +30,7 @@
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
   #:spec (if c t f) #:impl if-impl
-  #:cost boolean-move-cost #:aggregate if-cost)
+  #:cost (if-cost boolean-move-cost))
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 32bit-move-cost]
@@ -116,7 +116,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost boolean-move-cost #:aggregate if-cost)
+  #:cost (if-cost boolean-move-cost))
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 64bit-move-cost]

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -26,7 +26,7 @@
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
   #:spec (if c t f) #:impl if-impl
-  #:cost 0 #:aggregate if-cost)
+  #:cost (if-cost 0))
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 0]
@@ -112,7 +112,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost 0 #:aggregate if-cost)
+  #:cost (if-cost 0))
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 0]

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -26,7 +26,7 @@
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl =          #:cost 128]
@@ -112,7 +112,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost 256]

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -28,7 +28,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost move-cost #:aggregate if-cost)
+  #:cost (if-cost move-cost))
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl =          #:cost fl-move-cost]

--- a/src/platforms/racket.rkt
+++ b/src/platforms/racket.rkt
@@ -27,7 +27,7 @@
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
-  #:cost 1 #:aggregate if-cost)
+  #:cost (if-cost 1))
 
 (define-operations () <binary64>
   [PI.rkt       #:spec (PI)       #:impl (const pi)       #:fpcore PI       #:cost 1]

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -22,7 +22,8 @@
 (define-representation <binary32> #:cost 1)
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
-  #:spec (if c t f) #:impl (from-rival) #:cost 1 #:aggregate if-cost)
+  #:spec (if c t f) #:impl (from-rival)
+  #:cost (if-cost 1))
 
 (define-operations ([x <binary32>] [y <binary32>]) <bool>
   [==.f32 #:spec (== x y) #:impl (from-rival) #:cost 1]
@@ -102,7 +103,8 @@
 (define-representation <binary64> #:cost 1)
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
-  #:spec (if c t f) #:impl (from-rival) #:cost 1 #:aggregate if-cost)
+  #:spec (if c t f) #:impl (from-rival)
+  #:cost (if-cost 1))
 
 (define-operations ([x <binary64>] [y <binary64>]) <bool>
   [==.f64 #:spec (== x y) #:impl (from-rival) #:cost 1]

--- a/src/syntax/platforms-language.rkt
+++ b/src/syntax/platforms-language.rkt
@@ -55,5 +55,5 @@
 (define (if-impl c t f)
   (if c t f))
 
-(define (if-cost c t f)
-  (+ c (max t f)))
+(define (if-cost base)
+  (lambda (c t f) (+ base c (max t f))))

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -293,7 +293,7 @@
 
   <p>Here <code>if-impl</code> is a Herbie-provided Racket function
   that wraps a standard <code>if</code> statement, while
-  the <code>if<code> inside the <code>#:spec</code> is how
+  the <code>if</code> inside the <code>#:spec</code> is how
   specifications refer to mathematical conditional expressions.</p>
 
   <p>Conditional operations usually pass a procedure to

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -289,22 +289,19 @@
 
   <pre>(define-operation (if-f64 [c <bool>] [t &lt;binary64&gt;] [f &lt;binary64&gt;]) &lt;binary64&gt;
   #:spec (if c t f) #:impl if-impl
-  #:cost 14 #:aggregate if-cost)</pre>
+  #:cost (if-cost 14) )</pre>
 
   <p>Here <code>if-impl</code> is a Herbie-provided Racket function
   that wraps a standard <code>if</code> statement, while
   the <code>if<code> inside the <code>#:spec</code> is how
   specifications refer to mathematical conditional expressions.</p>
 
-  <p>Besides the standard <code>#:cost</code> field, conditional
-  operations should usually also specify <code>if-cost</code> for
-  the <code>#:aggregate</code> field. This informs Herbie that the
-  cost of an <code>if-f64</code> should only consider the bigger of
-  the true and false branches' costs. If the <code>#:aggregate</code>
-  field is removed, Herbie will add the costs costs of both branches,
-  just like a normal operation, even though only one branch is
-  actually executed. Other operations can also use aggregate
-  functions, but there's usually not a good reason for this.</p>
+  <p>Conditional operations usually pass a procedure to
+  <code>#:cost</code>. The helper <code>if-cost</code> returns a procedure
+  that receives the costs of the arguments and combines them into a
+  total cost. It computes the cost of evaluating the condition plus the
+  larger of the two branch costs. In this example we add a constant cost
+  of 14 to that value.</p>
 
   <p>A platform needs to define both <code>&lt;binary32&gt;</code>
   and <code>&lt;binary64&gt;</code> conditional operations if it uses


### PR DESCRIPTION
## Summary
The `#:aggregate` flag has been removed from operator definitions. `#:cost` now accepts either a constant number or a procedure. Numeric costs keep the `+` aggregator while procedures set the cost to zero and use that procedure for aggregation. Conditional operations now supply a cost procedure through the helper `if-cost`, which now requires an explicit base cost.

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`

------
https://chatgpt.com/codex/tasks/task_e_6887fcf446548331ba1bfc4d2214720f