### PR TITLE
Add a cache in front of every Rival accelerator

### DIFF
--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -5,6 +5,7 @@
          ffi/unsafe)
 
 (require "../core/rival.rkt"
+         "../config.rkt"
          "types.rkt")
 
 (provide from-rival
@@ -24,14 +25,23 @@
 
 ; ----------------------- RIVAL GENERATOR ---------------------------
 
+(define/reset caches '()
+  (lambda ()
+    (for ([cache (caches)])
+      (hash-clear! cache))))
+
 (define-generator ((from-rival) spec ctx)
   (define compiler (make-real-compiler (list spec) (list ctx)))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
+  (define cache (make-hash))
+  (caches (cons cache (caches)))
   (lambda pt
-    (define-values (_ exs) (real-apply compiler (list->vector pt)))
-    (if exs
-        (first exs)
-        fail)))
+    (hash-ref! cache pt
+               (lambda ()
+                 (define-values (_ exs) (real-apply compiler (list->vector pt)))
+                 (if exs
+                     (first exs)
+                     fail)))))
 
 ; ----------------------- FFI GENERATOR -----------------------------
 

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -34,7 +34,7 @@
 (define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
   (define compiler (make-real-compiler (list spec) (list ctx)))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
-  (define (compute pt)
+  (define (compute . pt)
     (define-values (_ exs) (real-apply compiler (list->vector pt)))
     (if exs
         (first exs)
@@ -43,7 +43,7 @@
     [cache?
      (define cache (make-hash))
      (caches (cons cache (caches)))
-     (lambda pt (hash-ref! cache pt (lambda () (compute pt))))]
+     (lambda pt (hash-ref! cache pt (lambda () (apply compute pt))))]
     [else compute]))
 
 ; ----------------------- FFI GENERATOR -----------------------------

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -25,10 +25,11 @@
 
 ; ----------------------- RIVAL GENERATOR ---------------------------
 
-(define/reset caches '()
-  (lambda ()
-    (for ([cache (caches)])
-      (hash-clear! cache))))
+(define/reset caches
+              '()
+              (lambda ()
+                (for ([cache (caches)])
+                  (hash-clear! cache))))
 
 (define-generator ((from-rival) spec ctx)
   (define compiler (make-real-compiler (list spec) (list ctx)))
@@ -36,7 +37,8 @@
   (define cache (make-hash))
   (caches (cons cache (caches)))
   (lambda pt
-    (hash-ref! cache pt
+    (hash-ref! cache
+               pt
                (lambda ()
                  (define-values (_ exs) (real-apply compiler (list->vector pt)))
                  (if exs

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -31,19 +31,20 @@
                 (for ([cache (caches)])
                   (hash-clear! cache))))
 
-(define-generator ((from-rival) spec ctx)
+(define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
   (define compiler (make-real-compiler (list spec) (list ctx)))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
-  (define cache (make-hash))
-  (caches (cons cache (caches)))
-  (lambda pt
-    (hash-ref! cache
-               pt
-               (lambda ()
-                 (define-values (_ exs) (real-apply compiler (list->vector pt)))
-                 (if exs
-                     (first exs)
-                     fail)))))
+  (define (compute pt)
+    (define-values (_ exs) (real-apply compiler (list->vector pt)))
+    (if exs
+        (first exs)
+        fail))
+  (cond
+    [cache?
+     (define cache (make-hash))
+     (caches (cons cache (caches)))
+     (lambda pt (hash-ref! cache pt (lambda () (compute pt))))]
+    [else compute]))
 
 ; ----------------------- FFI GENERATOR -----------------------------
 

--- a/www/doc/2.3/platforms.html
+++ b/www/doc/2.3/platforms.html
@@ -409,7 +409,10 @@
   operation's specification. Compilation is usually <em>much</em>
   slower than with a native floating-point implementation, but for
   unusual operations that are difficult to implement otherwise, it can
-  still allow compilation to proceed.</p>
+  still allow compilation to proceed. There is an
+  optional <code>#:cache?</code> argument to <code>from-rival</code>,
+  on by default. The cache makes Herbie much faster but uses a lot of
+  memory.</p>
 
   <p>Note that <code>from-rival</code> implementations are always
   "correctly-rounded", meaning as accurate as possible. Most targets


### PR DESCRIPTION
Rival "accelerators" are just platform operators defined with `from-rival`. These are _super duper slow_. So slow! We've got examples of them taking a benchmark from 1s → 40s. Some investigation of this for the `grow-libm` branch by @JonasRegehr revealed that we are frequently evaluating an accelerator with the _same exact input_ multiple times. This PR thus adds a cache in every `from-rival`-generated operator. One tricky bit is making sure we clear these between benchmarks.

For example, across `tutorial.rkt`, we seem to do 2.6M evaluations of a `sum5` accelerator in the `slow-rival` branch. After deduplicating I think there are 416k, which is a 6x reduction, and unsurprisingly the total runtime goes from 77s to 18s (about a 4x reduction).

I'm not 100% sure we should actually merge this—ideally we'd just make Rival fast enough that caching isn't worth it—but let's discuss Monday.