### PR TITLE
Log garbage collection in tracing

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -61,36 +61,39 @@
        (write-json (hash 'name "process_name" 'ph "M" 'ts 0 'pid 0 'tid 0 'args (hash 'name "herbie"))
                    out)))))
 
+(define (trace-sync)
+  (when *gc-logger*
+    (let drain ()
+      (match (sync/timeout 0 *gc-logger*)
+        [#f (void)]
+        [(vector _lvl _msg (app struct->vector data) _topic)
+         (define mode (~a (vector-ref data 1)))
+         (define start (exact-floor (* 1000 (vector-ref data 9))))
+         (define end (exact-floor (* 1000 (vector-ref data 10))))
+         (call-with-output-file "dump-trace.json"
+                                #:exists 'append
+                                (λ (out)
+                                  (fprintf out ",")
+                                  (write-json (hash 'name
+                                                    mode
+                                                    'ph
+                                                    "X"
+                                                    'ts
+                                                    start
+                                                    'dur
+                                                    (- end start)
+                                                    'pid
+                                                    0
+                                                    'tid
+                                                    (equal-hash-code 'gc)
+                                                    'args
+                                                    (hash))
+                                              out)))
+         (drain)]))))
+
 (define (trace name phase [args (hash)])
   (when (flag-set? 'dump 'trace)
-    (when *gc-logger*
-      (let drain ()
-        (match (sync/timeout 0 *gc-logger*)
-          [#f (void)]
-          [(vector _lvl _msg (app struct->vector data) _topic)
-           (define mode (~a (vector-ref data 1)))
-           (define start (exact-floor (* 1000 (vector-ref data 9))))
-           (define end (exact-floor (* 1000 (vector-ref data 10))))
-           (call-with-output-file "dump-trace.json"
-                                  #:exists 'append
-                                  (λ (out)
-                                    (fprintf out ",")
-                                    (write-json (hash 'name
-                                                      mode
-                                                      'ph
-                                                      "X"
-                                                      'ts
-                                                      start
-                                                      'dur
-                                                      (- end start)
-                                                      'pid
-                                                      0
-                                                      'tid
-                                                      (equal-hash-code 'gc)
-                                                      'args
-                                                      (hash))
-                                                out)))
-           (drain)])))
+    (trace-sync)
     (call-with-output-file "dump-trace.json"
                            #:exists 'append
                            (λ (out)
@@ -111,6 +114,7 @@
 
 (define (trace-end)
   (when (flag-set? 'dump 'trace)
+    (trace-sync)
     (call-with-output-file "dump-trace.json" #:exists 'append (λ (out) (fprintf out "]}\n")))))
 
 (define old-exit (exit-handler))
@@ -184,6 +188,7 @@
 
 (define (manager-ask msg . args)
   (log "Asking manager: ~a.\n" msg)
+  (trace-sync)
   (match manager
     [(? place? x) (apply manager-ask-threaded x msg args)]
     ['basic (apply manager-ask-basic msg args)]))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -59,6 +59,20 @@
      (λ (out)
        (fprintf out "{\"traceEvents\":[")
        (write-json (hash 'name "process_name" 'ph "M" 'ts 0 'pid 0 'tid 0 'args (hash 'name "herbie"))
+                   out)
+       (fprintf out ",")
+       (write-json (hash 'name
+                         "thread_name"
+                         'ph
+                         "M"
+                         'ts
+                         0
+                         'pid
+                         0
+                         'tid
+                         (equal-hash-code 'gc)
+                         'args
+                         (hash 'name "GC"))
                    out)))))
 
 (define (trace-sync)


### PR DESCRIPTION
This PR captures GC events in tracing by adding a GC log receiver and flush logged GC events every time the manager thread is active.

https://chatgpt.com/codex/tasks/task_e_689f9719d2088331a8a84c862cc013b6