### PR TITLE
Unify base cases and normal cases in Taylor

### DIFF
--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -425,6 +425,7 @@
   (make-series n
                0
                cache
+               n*
                (if (zero? n)
                    `(exp ,(coeffs 0))
                    (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
@@ -444,14 +445,15 @@
   (make-series n
                0
                cache
-               (if (zero? n)
+               n*
+               (if (zero? n*)
                    0
-                   (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
-                          [nums (for/list ([i (in-range 1 (+ n 1))]
+                   (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
+                          [nums (for/list ([i (in-range 1 (+ n* 1))]
                                            [coeff (in-vector coeffs*)]
                                            #:unless (equal? (deref coeff) 0))
                                   i)])
-                     `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
+                     `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
                              (if (= (modulo (apply + (map car p)) 2) 1)
                                  `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
                                      ,@(for/list ([(count num) (in-dict p)])
@@ -465,14 +467,15 @@
   (make-series n
                0
                cache
-               (if (zero? n)
+               n*
+               (if (zero? n*)
                    1
-                   (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
-                          [nums (for/list ([i (in-range 1 (+ n 1))]
+                   (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n* 1))))]
+                          [nums (for/list ([i (in-range 1 (+ n* 1))]
                                            [coeff (in-vector coeffs*)]
                                            #:unless (equal? (deref coeff) 0))
                                   i)])
-                     `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
+                     `(+ ,@(for/list ([p (all-partitions n* (sort nums >))])
                              (if (= (modulo (apply + (map car p)) 2) 0)
                                  `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
                                      ,@(for/list ([(count num) (in-dict p)])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -305,14 +305,16 @@
    so we extract that case out."
   (match-define (cons offset b) (normalize-series term))
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (reducer (adder `(/ 1 ,(b 0)))))
 
   (make-cached-series/extend n
                              (- offset)
                              cache
                              n*
-                             `(neg (+ ,@(for/list ([i (range n*)])
-                                          `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
+                             (if (zero? n*)
+                                 `(/ 1 ,(b 0))
+                                 `(neg (+ ,@(for/list ([i (range n*)])
+                                              `(* ,(dvector-ref cache i)
+                                                  (/ ,(b (- n* i)) ,(b 0)))))))))
 
 (define (taylor-quotient num denom)
   ;(-> term? term? term?)
@@ -322,15 +324,15 @@
   (match-define (cons noff a) (normalize-series num))
   (match-define (cons doff b) (normalize-series denom))
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (reducer (adder `(/ ,(a 0) ,(b 0)))))
-
   (make-cached-series/extend n
                              (- noff doff)
                              cache
                              n*
-                             `(- (/ ,(a n*) ,(b 0))
-                                 (+ ,@(for/list ([i (range n*)])
-                                        `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0))))))))
+                             (if (zero? n*)
+                                 `(/ ,(a 0) ,(b 0))
+                                 `(- (/ ,(a n*) ,(b 0))
+                                     (+ ,@(for/list ([i (range n*)])
+                                            `(* ,(dvector-ref cache i) (/ ,(b (- n* i)) ,(b 0)))))))))
 
 (define (modulo-series var n series)
   ;(-> symbol? number? term? term?)
@@ -356,15 +358,14 @@
   ;(-> symbol? term? term?)
   (match-define (cons offset* coeffs*) (modulo-series var 2 num))
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (reducer (adder `(sqrt ,(coeffs* 0)))))
-  (dvector-set! cache 1 (reducer (adder `(/ ,(coeffs* 1) (* 2 (sqrt ,(coeffs* 0)))))))
-
   (make-cached-series/extend
    n
    (/ offset* 2)
    cache
    n*
    (cond
+     [(zero? n*) `(sqrt ,(coeffs* 0))]
+     [(= n* 1) `(/ ,(coeffs* 1) (* 2 (sqrt ,(coeffs* 0))))]
      [(even? n*)
       `(/ (- ,(coeffs* n*)
              (pow ,(dvector-ref cache (/ n* 2)) 2)
@@ -383,23 +384,21 @@
   ;(-> symbol? term? term?)
   (match-define (cons offset* coeffs*) (modulo-series var 3 num))
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (reducer (adder `(cbrt ,(coeffs* 0)))))
-  (dvector-set! cache
-                1
-                (reducer (adder `(/ ,(coeffs* 1)
-                                    (* 3 (cbrt (* ,(dvector-ref cache 0) ,(dvector-ref cache 0))))))))
-
   (make-cached-series/extend
    n
    (/ offset* 3)
    cache
    n*
-   `(/ (- ,(coeffs* n*)
-          ,@(for*/list ([terms (n-sum-to 3 n*)]
-                        #:unless (set-member? terms n*))
-              (match-define (list a b c) terms)
-              `(* ,(dvector-ref cache a) ,(dvector-ref cache b) ,(dvector-ref cache c))))
-       (* 3 ,(dvector-ref cache 0) ,(dvector-ref cache 0)))))
+   (cond
+     [(zero? n*) `(cbrt ,(coeffs* 0))]
+     [(= n* 1) `(/ ,(coeffs* 1) (* 3 (cbrt (* ,(dvector-ref cache 0) ,(dvector-ref cache 0)))))]
+     [else
+      `(/ (- ,(coeffs* n*)
+             ,@(for*/list ([terms (n-sum-to 3 n*)]
+                           #:unless (set-member? terms n*))
+                 (match-define (list a b c) terms)
+                 `(* ,(dvector-ref cache a) ,(dvector-ref cache b) ,(dvector-ref cache c))))
+          (* 3 ,(dvector-ref cache 0) ,(dvector-ref cache 0)))])))
 
 (define (taylor-pow coeffs n)
   ;(-> term? number? term?)
@@ -432,63 +431,63 @@
 (define (taylor-exp coeffs)
   ;(-> (-> number? batchref?) term?)
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (reducer (adder `(exp ,(coeffs 0)))))
-
   (make-cached-series n
                       0
                       cache
-                      (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
-                             [nums (for/list ([i (in-range 1 (+ n 1))]
-                                              [coeff (in-vector coeffs*)]
-                                              #:unless (equal? (deref coeff) 0))
-                                     i)])
-                        `(* (exp ,(coeffs 0))
-                            (+ ,@(for/list ([p (all-partitions n (sort nums >))])
-                                   `(* ,@(for/list ([(count num) (in-dict p)])
-                                           `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                               ,(factorial count))))))))))
+                      (if (zero? n)
+                          `(exp ,(coeffs 0))
+                          (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
+                                 [nums (for/list ([i (in-range 1 (+ n 1))]
+                                                  [coeff (in-vector coeffs*)]
+                                                  #:unless (equal? (deref coeff) 0))
+                                         i)])
+                            `(* (exp ,(coeffs 0))
+                                (+ ,@(for/list ([p (all-partitions n (sort nums >))])
+                                       `(* ,@(for/list ([(count num) (in-dict p)])
+                                               `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                                   ,(factorial count)))))))))))
 
 (define (taylor-sin coeffs)
   ;(-> (-> number? batchref?) term?)
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (adder 0))
-
   (make-cached-series n
                       0
                       cache
-                      (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
-                             [nums (for/list ([i (in-range 1 (+ n 1))]
-                                              [coeff (in-vector coeffs*)]
-                                              #:unless (equal? (deref coeff) 0))
-                                     i)])
-                        `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
-                                (if (= (modulo (apply + (map car p)) 2) 1)
-                                    `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
-                                        ,@(for/list ([(count num) (in-dict p)])
-                                            `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                                ,(factorial count))))
-                                    0))))))
+                      (if (zero? n)
+                          0
+                          (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
+                                 [nums (for/list ([i (in-range 1 (+ n 1))]
+                                                  [coeff (in-vector coeffs*)]
+                                                  #:unless (equal? (deref coeff) 0))
+                                         i)])
+                            `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
+                                    (if (= (modulo (apply + (map car p)) 2) 1)
+                                        `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
+                                            ,@(for/list ([(count num) (in-dict p)])
+                                                `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                                    ,(factorial count))))
+                                        0)))))))
 
 (define (taylor-cos coeffs)
   ;(-> (-> number? batchref?) term?)
   (define cache (make-dvector 10))
-  (dvector-set! cache 0 (adder 1))
-
   (make-cached-series n
                       0
                       cache
-                      (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
-                             [nums (for/list ([i (in-range 1 (+ n 1))]
-                                              [coeff (in-vector coeffs*)]
-                                              #:unless (equal? (deref coeff) 0))
-                                     i)])
-                        `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
-                                (if (= (modulo (apply + (map car p)) 2) 0)
-                                    `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
-                                        ,@(for/list ([(count num) (in-dict p)])
-                                            `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
-                                                ,(factorial count))))
-                                    0))))))
+                      (if (zero? n)
+                          1
+                          (let* ([coeffs* (list->vector (map coeffs (range 1 (+ n 1))))]
+                                 [nums (for/list ([i (in-range 1 (+ n 1))]
+                                                  [coeff (in-vector coeffs*)]
+                                                  #:unless (equal? (deref coeff) 0))
+                                         i)])
+                            `(+ ,@(for/list ([p (all-partitions n (sort nums >))])
+                                    (if (= (modulo (apply + (map car p)) 2) 0)
+                                        `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
+                                            ,@(for/list ([(count num) (in-dict p)])
+                                                `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
+                                                    ,(factorial count))))
+                                        0)))))))
 
 ;; This is a hyper-specialized symbolic differentiator for log(f(x))
 


### PR DESCRIPTION
Updated the various Taylor series functions helper handle initial terms with explicit `cond`s instead of by pre-filling the cache. This should make it possible to clean up the `make-cached-series` helper later on.

https://chatgpt.com/codex/tasks/task_e_68d418cbe39c8331b845d10338b99ecc