### PR TITLE
Add dependency on `typed-racket-lib`

### DIFF
--- a/src/info.rkt
+++ b/src/info.rkt
@@ -17,6 +17,7 @@
 
 (define deps
   '(("base" #:version "8.0") "math-lib"
+                             "typed-racket-lib"
                              "profile-lib"
                              "rackunit-lib"
                              "web-server-lib"


### PR DESCRIPTION
We do use Typed Racket inside `regimes.rkt`. I'm not sure why, but `raco` seems to want us to declare the dependency, so fine.