### PR TITLE
Emit chrome tracing for server jobs

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -20,7 +20,7 @@
                        special
                        bools
                        branches)]
-        [dump . (egg rival egglog)]))
+        [dump . (egg rival egglog trace)]))
 
 (define default-flags
   #hash([precision . ()]


### PR DESCRIPTION
Herbie now emits [chrome://tracing](chrome://tracing) data (go to that URL in Chrome to view) via the new `dump:trace` flag. This is like the old server log, but threading-aware and visual. There's a bit of ugliness with closing the JSON array (JSON is bad actually) but still a big step up over textual logs.

<img width="777" height="63" alt="image" src="https://github.com/user-attachments/assets/2607f6c5-413f-4565-8173-675ed03d5fff" />

https://chatgpt.com/codex/tasks/task_e_68992102575c833187fb0c8a6d693793