### PR TITLE
Forget completed jobs after persisting web results

### DIFF
--- a/src/api/demo.rkt
+++ b/src/api/demo.rkt
@@ -97,7 +97,8 @@
     [(set-member? (all-pages result-hash) page)
      ;; Write page contents to disk
      (when (*demo-output*)
-       (write-results-to-disk result-hash path))
+       (write-results-to-disk result-hash path)
+       (job-forget job-id))
      (response 200
                #"OK"
                (current-seconds)


### PR DESCRIPTION
The web demo keeps job results in memory even when an output directory is configured, so jobs that are written to disk still accumulate in the job server and can cause the process to grow without bound. This is particularly noticeable on long-running deployments that log many jobs.

After writing a job's HTML and JSON into the output directory, the request handler now instructs the job manager to forget that job. Doing so makes the disk copy authoritative for subsequent requests and lets the job server reclaim the memory associated with finished jobs, avoiding unbounded growth when logging is enabled.

------
https://chatgpt.com/codex/tasks/task_e_68ccbf430de88331a76cd47f6db317cc