### PR TITLE
Extend cached Taylor series evaluation

### DIFF
--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -241,16 +241,7 @@
                    (adder 0)
                    ((cdr series) (+ n (- offset offset*)))))))]))
 
-(define-syntax-rule (make-cached-series n offset cache body ...)
-  (cons offset
-        (λ (n)
-          (unless (and (> (dvector-capacity cache) n) (dvector-ref cache n))
-            (let ([value (reducer (adder (begin
-                                           body ...)))])
-              (dvector-set! cache n value)))
-          (dvector-ref cache n))))
-
-(define-syntax-rule (make-cached-series/extend n offset cache n* body ...)
+(define-syntax-rule (make-series n offset cache n* body ...)
   (cons offset
         (λ (n)
           (when (>= n (dvector-length cache))
@@ -264,27 +255,27 @@
   ;(->* () #:rest (listof term?) term?)
   (match-define `((,offset . ,serieses) ...) (apply align-series terms))
   (define cache (make-dvector 10))
-  (make-cached-series/extend n
-                             (car offset)
-                             cache
-                             n*
-                             (make-sum (for/list ([series serieses])
-                                         (series n*)))))
+  (make-series n
+               (car offset)
+               cache
+               n*
+               (make-sum (for/list ([series serieses])
+                           (series n*)))))
 
 (define (taylor-negate term)
   ;(-> term? term?)
   (define cache (make-dvector 10))
-  (make-cached-series/extend n (car term) cache n* (list 'neg ((cdr term) n*))))
+  (make-series n (car term) cache n* (list 'neg ((cdr term) n*))))
 
 (define (taylor-mult left right)
   ;(-> term? term? term?)
   (define cache (make-dvector 10))
-  (make-cached-series/extend n
-                             (+ (car left) (car right))
-                             cache
-                             n*
-                             (make-sum (for/list ([i (range (+ n* 1))])
-                                         (list '* ((cdr left) i) ((cdr right) (- n* i)))))))
+  (make-series n
+               (+ (car left) (car right))
+               cache
+               n*
+               (make-sum (for/list ([i (range (+ n* 1))])
+                           (list '* ((cdr left) i) ((cdr right) (- n* i)))))))
 
 (define (normalize-series series)
   ;(-> term? term?)
@@ -309,12 +300,12 @@
   (define cache (make-dvector 10))
   (dvector-set! cache 0 (reducer (adder `(/ 1 ,(b 0)))))
 
-  (make-cached-series/extend n
-                             (- offset)
-                             cache
-                             n*
-                             `(neg (+ ,@(for/list ([i (range n*)])
-                                          `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
+  (make-series n
+               (- offset)
+               cache
+               n*
+               `(neg (+ ,@(for/list ([i (range n*)])
+                            `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
 
 (define (taylor-quotient num denom)
   ;(-> term? term? term?)
@@ -326,13 +317,13 @@
   (define cache (make-dvector 10))
   (dvector-set! cache 0 (reducer (adder `(/ ,(a 0) ,(b 0)))))
 
-  (make-cached-series/extend n
-                             (- noff doff)
-                             cache
-                             n*
-                             `(- (/ ,(a n*) ,(b 0))
-                                 (+ ,@(for/list ([i (range n*)])
-                                        `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
+  (make-series n
+               (- noff doff)
+               cache
+               n*
+               `(- (/ ,(a n*) ,(b 0))
+                   (+ ,@(for/list ([i (range n*)])
+                          `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
 
 (define (modulo-series var n series)
   ;(-> symbol? number? term? term?)
@@ -361,25 +352,24 @@
   (dvector-set! cache 0 (reducer (adder `(sqrt ,(coeffs* 0)))))
   (dvector-set! cache 1 (reducer (adder `(/ ,(coeffs* 1) (* 2 (sqrt ,(coeffs* 0)))))))
 
-  (make-cached-series/extend
-   n
-   (/ offset* 2)
-   cache
-   n*
-   (cond
-     [(even? n*)
-      `(/ (- ,(coeffs* n*)
-             (pow ,(dvector-ref cache (/ n* 2)) 2)
-             (+ ,@(for/list ([k (in-naturals 1)]
-                             #:break (>= k (- n* k)))
-                    `(* 2 (* ,(dvector-ref cache k) ,(dvector-ref cache (- n* k)))))))
-          (* 2 ,(dvector-ref cache 0)))]
-     [(odd? n*)
-      `(/ (- ,(coeffs* n*)
-             (+ ,@(for/list ([k (in-naturals 1)]
-                             #:break (>= k (- n* k)))
-                    `(* 2 (* ,(dvector-ref cache k) ,(dvector-ref cache (- n* k)))))))
-          (* 2 ,(dvector-ref cache 0)))])))
+  (make-series n
+               (/ offset* 2)
+               cache
+               n*
+               (cond
+                 [(even? n*)
+                  `(/ (- ,(coeffs* n*)
+                         (pow ,(dvector-ref cache (/ n* 2)) 2)
+                         (+ ,@(for/list ([k (in-naturals 1)]
+                                         #:break (>= k (- n* k)))
+                                `(* 2 (* ,(dvector-ref cache k) ,(dvector-ref cache (- n* k)))))))
+                      (* 2 ,(dvector-ref cache 0)))]
+                 [(odd? n*)
+                  `(/ (- ,(coeffs* n*)
+                         (+ ,@(for/list ([k (in-naturals 1)]
+                                         #:break (>= k (- n* k)))
+                                `(* 2 (* ,(dvector-ref cache k) ,(dvector-ref cache (- n* k)))))))
+                      (* 2 ,(dvector-ref cache 0)))])))
 
 (define (taylor-cbrt var num)
   ;(-> symbol? term? term?)
@@ -391,17 +381,16 @@
                 (reducer (adder `(/ ,(coeffs* 1)
                                     (* 3 (cbrt (* ,(dvector-ref cache 0) ,(dvector-ref cache 0))))))))
 
-  (make-cached-series/extend
-   n
-   (/ offset* 3)
-   cache
-   n*
-   `(/ (- ,(coeffs* n*)
-          ,@(for*/list ([terms (n-sum-to 3 n*)]
-                        #:unless (set-member? terms n*))
-              (match-define (list a b c) terms)
-              `(* ,(dvector-ref cache a) ,(dvector-ref cache b) ,(dvector-ref cache c))))
-       (* 3 ,(dvector-ref cache 0) ,(dvector-ref cache 0)))))
+  (make-series n
+               (/ offset* 3)
+               cache
+               n*
+               `(/ (- ,(coeffs* n*)
+                      ,@(for*/list ([terms (n-sum-to 3 n*)]
+                                    #:unless (set-member? terms n*))
+                          (match-define (list a b c) terms)
+                          `(* ,(dvector-ref cache a) ,(dvector-ref cache b) ,(dvector-ref cache c))))
+                   (* 3 ,(dvector-ref cache 0) ,(dvector-ref cache 0)))))
 
 (define (taylor-pow coeffs n)
   ;(-> term? number? term?)
@@ -436,64 +425,64 @@
   (define cache (make-dvector 10))
   (dvector-set! cache 0 (reducer (adder `(exp ,(coeffs 0)))))
 
-  (make-cached-series/extend n
-                             0
-                             cache
-                             n*
-                             (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
-                                    [nums (for/list ([i (in-range 1 (+ n* 1))]
-                                                     [coeff (in-vector coeffs*)]
-                                                     #:unless (equal? (deref coeff) 0))
-                                            i)])
-                               `(* (exp ,(coeffs 0))
-                                   (+ ,@(for/list ([p (all-partitions n* (sort nums >))])
-                                          `(* ,@(for/list ([(count num) (in-dict p)])
-                                                  `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                                      ,(factorial count))))))))))
+  (make-series n
+               0
+               cache
+               n*
+               (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
+                      [nums (for/list ([i (in-range 1 (+ n* 1))]
+                                       [coeff (in-vector coeffs*)]
+                                       #:unless (equal? (deref coeff) 0))
+                              i)])
+                 `(* (exp ,(coeffs 0))
+                     (+ ,@(for/list ([p (all-partitions n* (sort nums >))])
+                            `(* ,@(for/list ([(count num) (in-dict p)])
+                                    `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                        ,(factorial count))))))))))
 
 (define (taylor-sin coeffs)
   ;(-> (-> number? batchref?) term?)
   (define cache (make-dvector 10))
   (dvector-set! cache 0 (adder 0))
 
-  (make-cached-series/extend n
-                             0
-                             cache
-                             n*
-                             (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
-                                    [nums (for/list ([i (in-range 1 (+ n* 1))]
-                                                     [coeff (in-vector coeffs*)]
-                                                     #:unless (equal? (deref coeff) 0))
-                                            i)])
-                               `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
-                                       (if (= (modulo (apply + (map car p)) 2) 1)
-                                           `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
-                                               ,@(for/list ([(count num) (in-dict p)])
-                                                   `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                                       ,(factorial count))))
-                                           0))))))
+  (make-series n
+               0
+               cache
+               n*
+               (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
+                      [nums (for/list ([i (in-range 1 (+ n* 1))]
+                                       [coeff (in-vector coeffs*)]
+                                       #:unless (equal? (deref coeff) 0))
+                              i)])
+                 `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
+                         (if (= (modulo (apply + (map car p)) 2) 1)
+                             `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
+                                 ,@(for/list ([(count num) (in-dict p)])
+                                     `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                         ,(factorial count))))
+                             0))))))
 
 (define (taylor-cos coeffs)
   ;(-> (-> number? batchref?) term?)
   (define cache (make-dvector 10))
   (dvector-set! cache 0 (adder 1))
 
-  (make-cached-series/extend n
-                             0
-                             cache
-                             n*
-                             (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
-                                    [nums (for/list ([i (in-range 1 (+ n* 1))]
-                                                     [coeff (in-vector coeffs*)]
-                                                     #:unless (equal? (deref coeff) 0))
-                                            i)])
-                               `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
-                                       (if (= (modulo (apply + (map car p)) 2) 0)
-                                           `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
-                                               ,@(for/list ([(count num) (in-dict p)])
-                                                   `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                                       ,(factorial count))))
-                                           0))))))
+  (make-series n
+               0
+               cache
+               n*
+               (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
+                      [nums (for/list ([i (in-range 1 (+ n* 1))]
+                                       [coeff (in-vector coeffs*)]
+                                       #:unless (equal? (deref coeff) 0))
+                              i)])
+                 `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
+                         (if (= (modulo (apply + (map car p)) 2) 0)
+                             `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
+                                 ,@(for/list ([(count num) (in-dict p)])
+                                     `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                         ,(factorial count))))
+                             0))))))
 
 ;; This is a hyper-specialized symbolic differentiator for log(f(x))
 


### PR DESCRIPTION
This PR removes the distinction between `make-cached-series` and `make-cached-series/extend`. In practice we expect to always fill in the series in order anyway. The new thing is called `make-series`. Plan is to continue simplifying it through future PRs.

https://chatgpt.com/codex/tasks/task_e_68d4185e7e0483318a69810f637e1287