### PR TITLE
Added a zero polynomial to taylor expansions

### DIFF
--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -49,6 +49,10 @@
                 [altn (in-list altns)]
                 [fv (in-list free-vars)]
                 #:when (set-member? fv var)) ; check whether var exists in expr at all
+            (define zero-poly 0)
+            (define gen0 (approx spec-brf (hole (representation-name repr) zero-poly)))
+            (define brf0 (batch-add! global-batch gen0))
+            (sow (alt brf0 `(taylor ,name ,var) (list altn)))
             (for ([i (in-range (*taylor-order-limit*))])
               (define gen (approx spec-brf (hole (representation-name repr) (genexpr))))
               (define brf (batch-add! global-batch gen)) ; Munge gen


### PR DESCRIPTION
This PR adds a zero polynomial when generating taylor expansions. On nightly, [this branch](https://nightly.cs.washington.edu/reports/herbie/1756152407:zero-term-taylor:7c776612/) takes 50.5 min vs 49.3 min on [main](https://nightly.cs.washington.edu/reports/herbie/1756153756:main:8be6c941/), but the pareto curve appear to be slightly better:

<img width="816" height="487" alt="image" src="https://github.com/user-attachments/assets/feaec5cc-8a1c-4fdf-9410-dc5f7f488c61" />