### PR TITLE
Move platform rule generation into egg-herbie

### DIFF
--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -4,7 +4,6 @@
 (require "../utils/common.rkt"
          "../utils/errors.rkt"
          "../config.rkt"
-         "../core/rules.rkt"
          "matcher.rkt"
          "types.rkt"
          "syntax.rkt"
@@ -29,8 +28,6 @@
      (fprintf port "#<platform>"))])
 
 (provide *active-platform*
-         platform-lifting-rules
-         platform-lowering-rules
          platform-copy
          validate-platform!
          repr-exists?
@@ -180,44 +177,6 @@
          (define cost-proc (node-cost-proc expr repr))
          (define itypes (impl-info impl 'itype))
          (apply cost-proc (map loop args itypes))]))))
-
-;; Rules from impl to spec (fixed for a particular platform)
-(define/reset *lifting-rules* (make-hash))
-
-;; Rules from spec to impl (fixed for a particular platform)
-(define/reset *lowering-rules* (make-hash))
-
-;; Synthesizes the LHS and RHS of lifting/lowering rules.
-(define (impl->rule-parts impl)
-  (define vars (impl-info impl 'vars))
-  (define spec (impl-info impl 'spec))
-  (values vars spec (cons impl vars)))
-
-;; Synthesizes lifting rules for a platform platform.
-(define (platform-lifting-rules [pform (*active-platform*)])
-  (define impls (platform-impls pform))
-  (for/list ([impl (in-list impls)])
-    (hash-ref! (*lifting-rules*)
-               (cons impl pform)
-               (lambda ()
-                 (define name (sym-append 'lift- impl))
-                 (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
-                 (rule name impl-expr spec-expr '(lifting))))))
-
-;; Synthesizes lowering rules for a given platform.
-(define (platform-lowering-rules [pform (*active-platform*)])
-  (define impls (platform-impls pform))
-  (append* (for/list ([impl (in-list impls)])
-             (hash-ref! (*lowering-rules*)
-                        (cons impl pform)
-                        (lambda ()
-                          (define name (sym-append 'lower- impl))
-                          (define-values (vars spec-expr impl-expr) (impl->rule-parts impl))
-                          (list (rule name spec-expr impl-expr '(lowering))
-                                (rule (sym-append 'lower-unsound- impl)
-                                      (add-unsound spec-expr)
-                                      impl-expr
-                                      '(lowering))))))))
 
 ;; Extracts the `fpcore` field of an operator implementation
 ;; as a property dictionary and expression.


### PR DESCRIPTION
## Summary
- Inline `platform-lifting-rules` and `platform-lowering-rules` into `egg-herbie.rkt`
- Remove rule-generation helpers from `syntax/platform.rkt`

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`
- `raco test src/core/egg-herbie.rkt src/syntax/platform.rkt`


------
https://chatgpt.com/codex/tasks/task_e_689903e778448331836c2308ff21fbd1