### PR TITLE
Add `(! ... _)` to `#:fpcore`

### DIFF
--- a/src/platforms/c-windows.rkt
+++ b/src/platforms/c-windows.rkt
@@ -40,7 +40,7 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 32bit-move-cost]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 32bit-move-cost])
 
-(define-operations () <binary32> #:fpcore (:precision binary32)
+(define-operations () <binary32> #:fpcore (! :precision binary32 _)
   [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32bit-move-cost]
   [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32bit-move-cost]
   [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32bit-move-cost]
@@ -50,13 +50,13 @@
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 0.125)
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0.200]
   [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0.200]
   [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0.250]
   [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0.350])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 4.250]
   [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 4.250]
   [tan.f32    #:spec (tan x)    #:impl (from-libm 'tanf)    #:cost 4.750]
@@ -86,7 +86,7 @@
   [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 2.625]
   [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0.275])
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 2.000]
   [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 2.000]
   [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0.200]
@@ -96,7 +96,7 @@
   [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 1.750]
   [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 1.000])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0.900]
   [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0.900]
   [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 1.300])
@@ -115,7 +115,7 @@
   [*.f64 #:spec (* x y) #:impl * #:cost 0.250]
   [/.f64 #:spec (/ x y) #:impl / #:cost 0.350])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64bit-move-cost]
   [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64bit-move-cost]
   [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64bit-move-cost]
@@ -133,7 +133,7 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 64bit-move-cost]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 64bit-move-cost])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0.125]
   [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 4.200]
   [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 4.200]
@@ -164,7 +164,7 @@
   [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 2.625]
   [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0.250])
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 2.000]
   [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 2.000]
   [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0.200]
@@ -174,7 +174,7 @@
   [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 1.750]
   [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 1.000])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0.900]
   [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0.900]
   [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 1.300])

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -40,7 +40,7 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 32bit-move-cost]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 32bit-move-cost])
 
-(define-operations () <binary32> #:fpcore (:precision binary32)
+(define-operations () <binary32> #:fpcore (! :precision binary32 _)
   [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32bit-move-cost]
   [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32bit-move-cost]
   [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32bit-move-cost]
@@ -50,13 +50,13 @@
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 0.125)
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0.200]
   [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0.200]
   [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0.250]
   [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0.350])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0.125]
   [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 4.250]
   [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 4.250]
@@ -87,7 +87,7 @@
   [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 2.625]
   [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0.275])
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 2.000]
   [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 2.000]
   [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0.200]
@@ -97,7 +97,7 @@
   [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 1.750]
   [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 1.000])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0.900]
   [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0.900]
   [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 1.300])
@@ -126,7 +126,7 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 64bit-move-cost]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 64bit-move-cost])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64bit-move-cost]
   [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64bit-move-cost]
   [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64bit-move-cost]
@@ -135,13 +135,13 @@
 (define-operation (neg.f64 [x <binary64>]) <binary64>
   #:spec (neg x) #:impl - #:fpcore (! :precision binary64 (- x)) #:cost 0.125)
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [+.f64 #:spec (+ x y) #:impl + #:cost 0.200]
   [-.f64 #:spec (- x y) #:impl - #:cost 0.200]
   [*.f64 #:spec (* x y) #:impl * #:cost 0.250]
   [/.f64 #:spec (/ x y) #:impl / #:cost 0.350])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0.125]
   [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 4.200]
   [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 4.200]
@@ -172,7 +172,7 @@
   [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 2.625]
   [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0.250])
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 2.000]
   [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 2.000]
   [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0.200]
@@ -182,7 +182,7 @@
   [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 1.750]
   [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 1.000])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x) #:cost 0.900]
   [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0.900]
   [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 1.300])

--- a/src/platforms/herbie10.rkt
+++ b/src/platforms/herbie10.rkt
@@ -36,7 +36,7 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 0]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(define-operations () <binary32> #:fpcore (:precision binary32)
+(define-operations () <binary32> #:fpcore (! :precision binary32 _)
   [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 0]
   [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 0]
   [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 0]
@@ -46,13 +46,13 @@
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 0)
   
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 0]
   [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 0]
   [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 0]
   [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 0])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 0]
   [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 0]
   [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 0]
@@ -83,7 +83,7 @@
   [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 0]
   [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 0])
   
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 0]
   [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 0]
   [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 0]
@@ -93,7 +93,7 @@
   [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 0]
   [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 0])
   
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 0]
   [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 0]
   [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 0])
@@ -122,13 +122,13 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 0]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 0])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 0]
   [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 0]
   [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 0]
   [NAN.f64  #:spec (NAN)      #:impl (const +nan.0)  #:fpcore NAN      #:cost 0])
 
- (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
    [+.f64 #:spec (+ x y) #:impl + #:cost 0]
    [-.f64 #:spec (- x y) #:impl - #:cost 0]
    [*.f64 #:spec (* x y) #:impl * #:cost 0]
@@ -138,7 +138,7 @@
    #:spec (neg x) #:impl -
    #:fpcore (! :precision binary64 (- x)) #:cost 0)
   
- (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
    [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0]
    [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 0]
    [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 0]
@@ -169,7 +169,7 @@
    [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 0]
    [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0])
   
- (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+ (define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
    [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 0]
    [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 0]
    [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0]
@@ -179,7 +179,7 @@
    [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 0]
    [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 0])
   
- (define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+ (define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
    [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 0]
    [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 0]
    [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 0])

--- a/src/platforms/herbie20.rkt
+++ b/src/platforms/herbie20.rkt
@@ -36,7 +36,7 @@
   [<=.f32 #:spec (<= x y) #:impl <=         #:cost 128]
   [>=.f32 #:spec (>= x y) #:impl >=         #:cost 128])
 
-(define-operations () <binary32> #:fpcore (:precision binary32)
+(define-operations () <binary32> #:fpcore (! :precision binary32 _)
   [PI.f32       #:spec (PI)       #:impl (const (flsingle pi))       #:fpcore PI       #:cost 32]
   [E.f32        #:spec (E)        #:impl (const (flsingle (exp 1)))  #:fpcore E        #:cost 32]
   [INFINITY.f32 #:spec (INFINITY) #:impl (const +inf.0)              #:fpcore INFINITY #:cost 32]
@@ -46,13 +46,13 @@
   #:spec (neg x) #:impl (compose flsingle -)
   #:fpcore (! :precision binary32 (- x)) #:cost 64)
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [+.f32 #:spec (+ x y) #:impl (compose flsingle +) #:cost 64]
   [-.f32 #:spec (- x y) #:impl (compose flsingle -) #:cost 64]
   [*.f32 #:spec (* x y) #:impl (compose flsingle *) #:cost 128]
   [/.f32 #:spec (/ x y) #:impl (compose flsingle /) #:cost 320])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [fabs.f32   #:spec (fabs x)   #:impl (from-libm 'fabsf)   #:cost 64]
   [sin.f32    #:spec (sin x)    #:impl (from-libm 'sinf)    #:cost 3200]
   [cos.f32    #:spec (cos x)    #:impl (from-libm 'cosf)    #:cost 3200]
@@ -83,7 +83,7 @@
   [tgamma.f32 #:spec (tgamma x) #:impl (from-libm 'tgammaf) #:cost 3200]
   [trunc.f32  #:spec (trunc x)  #:impl (from-libm 'truncf)  #:cost 3200])
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [pow.f32       #:spec (pow x y)       #:impl (from-libm 'powf)       #:cost 3200]
   [atan2.f32     #:spec (atan2 x y)     #:impl (from-libm 'atan2f)     #:cost 3200]
   [copysign.f32  #:spec (copysign x y)  #:impl (from-libm 'copysignf)  #:cost 3200]
@@ -93,7 +93,7 @@
   [fmod.f32      #:spec (fmod x y)      #:impl (from-libm 'fmodf)      #:cost 3200]
   [remainder.f32 #:spec (remainder x y) #:impl (from-libm 'remainderf) #:cost 3200])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-libm 'erfcf)  #:fpcore (erfc x)  #:cost 3200]
   [expm1.f32 #:spec (- (exp x) 1) #:impl (from-libm 'expm1f) #:fpcore (expm1 x) #:cost 3200]
   [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-libm 'log1pf) #:fpcore (log1p x) #:cost 3200])
@@ -122,7 +122,7 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost 256]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost 256])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost 64]
   [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost 64]
   [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost 64]
@@ -132,13 +132,13 @@
   #:spec (neg x) #:impl -
   #:fpcore (! :precision binary64 (- x)) #:cost 128)
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [+.f64 #:spec (+ x y) #:impl + #:cost 128]
   [-.f64 #:spec (- x y) #:impl - #:cost 128]
   [*.f64 #:spec (* x y) #:impl * #:cost 256]
   [/.f64 #:spec (/ x y) #:impl / #:cost 640])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 128]
   [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 6400]
   [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 6400]
@@ -169,7 +169,7 @@
   [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 6400]
   [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 6400])
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 6400]
   [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 6400]
   [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 6400]
@@ -179,7 +179,7 @@
   [fmod.f64      #:spec (fmod x y)      #:impl (from-libm 'fmod)      #:cost 6400]
   [remainder.f64 #:spec (remainder x y) #:impl (from-libm 'remainder) #:cost 6400])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-libm 'erfc)  #:fpcore (erfc x)  #:cost 6400]
   [expm1.f64 #:spec (- (exp x) 1) #:impl (from-libm 'expm1) #:fpcore (expm1 x) #:cost 6400]
   [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-libm 'log1p) #:fpcore (log1p x) #:cost 6400])

--- a/src/platforms/math.rkt
+++ b/src/platforms/math.rkt
@@ -38,7 +38,7 @@
   [<=.f64 #:spec (<= x y) #:impl <=         #:cost fl-move-cost]
   [>=.f64 #:spec (>= x y) #:impl >=         #:cost fl-move-cost])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (const pi)      #:fpcore PI       #:cost fl-move-cost]
   [E.f64    #:spec (E)        #:impl (const (exp 1)) #:fpcore E        #:cost fl-move-cost]
   [INFINITY #:spec (INFINITY) #:impl (const +inf.0)  #:fpcore INFINITY #:cost fl-move-cost]
@@ -48,13 +48,13 @@
   #:spec (neg x) #:impl -
   #:fpcore (! :precision binary64 (- x)) #:cost 0.096592)
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [+.f64 #:spec (+ x y) #:impl + #:cost 0.164604]
   [-.f64 #:spec (- x y) #:impl - #:cost 0.15163999999999997]
   [*.f64 #:spec (* x y) #:impl * #:cost 0.20874800000000002]
   [/.f64 #:spec (/ x y) #:impl / #:cost 0.26615199999999994])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [fabs.f64   #:spec (fabs x)   #:impl (from-libm 'fabs)      #:cost 0.10162]
   [sin.f64    #:spec (sin x)    #:impl (from-libm 'sin)       #:cost 3.318128]
   [cos.f64    #:spec (cos x)    #:impl (from-libm 'cos)       #:cost 3.32288]
@@ -85,7 +85,7 @@
   [tgamma.f64 #:spec (tgamma x) #:impl (from-libm 'tgamma)    #:cost 1.882576]
   [trunc.f64  #:spec (trunc x)  #:impl (from-libm 'trunc)     #:cost 0.463644])
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [pow.f64       #:spec (pow x y)       #:impl (from-libm 'pow)       #:cost 1.52482]
   [atan2.f64     #:spec (atan2 x y)     #:impl (from-libm 'atan2)     #:cost 1.492804]
   [copysign.f64  #:spec (copysign x y)  #:impl (from-libm 'copysign)  #:cost 0.200452]

--- a/src/platforms/rival.rkt
+++ b/src/platforms/rival.rkt
@@ -32,20 +32,20 @@
   [<=.f32 #:spec (<= x y) #:impl (from-rival) #:cost 1]
   [>=.f32 #:spec (>= x y) #:impl (from-rival) #:cost 1])
 
-(define-operations () <binary32> #:fpcore (:precision binary32)
+(define-operations () <binary32> #:fpcore (! :precision binary32 _)
   [PI.f32 #:spec (PI) #:impl (from-rival) #:fpcore PI #:cost 1]
   [E.f32  #:spec (E)  #:impl (from-rival) #:fpcore E  #:cost 1])
 
 (define-operation (neg.f32 [x <binary32>]) <binary32>
   #:spec (neg x) #:impl (from-rival) #:fpcore (! :precision binary32 (- x)) #:cost 1)
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [+.f32 #:spec (+ x y) #:impl (from-rival) #:cost 1]
   [-.f32 #:spec (- x y) #:impl (from-rival) #:cost 1]
   [*.f32 #:spec (* x y) #:impl (from-rival) #:cost 1]
   [/.f32 #:spec (/ x y) #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [fabs.f32   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
   [sin.f32    #:spec (sin x)    #:impl (from-rival) #:cost 1]
   [cos.f32    #:spec (cos x)    #:impl (from-rival) #:cost 1]
@@ -76,7 +76,7 @@
   [tgamma.f32 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
   [trunc.f32  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>] [y <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [pow.f32       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
   [atan2.f32     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
   [copysign.f32  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
@@ -86,7 +86,7 @@
   [fmod.f32      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
   [remainder.f32 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary32>]) <binary32> #:fpcore (:precision binary32)
+(define-operations ([x <binary32>]) <binary32> #:fpcore (! :precision binary32 _)
   [erfc.f32  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
   [expm1.f32 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
   [log1p.f32 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])
@@ -112,7 +112,7 @@
   [<=.f64 #:spec (<= x y) #:impl (from-rival) #:cost 1]
   [>=.f64 #:spec (>= x y) #:impl (from-rival) #:cost 1])
 
-(define-operations () <binary64> #:fpcore (:precision binary64)
+(define-operations () <binary64> #:fpcore (! :precision binary64 _)
   [PI.f64   #:spec (PI)       #:impl (from-rival) #:cost 1]
   [E.f64    #:spec (E)        #:impl (from-rival) #:cost 1]
   [INFINITY #:spec (INFINITY) #:impl (from-rival) #:cost 1]
@@ -121,13 +121,13 @@
 (define-operation (neg.f64 [x <binary64>]) <binary64>
   #:spec (neg x) #:impl (from-rival) #:fpcore (! :precision binary64 (- x)) #:cost 1)
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [+.f64 #:spec (+ x y) #:impl (from-rival) #:cost 1]
   [-.f64 #:spec (- x y) #:impl (from-rival) #:cost 1]
   [*.f64 #:spec (* x y) #:impl (from-rival) #:cost 1]
   [/.f64 #:spec (/ x y) #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [fabs.f64   #:spec (fabs x)   #:impl (from-rival) #:cost 1]
   [sin.f64    #:spec (sin x)    #:impl (from-rival) #:cost 1]
   [cos.f64    #:spec (cos x)    #:impl (from-rival) #:cost 1]
@@ -158,7 +158,7 @@
   [tgamma.f64 #:spec (tgamma x) #:impl (from-rival) #:cost 1]
   [trunc.f64  #:spec (trunc x)  #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>] [y <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [pow.f64       #:spec (pow x y)       #:impl (from-rival) #:cost 1]
   [atan2.f64     #:spec (atan2 x y)     #:impl (from-rival) #:cost 1]
   [copysign.f64  #:spec (copysign x y)  #:impl (from-rival) #:cost 1]
@@ -168,7 +168,7 @@
   [fmod.f64      #:spec (fmod x y)      #:impl (from-rival) #:cost 1]
   [remainder.f64 #:spec (remainder x y) #:impl (from-rival) #:cost 1])
 
-(define-operations ([x <binary64>]) <binary64> #:fpcore (:precision binary64)
+(define-operations ([x <binary64>]) <binary64> #:fpcore (! :precision binary64 _)
   [erfc.f64  #:spec (- 1 (erf x)) #:impl (from-rival) #:fpcore (erfc x)  #:cost 1]
   [expm1.f64 #:spec (- (exp x) 1) #:impl (from-rival) #:fpcore (expm1 x) #:cost 1]
   [log1p.f64 #:spec (log (+ 1 x)) #:impl (from-rival) #:fpcore (log1p x) #:cost 1])

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -238,18 +238,14 @@
   (unless (equal? actual-ty otype)
     (type-error! spec actual-ty otype)))
 
-(define fpcore-context (make-parameter '()))
+(define fpcore-context (make-parameter '_))
 
 (define (fpcore-parameterize spec)
-  (if (empty? (fpcore-context))
-      spec
-      (match spec
-        [`(! ,props ... ,body)
-         (define props1 (make-immutable-hash (props->dict (fpcore-context))))
-         (define props2 (make-immutable-hash (props->dict props)))
-         (define props* (dict->props (hash-union props1 props2 #:combine (lambda (x y) y))))
-         `(! ,@props* ,body)]
-        [body `(! ,@(fpcore-context) ,body)])))
+  (let loop ([ctx (fpcore-context)])
+    (match ctx
+      ['_ spec]
+      [(list arg ...) (map loop arg)]
+      [_ ctx])))
 
 ; Registers an operator implementation `name` with context `ctx` and spec `spec`.
 ; Can optionally specify a floating-point implementation and fpcore translation.

--- a/www/doc/2.2/platforms.html
+++ b/www/doc/2.2/platforms.html
@@ -369,12 +369,12 @@
   operations:</p>
 
   <pre>(define-operations ([x &lt;binary32&gt;]) &lt;binary32&gt;
-    #:fpcore (:precision binary32)
+    #:fpcore (! :precision binary32 _)
     [fabs.f32 #:spec (fabs x) #:impl (from-libm 'fabsf) #:cost 0.125]
     [sin.f32  #:spec (sin x)  #:impl (from-libm 'sinf)  #:cost 4.250]
     ...)
   (define-operations ([x &lt;binary64&gt;]) &lt;binary64&gt;
-    #:fpcore (:precision binary64)
+    #:fpcore (! :precision binary64 _)
     [fabs.f64 #:spec (fabs x) #:impl (from-libm 'fabs)  #:cost 0.125]
     [sin.f64  #:spec (sin x)  #:impl (from-libm 'sin)   #:cost 4.200]
     ...)</pre>
@@ -384,7 +384,8 @@
   To disambiguate these functions in FPCore output,
   the <code>#:fpcore</code> argument to <code>define-operations</code>
   defines <a href="input.html">different FPCore properties</a> for
-  each set of operations.</p>
+  each set of operations. In that argument, the underscore is replaced
+  by each operation's <code>#:spec</code>.</p>
 
   <h3>Hard-to-emulate Operations</h3>
 


### PR DESCRIPTION
This PR changes the syntax of `#:fpcore` on `define-operations`, in that you now give an explicit FPCore expression with an `_` standing in for the spec. This should be more intuitive and look a little better.