### PR TITLE
Make `dump:rival` faster and more correct

### DIFF
--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -112,7 +112,7 @@
   (when dump-file
     (define args (map bigfloat->readable-string (vector->list pt*)))
     ;; convert to rational, because Rival reads as exact
-    (fprintf dump-file "(eval f ~a)" (string-join args " ")))
+    (fprintf dump-file "(eval f ~a)\n" (string-join args " ")))
   (define-values (status value)
     (with-handlers ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
                     [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -96,7 +96,7 @@
 
 (define (bigfloat->readable-string x)
   (define real (bigfloat->real x)) ; Exact rational unless inf/nan
-  (define float (real->double-flonum xreal))
+  (define float (real->double-flonum real))
   (if (= real float)
       (format "#i~a" float) ; The #i explicitly means nearest float
       (number->string real))) ; Backup is print as rational

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -94,6 +94,12 @@
                  machine
                  dump-file))
 
+(define (bigfloat->readable-string x)
+  (define xreal (bigfloat->real x))
+  (if (= xreal (real->double-flonum xreal))
+      (format "#i~a" (real->double-flonum xreal))
+      (number->string xreal)))
+
 ;; Runs a Rival machine on an input point.
 (define (real-apply compiler pt [hint #f])
   (match-define (real-compiler _ vars var-reprs _ _ machine dump-file) compiler)
@@ -104,9 +110,9 @@
                  [repr (in-vector var-reprs)])
       ((representation-repr->bf repr) val)))
   (when dump-file
-    (define args (map bigfloat->rational (vector->list pt*)))
+    (define args (map bigfloat->readable-string (vector->list pt*)))
     ;; convert to rational, because Rival reads as exact
-    (pretty-print `(eval f ,@args) dump-file 1))
+    (fprintf dump-file "(eval f ~a)" (string-join args " ")))
   (define-values (status value)
     (with-handlers ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]
                     [exn:rival:unsamplable? (lambda (e) (values 'exit #f))])

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -112,7 +112,6 @@
       ((representation-repr->bf repr) val)))
   (when dump-file
     (define args (map bigfloat->readable-string (vector->list pt*)))
-    ;; convert to rational, because Rival reads as exact
     (fprintf dump-file "(eval f ~a)\n" (string-join args " ")))
   (define-values (status value)
     (with-handlers ([exn:rival:invalid? (lambda (e) (values 'invalid #f))]

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -95,10 +95,11 @@
                  dump-file))
 
 (define (bigfloat->readable-string x)
-  (define xreal (bigfloat->real x))
-  (if (= xreal (real->double-flonum xreal))
-      (format "#i~a" (real->double-flonum xreal))
-      (number->string xreal)))
+  (define real (bigfloat->real x)) ; Exact rational unless inf/nan
+  (define float (real->double-flonum xreal))
+  (if (= real float)
+      (format "#i~a" float) ; The #i explicitly means nearest float
+      (number->string real))) ; Backup is print as rational
 
 ;; Runs a Rival machine on an input point.
 (define (real-apply compiler pt [hint #f])

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -142,7 +142,7 @@
   (timeline-push!/unsafe 'outcomes
                          (- (current-inexact-milliseconds) start)
                          (rival-profile machine 'iterations)
-                         (~a status)
+                         (symbol->string status)
                          1)
   (values status value))
 


### PR DESCRIPTION
The `dump:rival` flag outputs every Rival evaluation to a Rival-formatted file. However, it crashes on inf and NaN inputs; this PR fixes that. Additionally, the PR makes `dump:rival` much faster. The code used to output exact rationals for each argument; this makes the arguments really long. It turns out that you can write `#i3.2` in Racket (and thus Rival) to mean "the floating-point number closest to 3.2". Switching to that makes the output much shorter (and easier to read) which cuts runtime a lot. Moreover, this PR stops using `pretty-print`, which is slow, for `eval` lines; it keeps it for `define` lines, which are the ones you want pretty-printed, anyway.

In sum, `dump:rival` is much faster and probably still correct. It still adds something like a 2–3x overhead to Rival, but that might be unavoidable with writing stuff out to disk.