### PR TITLE
`batch-recurse` exceptions in case of cache violation

### DIFF
--- a/src/core/batch.rkt
+++ b/src/core/batch.rkt
@@ -129,11 +129,17 @@
                [args args])
       (define idx (batchref-idx brf))
       (cond
-        [(and (> (dvector-capacity visited) idx) (dvector-ref visited idx)) (dvector-ref out idx)]
+        [(and (> (dvector-capacity visited) idx) (dvector-ref visited idx))
+         (when (or (and (null? args) (not (equal? #t (dvector-ref visited idx))))
+                   (and (not (null? args)) (not (equal? args (dvector-ref visited idx)))))
+           (error 'batch-recurse "Cache violation with a different argument (~a) for ~a" args brf))
+         (dvector-ref out idx)]
         [else
          (define res (apply f brf (λ (brf . args) (loop brf args)) args))
          (dvector-set! out idx res)
-         (dvector-set! visited idx #t)
+         (if (null? args) ;; updating cache
+             (dvector-set! visited idx #t)
+             (dvector-set! visited idx args))
          res]))))
 
 ;; Same as batch-recurse but without using additional arguments inside a recurse function


### PR DESCRIPTION
This PR extends the `batch-recurse` function with support for additional evaluation arguments.

Previously, `batch-recurse` assumed that the result of a recursive evaluation depended only on the node being processed. However, users can now write a recurse function of the form:
```
(λ (brf recurse arg) ... arg ...)
```
In this case, the evaluation may legitimately depend on the extra argument(s).

Problem:
The existing `batch-recurse` implementation caches results without considering these arguments. If the arguments change between runs, the cache still returns the old result, which can lead to incorrect behavior. This violates the assumption that results are argument-independent.

Solution:
- `batch-recurse` now detects when evaluation arguments differ and warns the user, since correctness may no longer be guaranteed.
- A new function, `batch-greedy-recurse`, is introduced for cases where users explicitly want to re-evaluate when arguments change.

This makes argument-sensitive recursion both safer (via warnings) and more flexible (via explicit reevaluation).