### PR TITLE
Move profiling into server

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require profile
-         racket/engine
+(require racket/engine
          json)
 
 (require "../syntax/read.rkt"
@@ -22,7 +21,6 @@
          "../core/programs.rkt"
          "../core/points.rkt"
          "../core/explain.rkt"
-         "../utils/profile.rkt"
          "../utils/timeline.rkt"
          (submod "../utils/timeline.rkt" debug))
 
@@ -143,14 +141,8 @@
 ;;  Public interface
 ;;
 
-(define (run-herbie command
-                    test
-                    #:seed [seed #f]
-                    #:pcontext [pcontext #f]
-                    #:profile? [profile? #f]
-                    #:timeline? [timeline? #f])
+(define (run-herbie command test #:seed [seed #f] #:pcontext [pcontext #f] #:timeline? [timeline? #f])
   (define timeline #f)
-  (define profile #f)
 
   (define (on-exception start-time e)
     (parameterize ([*timeline-disabled* (not timeline?)])
@@ -195,15 +187,7 @@
         (job-result command test 'success time (timeline-extract) #f (warning-log) result))))
 
   (define (in-engine _)
-    (cond
-      [profile?
-       (define result
-         (profile-thunk compute-result
-                        #:order 'total
-                        #:delay 0.05
-                        #:render (λ (p order) (set! profile (profile->json p)))))
-       (struct-copy job-result result [profile profile])]
-      [else (compute-result)]))
+    (compute-result))
 
   ;; Branch on whether or not we should run inside an engine
   (define eng (engine in-engine))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -4,6 +4,7 @@
 (require (only-in xml write-xexpr))
 (require json)
 (require data/queue)
+(require profile)
 
 (require "../syntax/read.rkt"
          "../syntax/sugar.rkt"
@@ -23,6 +24,7 @@
          "../config.rkt"
          "datafile.rkt"
          "sandbox.rkt"
+         "../utils/profile.rkt"
          (submod "../utils/timeline.rkt" debug))
 
 (provide job-path
@@ -375,13 +377,17 @@
   (match-define (herbie-command command test seed pcontext profile? timeline?) h-command)
   (define metadata (hash 'job-id job-id 'command (~a command) 'name (test-name test)))
   (trace 'herbie 'B metadata)
+  (define run (λ () (run-herbie command test #:seed seed #:pcontext pcontext #:timeline? timeline?)))
   (define herbie-result
-    (run-herbie command
-                test
-                #:seed seed
-                #:pcontext pcontext
-                #:profile? profile?
-                #:timeline? timeline?))
+    (if profile?
+        (let ([profile-data #f])
+          (define result
+            (profile-thunk run
+                           #:order 'total
+                           #:delay 0.05
+                           #:render (λ (p order) (set! profile-data (profile->json p)))))
+          (struct-copy job-result result [profile profile-data]))
+        (run)))
   (trace 'herbie 'E metadata)
   (trace 'to-json 'B metadata)
   (define basic-output ((get-json-converter command) herbie-result job-id))


### PR DESCRIPTION
## Summary
- Move Herbie profiling from `sandbox.rkt` to `server.rkt`
- `server.rkt` now wraps `run-herbie` with `profile-thunk`
- Remove profiling code and dependency from `sandbox.rkt`

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`
- `raco test src/api/sandbox.rkt src/api/server.rkt`


------
https://chatgpt.com/codex/tasks/task_e_689f7bc1a3e88331beb8705d1cf4dbb1