### PR TITLE
Fix `main` syntax errors

### DIFF
--- a/src/syntax/platform-language.rkt
+++ b/src/syntax/platform-language.rkt
@@ -44,7 +44,6 @@
         [(? number?) 'real]
         [(? symbol?)
          #:when (assq expr env)
-         =>
          cdr]
         [(? symbol?) (bad! "unbound variable `~a`" expr)]
         [`(if ,cond ,ift ,iff)


### PR DESCRIPTION
Looks like Resyntax broke things, this PR fixes them. @jackfirth 