### PR TITLE
Fix histogram ID reuse in timeline report

### DIFF
--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -325,12 +325,13 @@
                                (td (pre ,expr)))))))))
 
 (define (render-phase-times times)
+  (define hist-id (make-id))
   `((dt "Calls")
     (dd (p ,(~r (length times) #:group-sep " ") " calls:")
-        (canvas ([id ,(format "calls-~a" (make-id))]
+        (canvas ([id ,(format "calls-~a" hist-id)]
                  [title
                   "Weighted histogram; height corresponds to percentage of runtime in that bucket."]))
-        (script ,(format "histogram('calls-~a', " (make-id)) ,(jsexpr->string (map first times)) ")")
+        (script ,(format "histogram('calls-~a', " hist-id) ,(jsexpr->string (map first times)) ")")
         (table ((class "times"))
                ,@(for/list ([rec (in-list (sort times > #:key first))]
                             [_ (in-range 5)])
@@ -338,12 +339,13 @@
                    `(tr (td ,(format-time time)) (td (pre ,(~a expr)))))))))
 
 (define (render-phase-series times)
+  (define hist-id (make-id))
   `((dt "Calls")
     (dd (p ,(~a (length times)) " calls:")
-        (canvas ([id ,(format "calls-~a" (make-id))]
+        (canvas ([id ,(format "calls-~a" hist-id)]
                  [title
                   "Weighted histogram; height corresponds to percentage of runtime in that bucket."]))
-        (script ,(format "histogram('calls-~a', " (make-id)) ,(jsexpr->string (map first times)) ")")
+        (script ,(format "histogram('calls-~a', " hist-id) ,(jsexpr->string (map first times)) ")")
         (table ((class "times"))
                (thead (tr (th "Time") (th "Variable") (th "Point")))
                ,@(for/list ([rec (in-list (sort times > #:key first))]


### PR DESCRIPTION
The timeline phase report was generating the histogram initialization script with a different DOM id from the `<canvas>` element it was supposed to populate. Because `make-id` was called twice, the JavaScript tried to draw into a non-existent element and nothing rendered.

This change threads a single identifier through both the canvas markup and the histogram script for the time and series tables, so the charts should now appear correctly when viewing the report. This should restore the expected visualization without affecting any other behavior.

------
https://chatgpt.com/codex/tasks/task_e_68d1f3c99f948331a9fb680549ebbfff