### PR TITLE
Add Herbie 2.3 release notes

### DIFF
--- a/www/doc/2.3/regime-dominators.svg
+++ b/www/doc/2.3/regime-dominators.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="300" viewBox="0 0 680 300" role="img" aria-labelledby="title desc">
+  <title id="title">SSA expression and Lengauer-Tarjan dominator tree</title>
+  <desc id="desc">The expression exp(a times x) minus 1 is written as top-down SSA. The dominator tree on the left points from values toward their common dominators; the value %2 dominates %0 and %1.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #333; }
+    .heading { font-size: 17px; font-weight: 600; }
+    .code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 16px; }
+    .tree-label { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 16px; }
+    .edge { fill: none; stroke: #666; stroke-width: 2; marker-end: url(#arrow); }
+    .node { fill: #fff; stroke: #555; stroke-width: 2; }
+    .critical { fill: #d9edf7; stroke: #204a87; stroke-width: 3; }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#666" />
+    </marker>
+  </defs>
+
+  <text x="42" y="34" class="heading">Dominator tree</text>
+  <text x="265" y="34" class="heading">SSA</text>
+
+  <!-- Curved edges point toward the common dominator below. -->
+  <path d="M 100 91 C 100 105 100 113 100 125" class="edge" />
+  <path d="M 130 110 C 118 110 110 118 100 125" class="edge" />
+  <path d="M 100 156 C 100 165 100 168 100 175" class="edge" />
+  <path d="M 100 206 C 100 217 100 225 100 235" class="edge" />
+  <path d="M 130 215 C 118 215 110 225 100 235" class="edge" />
+
+  <rect x="75" y="60" width="50" height="31" rx="15" class="node" />
+  <text x="100" y="82" text-anchor="middle" class="tree-label">%0</text>
+  <rect x="130" y="95" width="50" height="31" rx="15" class="node" />
+  <text x="155" y="117" text-anchor="middle" class="tree-label">%1</text>
+  <rect x="75" y="125" width="50" height="31" rx="15" class="critical" />
+  <text x="100" y="147" text-anchor="middle" class="tree-label">%2</text>
+  <rect x="75" y="175" width="50" height="31" rx="15" class="node" />
+  <text x="100" y="197" text-anchor="middle" class="tree-label">%3</text>
+  <rect x="130" y="200" width="50" height="31" rx="15" class="node" />
+  <text x="155" y="222" text-anchor="middle" class="tree-label">%4</text>
+  <rect x="75" y="235" width="50" height="31" rx="15" class="node" />
+  <text x="100" y="257" text-anchor="middle" class="tree-label">%5</text>
+
+  <text x="265" y="82" class="code">%0 = a</text>
+  <text x="265" y="117" class="code">%1 = x</text>
+  <text x="265" y="152" class="code">%2 = (* %0 %1)</text>
+  <text x="265" y="187" class="code">%3 = (exp %2)</text>
+  <text x="265" y="222" class="code">%4 = 1</text>
+  <text x="265" y="257" class="code">%5 = (- %3 %4)</text>
+</svg>

--- a/www/doc/2.3/regime-dominators.svg
+++ b/www/doc/2.3/regime-dominators.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="680" height="300" viewBox="0 0 680 300" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="356" height="248" viewBox="42 20 356 248" role="img" aria-labelledby="title desc">
   <title id="title">SSA expression and Lengauer-Tarjan dominator tree</title>
   <desc id="desc">The expression exp(a times x) minus 1 is written as top-down SSA. The dominator tree on the left points from values toward their common dominators; the value %2 dominates %0 and %1.</desc>
   <style>

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -11,6 +11,10 @@
     .showcase.side-by-side { display: flex; gap: 1em; }
     .showcase.side-by-side :nth-child(1) { width: 60%; }
     .showcase.side-by-side :nth-child(2) { flex-grow: 1; hyphens: auto; }
+    #team {
+        display: block; box-sizing: border-box; width: 100%;
+        border-radius: 2em; border: 3px solid black;
+    }
   </style>
 </head>
 <body>
@@ -27,9 +31,8 @@
   </header>
 
   <p>The <a href="../..">Herbie</a> developers are excited to announce
-  Herbie 2.3! This release makes Herbie simplifies the core while
-  improving result quality, improves scalability to large expressions,
-  and continues to refine the retargetable platforms feature.</p>
+  Herbie 2.3! This release simplifies Herbie's core, improves performance
+  on large expressions, and introduces new backends, including Rival 3.</p>
 
   <p><b>What is Herbie?</b> Herbie compiles mathematical expressions
   to fast and accurate floating point programs, avoiding the bugs,
@@ -41,14 +44,14 @@
   <p>Taylor expansion has also been substantially reworked. Herbie can now
   recognize and construct more useful series, including expansions involving
   binary inputs, odd powers, fractional powers, and functions such as
-  <code>fabs</code>. It does a better job both caching duplicate work
-  and skipping unnecessary work. We also added extensive observability
+  <code>fabs</code>. It is better at both caching duplicate work and
+  skipping unnecessary work. We also added extensive observability
   tooling to the Taylor series pass, giving us the confidence to
-  significantly reduce tuning parameters. Taylor series runtime is
+  significantly reduce tuning parameters. Taylor-series runtime is
   thus dramatically reduced.</p>
 
   <p>Several aspects of the Herbie "main loop" were redesigned. Most
-  significantly, the "alt picking" system was entirely removed/ This
+  significantly, the "alt picking" system was entirely removed. This
   moderately increases runtime but also produces better-quality
   results and removes a hard-to-tune hyperparameter from Herbie,
   making the compilation pipeline easier to understand.</p>
@@ -59,8 +62,8 @@
   Reconstruction also now incorporates observable equivalence
   reasoning, allowing Herbie to quickly discard identical candidate
   programs. As a result, Herbie can search through significantly more
-  candidate programs, finding higher-quality results, without it
-  taking more time.</p>
+  candidate programs, finding higher-quality results, without taking
+  more time.</p>
 
   <h2>Faster and More Scalable</h2>
 
@@ -71,8 +74,8 @@
 %3 = (* %2 %2)
 %4 = (- %3 %1)</pre>
     <figcaption>
-      Herbie's "batch" datastructure stores an SSA-style sequence of
-      instructions. It can represent one <em>or multiple</em>
+      Herbie's "batch" data structure stores an SSA-style sequence of
+      instructions. It can represent one <em>or more</em>
       programs, and those programs can share common subexpressions
       among them. Rewrites, analyses, and other operations on batches
       are cached, which is especially valuable when thousands of
@@ -81,7 +84,7 @@
   </figure>
 
   <p><a href="../2.2/release-notes.html">Herbie 2.2</a> introduced the
-  "batch" datastructure to store multiple candidate programs with
+  "batch" data structure to store multiple candidate programs with
   shared subexpressions, and Herbie 2.3 extended that representation
   to all of Herbie's internal subsystems, including evaluation,
   rewriting, pruning, compilation, and report generation. Besides
@@ -104,12 +107,11 @@
   supported. New platforms for Python and Julia have been added.</p>
 
   <p>Herbie 2.3 includes beta support for array-valued expressions.
-  Support is still spotty, but arrays allow Herbie to reason about
-  compound operations (like <code>sincos</code>) and to model new
-  hardware (like matrix accelerators). This opens the door to using
-  Herbie for a broader class of numerical code, including small
-  vector-like computations. That said, arrays are still experimental,
-  with limited usability in the default platforms.</p>
+  Support is still spotty, but arrays set the foundation for Herbie to
+  reason about compound operations (like <code>sincos</code>) and model
+  new hardware (like matrix accelerators) down the line. That said,
+  arrays are still experimental, with limited usability in the default
+  platforms.</p>
 
   <p>Herbie's real arithmetic engine, Rival, was
   <a href="https://crates.io/crates/rival3">ported to Rust</a>. This
@@ -120,13 +122,13 @@
 
   <p>Herbie's <a href="https://github.com/egraphs-good/egglog">egglog</a>
   rewriting backend received significant attention. Egglog is a
-  successor <a href="https://github.com/egraphs-good/egg">egg</a>,
+  successor to <a href="https://github.com/egraphs-good/egg">egg</a>,
   Herbie's default rewrite engine, incorporating a variety of advanced
   features like typed expressions and multiple analyses. The egglog
   backend now produces better results than the default egg backend,
   but is still significantly slower. We are working with the egglog
   developers to improve egglog's performance and hope to switch to it
-  as the default once tha twork is complete.</p>
+  as the default once that work is complete.</p>
 
   <h2>Internal Changes and Improvements</h2>
   
@@ -137,10 +139,10 @@
       filters are applied. Report pages are now smaller on disk.</li>
     <li>Report code has also been substantially simplified, including
       dropping a dependency on Math.js and loading all other
-      dependencies from <a href="https://unpkg.com/">unpkg</a>. This
+      dependencies from <a href="https://www.jsdelivr.com/">jsDelivr</a>. This
       reduces loading time.</li>
     <li>Garbage collection now gets a dedicated section in Herbie's
-      observability tooling, better attributing time spent, and is
+      observability tooling, which better attributes time spent, and is
       also shown in the traces that Herbie can dump. This allowed us
       to debug dozens of over-allocating loops, substantially reducing
       Herbie's memory usage and garbage collection time.</li>
@@ -157,14 +159,14 @@
   agents. Some uses are especially transformative. For example, we
   used coding agents to track down unnecessary allocations and
   optimize hot procedures. This work is time-consuming but rote, and
-  the resulting patches easy to review. Porting was another valuable
+  the resulting patches are easy to review. Porting was another valuable
   use case: the port of Rival to Rust, or on a smaller scale the
   porting of Herbie's Pareto combination code to JavaScript, was made
   much easier by coding agents.</p>
 
   <p>Many capable students graduated last summer, so the Herbie 2.3
   team was on the smaller side. Yet this is one of the bigger
-  releases! It's not clear, that this rate of development will
+  releases! It's not clear that this rate of development will
   continue; we have picked much of the low-hanging fruit. But we are
   excited to see agents improve and, in turn, improve Herbie.</p>
 

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -8,8 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     .showcase { margin: 1em 0; }
-    .showcase.side-by-side { display: flex; gap: 1em; }
-    .showcase.side-by-side :nth-child(1) { width: 60%; }
+    .showcase.side-by-side :nth-child(1) { width: 200%; }
     .showcase.side-by-side :nth-child(2) { flex-grow: 1; hyphens: auto; }
     #team {
         display: block; box-sizing: border-box; width: 100%;
@@ -45,13 +44,13 @@
     <img width="100%" src="timeline-phase-comparison.svg"
       alt="Aggregate Herbie timeline phases for versions 2.2 and 2.3 across 563 common benchmarks." />
     <figcaption>
-      Herbie 2.3 is roughly 7% faster than Herbie 2.2 across 563
-      common benchmarks. Garbage collection time drops dramatically,
-      from 18.78 to 11.68 minutes, and most other phases get somewhat
-      faster. The new <code>reconstruct</code> phase, light blue,
-      handles Herbie 2.3's much larger search space. That larger
-      search space results in programs roughly 9% better&mdash;faster
-      or higher accuracy&mdash;than Herbie 2.2.
+      Herbie 2.3 is roughly 7% faster than Herbie 2.2. Garbage
+      collection time drops dramatically, from 18.78 to 11.68 minutes,
+      and most other phases get somewhat faster. The
+      new <code>reconstruct</code> phase, light blue, handles Herbie
+      2.3's much larger search space. That larger search space results
+      in programs roughly 9% better&mdash;faster or higher
+      accuracy&mdash;than Herbie 2.2.
     </figcaption>
   </figure>
 
@@ -92,27 +91,32 @@
     </figcaption>
   </figure>
 
-  <p><a href="../2.2/release-notes.html">Herbie 2.2</a> introduced the
-  "batch" data structure that shares subexpressions across related
-  programs, and Herbie 2.3 made it the common representation for all
-  of Herbie's internal subsystems, including evaluation, rewriting,
-  pruning, compilation, and report generation. Operations on batches
-  are cached, so Herbie can now reuse duplicate computations across
-  similar programs.</p>
+  <p><a href="../2.2/release-notes.html">Herbie 2.2</a> introduced a
+  SSA-like "batch" data structure to share subexpressions across
+  multiple candidate programs. Herbie 2.3 makes it the common
+  representation for all of Herbie's internal subsystems, including
+  evaluation, rewriting, pruning, compilation, and report generation.
+  Operations on batches are cached, so Herbie now reuses computations
+  across candidate programs instead of duplicating them.</p>
 
-  <p>Other subsystems leveraged this change to introduce new algorithms,
-    including Lengauer-Tarjan for branch expressions and a more complex
-  dynamic program for regime inference that replaces multiple calls
-  with a single exact solve. These algorithms are not only faster but
-  have superior asymptotics, which helps Herbie scale.</p>
+  <p>Other subsystems leveraged this change to introduce new and
+  faster algorithms, including Lengauer-Tarjan for branch expressions
+  and a more complex dynamic program for regime inference that
+  replaces multiple calls with a single exact solver. These algorithms
+  are not only faster but have superior asymptotics.</p>
+
+  <p>As part of this emphasis on scalability, we've added over a
+  hundred new benchmarks drawn from larger programs, and are looking
+  to add more as Herbie continues to improve. We're excited about
+  applying Herbie to full scientific formulas and kernels.</p>
 
   <h2>More Capable Platforms and Backends</h2>
 
   <figure class="showcase">
     <pre>%0 = x
-%1 = (sincos %0)       ; [sin(x), cos(x)]
-%2 = (ref %1 0)        ; sin(x)
-%3 = (ref %1 1)        ; cos(x)
+%1 = (sincos %0)       ; => [sin(x), cos(x)]
+%2 = (ref %1 0)        ; => sin(x)
+%3 = (ref %1 1)        ; => cos(x)
 %4 = (+ %2 %3)</pre>
     <figcaption>
       Herbie's new arrays feature can model the <code>sincos</code>
@@ -123,31 +127,24 @@
     </figcaption>
   </figure>
 
-  <p>Herbie's <a href="platforms.html">platforms API</a> allows Herbie
-  to tailor its results for a specific language and hardware platform.
-  Herbie 2.3 expands that API, allowing platforms to define new
-  representations and to load operator implementations from external
-  libraries. Helper functions now use the platform API, so are better
-  supported. New platforms for Python and Julia have been added.</p>
+  <p>Herbie 2.3 includes initial support for array-valued expressions.
+  This is the foundation for reasoning about compound operations
+  (like <code>sincos</code>) and new hardware (like vector and matrix
+  accelerators). That said, arrays are still experimental, with usage
+  the default platforms limited to just the <code>sincos</code>
+  operation. We plan to expand that usage in later releases.</p>
 
-  <p>Herbie 2.3 includes beta support for array-valued expressions.
-  Support is still spotty, but arrays set the foundation for Herbie to
-  reason about compound operations (like <code>sincos</code>) and model
-  new hardware (like matrix accelerators) down the line. That said,
-  arrays are still experimental, with limited usability in the default
-  platforms.</p>
-
-  <p>Herbie's real arithmetic engine, Rival, was
-  <a href="https://crates.io/crates/rival3">ported to Rust</a>. This
-  makes it significantly faster, lifting one of the most challenging
-  bottlenecks in Herbie's compilation pipeline. Rival is, to our
-  knowledge, by far the fastest real arithmetic library, and we also
-  hope other projects make use of it.</p>
+  <p>We ported Rival, Herbie's real arithmetic engine,
+  <a href="https://crates.io/crates/rival3">to Rust</a>. Rival was
+  already, to our knowledge, by far the fastest real arithmetic
+  library, and the Rust version is significantly faster. Besides
+  lifting one of Herbie's most challenging performance bottlenecks, we
+  hope this Rust version is also useful to other projects.</p>
 
   <p>Herbie's <a href="https://github.com/egraphs-good/egglog">egglog</a>
   rewriting backend received significant attention. Egglog is a
   successor to <a href="https://github.com/egraphs-good/egg">egg</a>,
-  Herbie's default rewrite engine, incorporating a variety of advanced
+  Herbie's default rewriting backend, and incorporates advanced
   features like typed expressions and multiple analyses. The egglog
   backend now produces better results than the default egg backend,
   but is still significantly slower. We are working with the egglog
@@ -155,44 +152,45 @@
   as the default once that work is complete.</p>
 
   <h2>Internal Changes and Improvements</h2>
-  
+
   <ul>
-    <li>Herbie was made reproducible by sorting hash-dependent
-      sequences.</li>
-    <li>Report pages now dynamically recompute Pareto curves as
-      filters are applied. Report pages are now smaller on disk.</li>
-    <li>Report code has also been substantially simplified, including
-      dropping a dependency on Math.js and loading all other
-      dependencies from <a href="https://www.jsdelivr.com/">jsDelivr</a>. This
-      reduces loading time.</li>
-    <li>Garbage collection now gets a dedicated section in Herbie's
-      observability tooling, which better attributes time spent, and is
-      also shown in the traces that Herbie can dump. This allowed us
-      to debug dozens of over-allocating loops, substantially reducing
-      Herbie's memory usage and garbage collection time.</li>
+    <li><a href="platforms.html">Platforms</a> can now load operator
+      implementations from external libraries.</li>
+    <li>Herbie now ships with platforms for Python and Julia.</li>
+    <li>Herbie sorts hash-dependent sequences to ensure reproducibility.</li>
+    <li>Report page plots are now dynamically recomputed as filters
+      are applied. Report pages data is now smaller on disk.</li>
+    <li>Report pages load dependencies
+      from <a href="https://www.jsdelivr.com/">jsDelivr</a>,
+      and no longer load Math.js, reducing loading time.</li>
+    <li>Garbage collection is now tracked in Herbie's observability
+      and tracing tools. This allowed us to debug dozens of
+      over-allocating loops, substantially reducing Herbie's memory
+      usage and garbage collection time.</li>
     <li>Taylor series now produce significantly richer observability
       information.</li>
     <li>Herbie's preprocessing system can now be disabled with
       flags.</li>
   </ul>
 
-  <h2>On Coding Agents</h2>
+  <h2>Thank You to Coding Agents</h2>
 
   <p>Finally, a note on the impact of coding agents on Herbie. The
   vast majority of new code in this release was written by coding
-  agents. Some uses are especially transformative. For example, we
+  agents, mostly Codex. Some uses were especially transformative. We
   used coding agents to track down unnecessary allocations and
   optimize hot procedures. This work is time-consuming but rote, and
-  the resulting patches are easy to review. Porting was another valuable
-  use case: the port of Rival to Rust, or on a smaller scale the
-  porting of Herbie's Pareto combination code to JavaScript, was made
-  much easier by coding agents.</p>
+  the resulting patches are easy to review. The port of Rival to Rust,
+  or on a smaller scale the porting of Herbie's Pareto combination
+  code to JavaScript, was also done partly by coding agents, though it
+  also required substantial human oversight.</p>
 
   <p>Many capable students graduated last summer, so the Herbie 2.3
   team was on the smaller side. Yet this is one of the bigger
-  releases! It's not clear that this rate of development will
-  continue; we have picked much of the low-hanging fruit. But we are
-  excited to see agents improve and, in turn, improve Herbie.</p>
+  releases, all thanks to coding agents! We don't think this rate of
+  development will continue; we have picked much of the low-hanging
+  fruit. But we are excited to see agents improve and, in turn,
+  improve Herbie.</p>
 
   <h2>Try it out!</h2>
 

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Herbie 2.2 Release Notes</title>
+  <title>Herbie 2.3 Release Notes</title>
   <link rel='stylesheet' type='text/css' href="../../main.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,15 +11,11 @@
     .showcase.side-by-side { display: flex; gap: 1em; }
     .showcase.side-by-side :nth-child(1) { width: 60%; }
     .showcase.side-by-side :nth-child(2) { flex-grow: 1; hyphens: auto; }
-    #team {
-        display: block; box-sizing: border-box; width: 100%;
-        border-radius: 2em; border: 3px solid black;
-    }
   </style>
 </head>
 <body>
   <header>
-    <h1>Herbie 2.2 Release Notes</h1>
+    <h1>Herbie 2.3 Release Notes</h1>
     <a href="../.."><img class="logo" src="../../logo-car.png" /></a>
     <nav>
       <ul>
@@ -31,236 +27,135 @@
   </header>
 
   <p>The <a href="../..">Herbie</a> developers are excited to announce
-  Herbie 2.2! This release focuses extensible compilation targets
-  using <i>platforms</i>.</p>
+  Herbie 2.3! This release makes Herbie faster and more scalable, while
+  continuing the move toward a numerical compiler that can target many
+  different platforms.</p>
 
   <p><b>What is Herbie?</b> Herbie compiles mathematical expressions
   to fast and accurate floating point programs, avoiding the bugs,
   errors, and surprises of floating point arithmetic.
   Visit <a href="../..">the main page</a> to learn more.</p>
-  
-  <!--<img src="team.png" id="team" alt="The Herbie 2.2 team at UW and U of U" />-->
 
-  <h2>Releasing the Platforms API</h2>
-
-  <figure class="showcase">
-    <pre>(define-operation (cosd [x &lt;binary64&gt;]) &lt;binary64&gt;
-          #:spec (cos (* x (/ (PI) 180)))
-          #:impl (from-rival)
-          #:cost 12.5)</pre>
-
-    <figcaption>
-      Herbie 2.2's <a href="platforms.html">platforms</a> allow you to
-      define custom compilation targets, including novel hardware
-      (CPUs, GPUs, FPGAs, TPUs), programming languages (Julia, Matlab,
-      Fortran), or software libraries (Numpy, Eigen, cuBLAS).
-      Platforms can define new number formats, new floating-point
-      operations on those formats, and new cost models for those
-      operations. Herbie will automatically optimize its results for
-      your platform.
-    </figcaption>
-  </figure>
-
-  <p>
-  Last year, <a href="../2.1/release-notes.html">Herbie 2.1</a>
-  included the beginnings of <i>platforms</i>, Herbie's API for
-  multiple backends. We've simplified and improved this API, and are
-  now ready to release it.</p>
-  
-  <p>In short, platforms allow you define the functions Herbie is
-  allowed to use when compiling floating-point programs. A platform
-  can expose Python's <code>fsum</code>, Julia's <code>cosd</code>, or
-  AVX's <code>rcpps</code> to Herbie, which can then use those
-  functions to produce even faster and more accurate output.
-  Our <a href="../papers.html">recent publications</a> demonstrate
-  dramatic accuracy and performance improvements using platforms.</p>
-
-  <p>Platforms are a large change, and we invite users to try it out.
-  The <a href="platforms.html">platforms documentation</a> explains
-  how to select different built-in platforms, or even how to write
-  your own.</p>
-  
-  <p>Besides the new feature, platforms allow us to deprecate a
-  variety of now-superseded features:</p>
-
-  <ul>
-    <li>The default platform now uses a realistic, auto-tuned cost
-    model which should lead to faster code in practice.</li>
-
-    <li>The Herbie 2.0 and 2.1 cost models are replaced by
-    the <code>herbie20</code> platform.</li>
-
-    <li>The <code>--no-pareto</code> flag is replaced by
-    the <code>herbie10</code> platform.</li>
-
-    <li>Plugins are now replaced by ordinary Racket libraries imported
-    directly by plugins.</li>
-    
-    <li>Preprocessing is now replaced by standard platform-provided
-    functions such
-    as <code>fmin</code>, <code>fmax</code>, <code>fabs</code>,
-    and <code>copysign</code>.</li>
-  </ul>
-
-  <h2>Restructuring the Main Loop</h2>
-  
-  <figure class="showcase">
-    <img src="system-2.2.png"
-         alt="The new Herbie main loop.
-              The simplify step and patch table have been removed,
-              while the compute phase has been added.">
-    <figcaption>
-      The Herbie main loop is dramatically simplified, with no
-      separate simplify or localize phase and a new compute phase that
-      aid with hard-to-compute constants.
-    </figcaption>
-  </figure>
-
-  <p>We've overhauled the Herbie main loop, which is the high-level
-  algorithm that invokes different Herbie sub-systems to generate and
-  filter different candidate programs. This overhaul both introduces
-  new systems, which should make Herbie more capable, and reduce
-  duplicative work, dramatically speeding up Herbie. Specifically:</p>
-
-  <ul>
-    <li>A new compute phase was added, which replaces variable-free
-      subexpressions with constants. The constants are computed using
-      high-precision arithmetic and are guaranteed to be exact.</li>
-    <li>The simplification phase was removed. This phase mostly
-      duplicated work already done by the rewrite phase, so removing it
-      had very little impact on performance and accuracy of generated
-      code, but reduced Herbie runtime significantly.</li>
-    <li>The localize phase was also removed. This phase existed to
-      reduce duplicate work in other phases; batches deduplicate the
-      work automatically so localize is no longer needed. Removing this
-      phase also significantly sped up Herbie.</li>
-    <li>Minor phases like initial and final simplify were removed as
-      well. Most importantly, this allowed replacing the existing,
-      complex "accelerator" API (never fully released) and replace it
-      with the much simpler "platform" API.</li>
-    <li>Herbie more correctly tracks Taylor approximations inside
-      Herbie, and will now avoid making "approximations to
-      approximations" leading to runaway error in rare cases.</li>
-  </ul>
-      
-
-  <h2>Flattening Expressions to Batches</h2>
+  <h2>Faster and More Scalable</h2>
 
   <figure class="showcase side-by-side">
     <pre>%0 = x
 %1 = (literal 1)
 %2 = (+ %0 %1)
 %3 = (* %2 %2)
-%4 = (- %3 %1)
-%5 = (neg %2)
-%6 = (* %5 %5)
-%7 = (- %6 %1))</pre>
+%4 = (- %3 %1)</pre>
     <figcaption>
-      An example of a batch, containing two expressions (and their
-      subexpressions): <code>(x + 1)<sup>2</sup> - 1</code>
-      and <code>(-(x + 1))<sup>2</sup> - 1</code>. Shared
-      subexpressions are only represented once in the batch, and are
-      only processed once by Herbie.
+      Herbie's batch representation stores shared subexpressions once and
+      refers to them by index. This lets several parts of the optimizer work
+      on the same data without repeatedly converting whole expression trees.
     </figcaption>
   </figure>
 
-  <p>We have also changed Herbie's main data structure for
-  representing programs. Until now, Herbie represented programs via
-  their abstract syntax tree. While simple and effective, this
-  representation lead to processing identical subexpressions
-  repeatedly. This was especially problematic for larger programs,
-  which can sometimes have the same subexpression appear exponentially
-  many times.</p>
+  <p>Herbie 2.3 continues the work started in
+  <a href="../2.2/release-notes.html">Herbie 2.2</a> to simplify and speed
+  up its core. Candidate programs are now processed more consistently in a
+  compact <i>batch</i> representation, rather than as separate syntax trees.
+  Batches share subexpressions and can be reused by evaluation, rewriting,
+  pruning, compilation, and report generation.</p>
 
-  <p>The batch data structure instead uses a flat array with
-  back-references to represent programs, which means that duplicate
-  subexpressions appear and are processed just once. This lead to
-  significant speedups throughout Herbie:</p>
+  <p>This change is especially helpful for large expressions and for phases
+  that consider many alternatives. The compiler, Taylor-series code, and
+  e-graph interfaces now make much broader use of batches, reducing copying
+  and repeated work. Herbie also does a better job of grouping related
+  alternatives and reusing intermediate results.</p>
 
-  <ul>
-    <li>Batches automatically deduplicates identical candidate
-      programs, which occur when multiple Herbie phases produce the
-      same output. There were a lot more of these than we thought; in
-      some cases as much as 25&times; deduplication occurs.</li>
-    <li>The series phase, now uses batches internally, allowing Herbie
-      to consider many more series expansions.</li>
-    <li>Herbie's FFI layer for interacting with
-      the <a href="https://egraphs-good.github.io/">egg</a> library now
-      leverages batches to reduce time spent copying data in and out of
-      egg.</li>
-    <li> In some cases, one batch is shared across multiple phases
-      (like evaluation and pruning), reducing duplication even
-      further.</li>
-    <li>The derivations phase was dramatically sped up by caching
-      proof objects across multiple candidate programs. Additionally,
-      a debugging pass called "soundiness" was removed entirely, since
-      the problems it was built to debug no longer occur. Thanks to
-      both changes, derivations take almost no time at all any
-      more.</li>
-  </ul>
+  <p>Regime inference and reconstruction received substantial algorithmic
+  improvements as well. These changes reduce memory use and make difficult
+  expressions more practical, while keeping the generated programs and
+  their accuracy tradeoffs intact. Batch processing is also better integrated
+  with shell and web batch modes, including multi-threaded runs.</p>
 
-  <h2>Sister Projects</h2>
-  
-  <p>
-    The <a href="https://github.com/herbie-fp/odyssey">Odyssey
-      numerics workbench</a> is releasing version 1.2 today, featuring
-      a new "local error" component and various design tweaks and
-      improvements. Odyssey can be tried from
-      its <a href="https://herbie-fp.github.io/odyssey/">online
-      demo</a> or installed locally from
-      the <a href="https://marketplace.visualstudio.com/items?itemName=herbie-fp.odyssey-fp">VS
-      Code Marketplace</a>.
-  </p>
-  
-  <p>
-    The <a href="https://github.com/herbie-fp/rival">Rival
-    real-arithmetic package</a> is releasing version 2.2 today,
-    including various tweaks, optimizations, and improvements. Most
-    significantly, a new "hints" feature significantly speeds up
-    sampling expressions that
-    use <code>fmin</code>, <code>fmax</code>, and <code>if</code>.
-  </p>
+  <h2>Improved Numerical Search</h2>
 
-  <h2>Other improvements</h2>
+  <p>Herbie 2.3 uses <a href="https://docs.racket-lang.org/rival/">Rival 3</a>
+  as its default real-arithmetic engine. Rival 3 improves the evaluation and
+  compilation path used while Herbie samples expressions, with the largest
+  benefits on complicated expressions and nonstandard representations.</p>
 
-  <ul>
-    <li>Herbie now offers a basic <a href="api-endpoints.html">HTTP
-        API</a>, including both synchronous and asynchronous jobs and
-      access to various internal Herbie features. This HTTP API is a
-      work in progress and is primarily built to support Odyssey.
-      However, our work on the API has also enabled the
-      standard <a href="using-web.html">Herbie web interface</a> to
-      support <a href="options.html">threads</a>, which should make
-      Herbie faster in a lot of common use cases.</li>
-    <li>Small quality-of-life changes have been made to the Herbie
-      reports, including hiding duplicate alternatives, updating
-      various dependencies, and generating the reports more
-      quickly.</li>
-    <li>Optional, off-by-default support for
-      the <a href="https://github.com/egraphs-good/egglog">egglog</a>
-      rewriting engine has been added. We are excited about growth and
-      competition among rewrite engines and hope to continue driving
-      forward this research area.</li>
-    <li>Fixing a variety of small bugs, such as nondeterminism due to
-      an incorrect type signature for <code>fma</code> and new rewrite
-      rules to unlock more accurate results.</li>
-    <li>Many general-purpose cleanups, including removing a lot of
-      now-unnecessary nightly infrastructure, adoption of a new
-      formatting guideline, reorganization of the source code, and new
-      debug infrastructure.</li>
-  </ul>
+  <p>Taylor expansion has also been substantially reworked. Herbie can now
+  recognize and construct more useful series, including expansions involving
+  binary inputs, odd powers, fractional powers, and functions such as
+  <code>fabs</code>. It more carefully tracks which approximations survive the
+  search, reducing unhelpful or redundant expansions.</p>
+
+  <p>Preprocessing is now more closely integrated with the main batch-based
+  search. Platform-provided operations can participate in preprocessing and
+  in the specification and implementation sides of a candidate, giving
+  Herbie more opportunities to use operations that are actually available on
+  the selected target.</p>
+
+  <p>Finally, Herbie's search is more reproducible. Alternative ordering and
+  several sources of accidental nondeterminism were cleaned up, so repeated
+  runs with the same seed are more likely to produce the same reports and
+  output.</p>
+
+  <h2>Early Support for Arrays</h2>
+
+  <p>Herbie 2.3 includes beta support for array-valued expressions. Herbie can
+  represent arrays, reason about basic array operations, and compile some
+  array programs through supported platforms. This opens the door to using
+  Herbie for a broader class of numerical code, including small vector-like
+  computations.</p>
+
+  <p>Arrays are still experimental. Support varies by operation and platform,
+  and some parts of the optimizer and report pipeline remain incomplete. We
+  invite users to try the feature, but recommend treating it as a preview
+  rather than as a stable interface.</p>
+
+  <h2>More Capable Platforms and Backends</h2>
+
+  <p>Herbie 2.2 introduced the public
+  <a href="platforms.html">platforms API</a>. Herbie 2.3 expands that API
+  and makes it more useful in real applications. A platform can define its
+  own representations, operations, implementations, and costs, and can
+  provide implementations from an external language or library. Platform
+  state is preserved when work is sent to Herbie's workers, so custom
+  platforms behave more consistently in threaded and batch runs.</p>
+
+  <p>More built-in targets and platform functions are available, including
+  support for additional language and library conventions. The platform
+  documentation now explains how to load external functions, add operations,
+  and use a platform to describe a custom compilation target.</p>
+
+  <p>Herbie also includes a much more capable experimental backend based on
+  <a href="https://github.com/egraphs-good/egglog">egglog</a>. The backend
+  can work with the same batch and platform information as the main search and
+  has improved scheduling, extraction, and handling of target-specific
+  representations. Egglog remains off by default while we continue to test it
+  and compare it with Herbie's standard e-graph backend.</p>
+
+  <h2>Better Reports and Tooling</h2>
+
+  <p>Reports have been updated to handle the larger and more varied searches
+  produced by Herbie 2.3. Pareto comparisons are computed and cached more
+  efficiently, making report pages substantially more responsive on large
+  result sets. The report frontend no longer depends on Math.js, reducing the
+  amount of JavaScript it needs to load.</p>
+
+  <p>Reports also contain more complete alternative data and clearer timeline
+  information for batches, Taylor expansions, garbage collection, and other
+  expensive phases. These additions make it easier to understand both the
+  quality of Herbie's output and the time and memory spent producing it.</p>
+
+  <p>Along the way, we fixed many smaller issues in the web interface, HTTP
+  API, platform loading, output generation, and cross-platform installation.
+  The <a href="options.html">options documentation</a> describes the current
+  defaults, including the new preprocessing controls and the experimental
+  debugging options.</p>
 
   <h2>Try it out!</h2>
 
-  <p>
-    We want Herbie to be more useful to scientists, engineers, and
-    programmers around the world. We've got a lot of features we're
-    excited to work on in the coming months. Please
-    <a href="https://github.com/herbie-fp/herbie/issues">report bugs</a>
-    or <a href="https://github.com/herbie-fp/herbie">contribute</a>.
-  </p>
+  <p>We want Herbie to be more useful to scientists, engineers, and
+  programmers around the world. Please
+  <a href="https://github.com/herbie-fp/herbie/issues">report bugs</a> or
+  <a href="https://github.com/herbie-fp/herbie">contribute</a>.</p>
   <br>
   <p style="font-weight: bold; text-align: center;">If you find Herbie
-  useful, <a href="mailto:herbie@cs.washington.edu">let us know!</p>
+  useful, <a href="mailto:herbie@cs.washington.edu">let us know!</a></p>
 </body>
 </html>

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -27,14 +27,40 @@
   </header>
 
   <p>The <a href="../..">Herbie</a> developers are excited to announce
-  Herbie 2.3! This release makes Herbie faster and more scalable, while
-  continuing the move toward a numerical compiler that can target many
-  different platforms.</p>
+  Herbie 2.3! This release makes Herbie simplifies the core while
+  improving result quality, improves scalability to large expressions,
+  and continues to refine the retargetable platforms feature.</p>
 
   <p><b>What is Herbie?</b> Herbie compiles mathematical expressions
   to fast and accurate floating point programs, avoiding the bugs,
   errors, and surprises of floating point arithmetic.
   Visit <a href="../..">the main page</a> to learn more.</p>
+
+  <h2>Improving the Core</h2>
+
+  <p>Taylor expansion has also been substantially reworked. Herbie can now
+  recognize and construct more useful series, including expansions involving
+  binary inputs, odd powers, fractional powers, and functions such as
+  <code>fabs</code>. It does a better job both caching duplicate work
+  and skipping unnecessary work. We also added extensive observability
+  tooling to the Taylor series pass, giving us the confidence to
+  significantly reduce tuning parameters. Taylor series runtime is
+  thus dramatically reduced.</p>
+
+  <p>Several aspects of the Herbie "main loop" were redesigned. Most
+  significantly, the "alt picking" system was entirely removed/ This
+  moderately increases runtime but also produces better-quality
+  results and removes a hard-to-tune hyperparameter from Herbie,
+  making the compilation pipeline easier to understand.</p>
+  
+  <p>The core "patching" loop was also broken out into a separate
+  phase, called "reconstruction", and that phase was extensively
+  rewritten to build reachability maps that speed up patching itself.
+  Reconstruction also now incorporates observable equivalence
+  reasoning, allowing Herbie to quickly discard identical candidate
+  programs. As a result, Herbie can search through significantly more
+  candidate programs, finding higher-quality results, without it
+  taking more time.</p>
 
   <h2>Faster and More Scalable</h2>
 
@@ -45,108 +71,102 @@
 %3 = (* %2 %2)
 %4 = (- %3 %1)</pre>
     <figcaption>
-      Herbie's batch representation stores shared subexpressions once and
-      refers to them by index. This lets several parts of the optimizer work
-      on the same data without repeatedly converting whole expression trees.
+      Herbie's "batch" datastructure stores an SSA-style sequence of
+      instructions. It can represent one <em>or multiple</em>
+      programs, and those programs can share common subexpressions
+      among them. Rewrites, analyses, and other operations on batches
+      are cached, which is especially valuable when thousands of
+      programs reuse a small number of common instructions.
     </figcaption>
   </figure>
 
-  <p>Herbie 2.3 continues the work started in
-  <a href="../2.2/release-notes.html">Herbie 2.2</a> to simplify and speed
-  up its core. Candidate programs are now processed more consistently in a
-  compact <i>batch</i> representation, rather than as separate syntax trees.
-  Batches share subexpressions and can be reused by evaluation, rewriting,
-  pruning, compilation, and report generation.</p>
+  <p><a href="../2.2/release-notes.html">Herbie 2.2</a> introduced the
+  "batch" datastructure to store multiple candidate programs with
+  shared subexpressions, and Herbie 2.3 extended that representation
+  to all of Herbie's internal subsystems, including evaluation,
+  rewriting, pruning, compilation, and report generation. Besides
+  improving compilation time, especially on the largest programs, this
+  also aligns Herbie with standard compiler practice, since batches
+  are effectively a type of SSA representation.</p>
 
-  <p>This change is especially helpful for large expressions and for phases
-  that consider many alternatives. The compiler, Taylor-series code, and
-  e-graph interfaces now make much broader use of batches, reducing copying
-  and repeated work. Herbie also does a better job of grouping related
-  alternatives and reusing intermediate results.</p>
-
-  <p>Regime inference and reconstruction received substantial algorithmic
-  improvements as well. These changes reduce memory use and make difficult
-  expressions more practical, while keeping the generated programs and
-  their accuracy tradeoffs intact. Batch processing is also better integrated
-  with shell and web batch modes, including multi-threaded runs.</p>
-
-  <h2>Improved Numerical Search</h2>
-
-  <p>Herbie 2.3 uses <a href="https://docs.racket-lang.org/rival/">Rival 3</a>
-  as its default real-arithmetic engine. Rival 3 improves the evaluation and
-  compilation path used while Herbie samples expressions, with the largest
-  benefits on complicated expressions and nonstandard representations.</p>
-
-  <p>Taylor expansion has also been substantially reworked. Herbie can now
-  recognize and construct more useful series, including expansions involving
-  binary inputs, odd powers, fractional powers, and functions such as
-  <code>fabs</code>. It more carefully tracks which approximations survive the
-  search, reducing unhelpful or redundant expansions.</p>
-
-  <p>Preprocessing is now more closely integrated with the main batch-based
-  search. Platform-provided operations can participate in preprocessing and
-  in the specification and implementation sides of a candidate, giving
-  Herbie more opportunities to use operations that are actually available on
-  the selected target.</p>
-
-  <p>Finally, Herbie's search is more reproducible. Alternative ordering and
-  several sources of accidental nondeterminism were cleaned up, so repeated
-  runs with the same seed are more likely to produce the same reports and
-  output.</p>
-
-  <h2>Early Support for Arrays</h2>
-
-  <p>Herbie 2.3 includes beta support for array-valued expressions. Herbie can
-  represent arrays, reason about basic array operations, and compile some
-  array programs through supported platforms. This opens the door to using
-  Herbie for a broader class of numerical code, including small vector-like
-  computations.</p>
-
-  <p>Arrays are still experimental. Support varies by operation and platform,
-  and some parts of the optimizer and report pipeline remain incomplete. We
-  invite users to try the feature, but recommend treating it as a preview
-  rather than as a stable interface.</p>
+  <p>Other subsystems leveraged this change to introduce new, standard
+  algorithms, including Lengauer-Tarjan for branch expressions and a
+  more complex dynamic programming formulation of regime
+  inference.</p>
 
   <h2>More Capable Platforms and Backends</h2>
 
-  <p>Herbie 2.2 introduced the public
-  <a href="platforms.html">platforms API</a>. Herbie 2.3 expands that API
-  and makes it more useful in real applications. A platform can define its
-  own representations, operations, implementations, and costs, and can
-  provide implementations from an external language or library. Platform
-  state is preserved when work is sent to Herbie's workers, so custom
-  platforms behave more consistently in threaded and batch runs.</p>
+  <p>Herbie's <a href="platforms.html">platforms API</a> allows Herbie
+  to tailor its results for a specific language and hardware platform.
+  Herbie 2.3 expands that API, allowing platforms to define new
+  representations and to load operator implementations from external
+  libraries. Helper functions now use the platform API, so are better
+  supported. New platforms for Python and Julia have been added.</p>
 
-  <p>More built-in targets and platform functions are available, including
-  support for additional language and library conventions. The platform
-  documentation now explains how to load external functions, add operations,
-  and use a platform to describe a custom compilation target.</p>
+  <p>Herbie 2.3 includes beta support for array-valued expressions.
+  Support is still spotty, but arrays allow Herbie to reason about
+  compound operations (like <code>sincos</code>) and to model new
+  hardware (like matrix accelerators). This opens the door to using
+  Herbie for a broader class of numerical code, including small
+  vector-like computations. That said, arrays are still experimental,
+  with limited usability in the default platforms.</p>
 
-  <p>Herbie also includes a much more capable experimental backend based on
-  <a href="https://github.com/egraphs-good/egglog">egglog</a>. The backend
-  can work with the same batch and platform information as the main search and
-  has improved scheduling, extraction, and handling of target-specific
-  representations. Egglog remains off by default while we continue to test it
-  and compare it with Herbie's standard e-graph backend.</p>
+  <p>Herbie's real arithmetic engine, Rival, was
+  <a href="https://crates.io/crates/rival3">ported to Rust</a>. This
+  makes it significantly faster, lifting one of the most challenging
+  bottlenecks in Herbie's compilation pipeline. Rival is, to our
+  knowledge, by far the fastest real arithmetic library, and we also
+  hope other projects make use of it.</p>
 
-  <h2>Better Reports and Tooling</h2>
+  <p>Herbie's <a href="https://github.com/egraphs-good/egglog">egglog</a>
+  rewriting backend received significant attention. Egglog is a
+  successor <a href="https://github.com/egraphs-good/egg">egg</a>,
+  Herbie's default rewrite engine, incorporating a variety of advanced
+  features like typed expressions and multiple analyses. The egglog
+  backend now produces better results than the default egg backend,
+  but is still significantly slower. We are working with the egglog
+  developers to improve egglog's performance and hope to switch to it
+  as the default once tha twork is complete.</p>
 
-  <p>Reports have been updated to handle the larger and more varied searches
-  produced by Herbie 2.3. Pareto comparisons are computed and cached more
-  efficiently, making report pages substantially more responsive on large
-  result sets. The report frontend no longer depends on Math.js, reducing the
-  amount of JavaScript it needs to load.</p>
+  <h2>Internal Changes and Improvements</h2>
+  
+  <ul>
+    <li>Herbie was made reproducible by sorting hash-dependent
+      sequences.</li>
+    <li>Report pages now dynamically recompute Pareto curves as
+      filters are applied. Report pages are now smaller on disk.</li>
+    <li>Report code has also been substantially simplified, including
+      dropping a dependency on Math.js and loading all other
+      dependencies from <a href="https://unpkg.com/">unpkg</a>. This
+      reduces loading time.</li>
+    <li>Garbage collection now gets a dedicated section in Herbie's
+      observability tooling, better attributing time spent, and is
+      also shown in the traces that Herbie can dump. This allowed us
+      to debug dozens of over-allocating loops, substantially reducing
+      Herbie's memory usage and garbage collection time.</li>
+    <li>Taylor series now produce significantly richer observability
+      information.</li>
+    <li>Herbie's preprocessing system can now be disabled with
+      flags.</li>
+  </ul>
 
-  <p>Reports also contain more complete alternative data and clearer timeline
-  information for batches, Taylor expansions, garbage collection, and other
-  expensive phases. These additions make it easier to understand both the
-  quality of Herbie's output and the time and memory spent producing it.</p>
+  <h2>On Coding Agents</h2>
 
-  <p>Along the way, we fixed many smaller issues in the web interface, HTTP
-  API, platform loading, output generation, and cross-platform installation.
-  The <a href="options.html">options documentation</a> describes the current
-  defaults, including the new preprocessing controls and the experimental
-  debugging options.</p>
+  <p>Finally, a note on the impact of coding agents on Herbie. The
+  vast majority of new code in this release was written by coding
+  agents. Some uses are especially transformative. For example, we
+  used coding agents to track down unnecessary allocations and
+  optimize hot procedures. This work is time-consuming but rote, and
+  the resulting patches easy to review. Porting was another valuable
+  use case: the port of Rival to Rust, or on a smaller scale the
+  porting of Herbie's Pareto combination code to JavaScript, was made
+  much easier by coding agents.</p>
+
+  <p>Many capable students graduated last summer, so the Herbie 2.3
+  team was on the smaller side. Yet this is one of the bigger
+  releases! It's not clear, that this rate of development will
+  continue; we have picked much of the low-hanging fruit. But we are
+  excited to see agents improve and, in turn, improve Herbie.</p>
 
   <h2>Try it out!</h2>
 

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -41,75 +41,63 @@
 
   <h2>Improving the Core</h2>
 
-  <figure class="showcase side-by-side">
-    <pre>(sin (fabs x))
-
-Taylor series around x = 0:
-
-fabs(x) * (1
-  - fabs(x)^2 / 6
-  + fabs(x)^4 / 120
-  - fabs(x)^6 / 5040
-  + ...)</pre>
-    <figcaption>
-      Herbie's Taylor engine factors out <code>fabs(x)</code> and expands
-      the remaining terms as a series in <code>fabs(x)^2</code>. This
-      representation handles the nondifferentiability of <code>fabs</code>
-      at zero while still exposing the useful series structure.
-    </figcaption>
-  </figure>
-
-  <p>Taylor expansion has also been substantially reworked. Herbie can now
-  recognize and construct more useful series, including expansions involving
-  binary inputs, odd powers, fractional powers, and functions such as
-  <code>fabs</code>. It is better at both caching duplicate work and
-  skipping unnecessary work. We also added extensive observability
-  tooling to the Taylor series pass, giving us the confidence to
-  significantly reduce tuning parameters. Taylor-series runtime is
-  thus dramatically reduced.</p>
-
-  <p>Several aspects of the Herbie "main loop" were redesigned. Most
-  significantly, the "alt picking" system was entirely removed. This
-  moderately increases runtime but also produces better-quality
-  results and removes a hard-to-tune hyperparameter from Herbie,
-  making the compilation pipeline easier to understand.</p>
-  
-  <p>The core "patching" loop was also broken out into a separate
-  phase, called "reconstruction", and that phase was extensively
-  rewritten to build reachability maps that speed up patching itself.
-  Reconstruction also now incorporates observable equivalence
-  reasoning, allowing Herbie to quickly discard identical candidate
-  programs. As a result, Herbie can search through significantly more
-  candidate programs, finding higher-quality results, without taking
-  more time.</p>
-
-  <h2>Faster and More Scalable</h2>
-
   <figure class="showcase">
     <img width="100%" src="timeline-phase-comparison.svg"
       alt="Aggregate Herbie timeline phases for versions 2.2 and 2.3 across 563 common benchmarks." />
     <figcaption>
-      Across 563 common benchmarks, total time drops from 44.4 to 41.1
-      minutes. Garbage collection time drops dramatically, from 18.78 to
-      11.68 minutes, and most existing phases improve even as Herbie adds
-      a substantial new <code>reconstruct</code> phase that reflects the
-      much larger search space it can now explore.
+      Herbie 2.3 is roughly 7% faster than Herbie 2.2 across 563
+      common benchmarks. Garbage collection time drops dramatically,
+      from 18.78 to 11.68 minutes, and most other phases get somewhat
+      faster. The new <code>reconstruct</code> phase, light blue,
+      handles Herbie 2.3's much larger search space.
+    </figcaption>
+  </figure>
+
+  <p>Herbie's "alt picking" system was entirely removed. Instead of
+  selecting individual candidate programs to search more deeply,
+  Herbie now searches all candidate programs in parallel. This
+  increases runtime but also produces better-quality results and
+  removes a hard-to-tune hyperparameter from Herbie, making the
+  compilation pipeline easier to understand.</p>
+
+  <p>The core "patching" loop was also broken out into a separate
+  "reconstruction" phase to handle huge numbers of candidate programs
+  more efficiently. Reconstruction builds reachability maps and uses
+  observable equivalence to quickly discard identical candidate
+  programs. As a result, Herbie 2.3 searches through significantly
+  more candidate programs than Herbie 2.2, without a corresponding
+  increase in runtime.</p>
+
+  <p>Taylor expansion has also been substantially reworked. Herbie can
+  now recognize and construct series expansions involving odd powers,
+  fractional powers, and absolute values. It is better at both caching
+  duplicate work and skipping unnecessary work. We also significantly
+  reduced series expansion tuning parameters after confirming that
+  this would not change results. Series expansion is thus
+  significantly faster.</p>
+
+  <h2>Faster and More Scalable</h2>
+
+  <figure class="showcase side-by-side">
+    <pre></pre>
+    <figcaption>
+      
     </figcaption>
   </figure>
 
   <p><a href="../2.2/release-notes.html">Herbie 2.2</a> introduced the
-  "batch" data structure to store multiple candidate programs with
-  shared subexpressions, and Herbie 2.3 extended that representation
-  to all of Herbie's internal subsystems, including evaluation,
-  rewriting, pruning, compilation, and report generation. Besides
-  improving compilation time, especially on the largest programs, this
-  also aligns Herbie with standard compiler practice, since batches
-  are effectively a type of SSA representation.</p>
+  "batch" data structure that shares subexpressions across related
+  programs, and Herbie 2.3 made it the common representation for all
+  of Herbie's internal subsystems, including evaluation, rewriting,
+  pruning, compilation, and report generation. Operations on batches
+  are cached, so Herbie can now reuse duplicate computations across
+  similar programs.</p>
 
-  <p>Other subsystems leveraged this change to introduce new, standard
-  algorithms, including Lengauer-Tarjan for branch expressions and a
-  more complex dynamic programming formulation of regime
-  inference.</p>
+  <p>Other subsystems leveraged this change to introduce new,
+  including Lengauer-Tarjan for branch expressions and a more complex
+  dynamic program for regime inference that replaces multiple calls
+  with a single exact solve. These algorithms are not only faster but
+  have superior asymptotics, which helps Herbie scale.</p>
 
   <h2>More Capable Platforms and Backends</h2>
 
@@ -120,9 +108,11 @@ fabs(x) * (1
 %3 = (ref %1 1)        ; cos(x)
 %4 = (+ %2 %3)</pre>
     <figcaption>
-      A platform-specific <code>sincos</code> operation can provide both
-      sine and cosine to later computations. The faux-SSA form makes the
-      shared intermediate value explicit.
+      Herbie's new arrays feature can model the <code>sincos</code>
+      operation, which computes both sine and cosine in a single call.
+      <code>%1</code> stores an array and later <code>ref</code>
+      operations extract its entries. The final result is equal
+      to <code>sin(x) + cos(x)</code>, but computed faster.
     </figcaption>
   </figure>
 

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -49,7 +49,9 @@
       common benchmarks. Garbage collection time drops dramatically,
       from 18.78 to 11.68 minutes, and most other phases get somewhat
       faster. The new <code>reconstruct</code> phase, light blue,
-      handles Herbie 2.3's much larger search space.
+      handles Herbie 2.3's much larger search space. That larger
+      search space results in programs roughly 9% better&mdash;faster
+      or higher accuracy&mdash;than Herbie 2.2.
     </figcaption>
   </figure>
 
@@ -79,9 +81,14 @@
   <h2>Faster and More Scalable</h2>
 
   <figure class="showcase side-by-side">
-    <pre></pre>
+    <img width="100%" src="regime-dominators.svg"
+      alt="SSA expression graph and Lengauer-Tarjan dominator tree for exp(a*x) - 1; a*x dominates both a and x." />
     <figcaption>
-      
+      Herbie's internal representation of <code>exp(a*x) - 1</code>.
+      Next to it, the Lengauer-Tarjan dominator tree used by regime
+      inference in Herbie 2.3, which identifies <code>%2</code>, or
+      <code>a*x</code>, as a branch expression containing all uses of
+      the <code>a</code> and <code>x</code> variables.
     </figcaption>
   </figure>
 
@@ -93,8 +100,8 @@
   are cached, so Herbie can now reuse duplicate computations across
   similar programs.</p>
 
-  <p>Other subsystems leveraged this change to introduce new,
-  including Lengauer-Tarjan for branch expressions and a more complex
+  <p>Other subsystems leveraged this change to introduce new algorithms,
+    including Lengauer-Tarjan for branch expressions and a more complex
   dynamic program for regime inference that replaces multiple calls
   with a single exact solve. These algorithms are not only faster but
   have superior asymptotics, which helps Herbie scale.</p>

--- a/www/doc/2.3/release-notes.html
+++ b/www/doc/2.3/release-notes.html
@@ -41,6 +41,24 @@
 
   <h2>Improving the Core</h2>
 
+  <figure class="showcase side-by-side">
+    <pre>(sin (fabs x))
+
+Taylor series around x = 0:
+
+fabs(x) * (1
+  - fabs(x)^2 / 6
+  + fabs(x)^4 / 120
+  - fabs(x)^6 / 5040
+  + ...)</pre>
+    <figcaption>
+      Herbie's Taylor engine factors out <code>fabs(x)</code> and expands
+      the remaining terms as a series in <code>fabs(x)^2</code>. This
+      representation handles the nondifferentiability of <code>fabs</code>
+      at zero while still exposing the useful series structure.
+    </figcaption>
+  </figure>
+
   <p>Taylor expansion has also been substantially reworked. Herbie can now
   recognize and construct more useful series, including expansions involving
   binary inputs, odd powers, fractional powers, and functions such as
@@ -67,19 +85,15 @@
 
   <h2>Faster and More Scalable</h2>
 
-  <figure class="showcase side-by-side">
-    <pre>%0 = x
-%1 = (literal 1)
-%2 = (+ %0 %1)
-%3 = (* %2 %2)
-%4 = (- %3 %1)</pre>
+  <figure class="showcase">
+    <img width="100%" src="timeline-phase-comparison.svg"
+      alt="Aggregate Herbie timeline phases for versions 2.2 and 2.3 across 563 common benchmarks." />
     <figcaption>
-      Herbie's "batch" data structure stores an SSA-style sequence of
-      instructions. It can represent one <em>or more</em>
-      programs, and those programs can share common subexpressions
-      among them. Rewrites, analyses, and other operations on batches
-      are cached, which is especially valuable when thousands of
-      programs reuse a small number of common instructions.
+      Across 563 common benchmarks, total time drops from 44.4 to 41.1
+      minutes. Garbage collection time drops dramatically, from 18.78 to
+      11.68 minutes, and most existing phases improve even as Herbie adds
+      a substantial new <code>reconstruct</code> phase that reflects the
+      much larger search space it can now explore.
     </figcaption>
   </figure>
 
@@ -98,6 +112,19 @@
   inference.</p>
 
   <h2>More Capable Platforms and Backends</h2>
+
+  <figure class="showcase">
+    <pre>%0 = x
+%1 = (sincos %0)       ; [sin(x), cos(x)]
+%2 = (ref %1 0)        ; sin(x)
+%3 = (ref %1 1)        ; cos(x)
+%4 = (+ %2 %3)</pre>
+    <figcaption>
+      A platform-specific <code>sincos</code> operation can provide both
+      sine and cosine to later computations. The faux-SSA form makes the
+      shared intermediate value explicit.
+    </figcaption>
+  </figure>
 
   <p>Herbie's <a href="platforms.html">platforms API</a> allows Herbie
   to tailor its results for a specific language and hardware platform.

--- a/www/doc/2.3/timeline-phase-comparison.svg
+++ b/www/doc/2.3/timeline-phase-comparison.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1030" height="250" viewBox="0 0 1030 250" role="img" aria-labelledby="title desc">
+  <title id="title">Herbie timeline phase totals: 2.2 versus 2.3</title>
+  <desc id="desc">Horizontal stacked bars compare aggregate phase minutes over 563 common benchmarks. The 2.2 bar totals 44.4 minutes and the 2.3 bar totals 41.1 minutes. GC is shown as its own phase in both bars.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #333; }
+    .bar-label { font-size: 16px; font-weight: 600; }
+    .total { font-size: 15px; fill: #555; }
+  </style>
+
+  <rect x="64" y="64" width="900" height="54" rx="4" fill="#f1f1f1"/>
+  <rect x="64" y="154" width="900" height="54" rx="4" fill="#f1f1f1"/>
+
+  <text x="24" y="96" class="bar-label">2.2</text>
+  <text x="24" y="186" class="bar-label">2.3</text>
+
+  <!-- 2.2: GC extracted from each phase before stacking. -->
+  <g aria-label="2.2 phase totals">
+    <rect x="64" y="64" width="375.62" height="54" fill="#888a85"><title>gc: 18.78 min</title></rect>
+    <rect x="439.62" y="64" width="197.47" height="54" fill="#edd400"><title>sample: 9.87 min</title></rect>
+    <rect x="637.08" y="64" width="91.99" height="54" fill="#4e9a06"><title>rewrite: 4.60 min</title></rect>
+    <rect x="729.08" y="64" width="47.03" height="54" fill="#204a87"><title>eval: 2.35 min</title></rect>
+    <rect x="776.11" y="64" width="48.19" height="54" fill="#ad7fa8"><title>series: 2.41 min</title></rect>
+    <rect x="824.29" y="64" width="49.22" height="54" fill="#a40000"><title>regimes: 2.46 min</title></rect>
+    <rect x="873.51" y="64" width="17.15" height="54" fill="#8ae234"><title>derivations: 0.86 min</title></rect>
+    <rect x="890.67" y="64" width="15.64" height="54" fill="#5c3566"><title>preprocess: 0.78 min</title></rect>
+    <rect x="906.31" y="64" width="18.79" height="54" fill="#3465a4"><title>prune: 0.94 min</title></rect>
+    <rect x="925.10" y="64" width="15.78" height="54" fill="#fce94f"><title>analyze: 0.79 min</title></rect>
+    <rect x="940.88" y="64" width="10.04" height="54" fill="#cc0000"><title>bsearch: 0.50 min</title></rect>
+    <rect x="950.91" y="64" width="0.02" height="54" fill="#666"><title>start: 0.00 min</title></rect>
+  </g>
+
+  <!-- 2.3: restricted to the same 563 benchmark names. -->
+  <g aria-label="2.3 phase totals">
+    <rect x="64" y="154" width="233.69" height="54" fill="#888a85"><title>gc: 11.68 min</title></rect>
+    <rect x="297.69" y="154" width="163.76" height="54" fill="#edd400"><title>sample: 8.19 min</title></rect>
+    <rect x="461.45" y="154" width="78.70" height="54" fill="#4e9a06"><title>rewrite: 3.93 min</title></rect>
+    <rect x="540.14" y="154" width="51.89" height="54" fill="#204a87"><title>eval: 2.59 min</title></rect>
+    <rect x="592.04" y="154" width="145.68" height="54" fill="#729fcf"><title>reconstruct: 7.28 min</title></rect>
+    <rect x="737.71" y="154" width="36.85" height="54" fill="#ad7fa8"><title>series: 1.84 min</title></rect>
+    <rect x="774.56" y="154" width="40.71" height="54" fill="#a40000"><title>regimes: 2.04 min</title></rect>
+    <rect x="815.28" y="154" width="23.96" height="54" fill="#8ae234"><title>derivations: 1.20 min</title></rect>
+    <rect x="839.23" y="154" width="16.14" height="54" fill="#5c3566"><title>preprocess: 0.81 min</title></rect>
+    <rect x="855.37" y="154" width="13.76" height="54" fill="#3465a4"><title>prune: 0.69 min</title></rect>
+    <rect x="869.13" y="154" width="7.48" height="54" fill="#fce94f"><title>analyze: 0.37 min</title></rect>
+    <rect x="876.61" y="154" width="8.72" height="54" fill="#cc0000"><title>bsearch: 0.44 min</title></rect>
+    <rect x="885.33" y="154" width="0.01" height="54" fill="#666"><title>start: 0.00 min</title></rect>
+    <rect x="885.34" y="154" width="0.00" height="54" fill="#666"><title>end: 0.00 min</title></rect>
+  </g>
+
+  <text x="980" y="96" text-anchor="start" class="total">44.4</text>
+  <text x="980" y="186" text-anchor="start" class="total">41.1</text>
+</svg>

--- a/www/main.css
+++ b/www/main.css
@@ -17,9 +17,14 @@ p, li, dd, blockquote, figcaption, summary {
 }
 dd { margin: .5em 0 1em; }
 
-.showcase { background: #ddd; padding: 1em; margin: 4em 0; clear: both;}
-.showcase > h2 { margin: 0 0 1em; }
-.showcase figcaption {font-size: 15px; line-height: 1.4; margin-top: 1em;}
+.showcase {
+  display: flex; flex-direction: column; gap: 1em;
+  background: #ddd; padding: 1em; margin: 4em 0; clear: both;
+}
+.showcase > h2 { margin: 0; }
+.showcase figcaption {font-size: 15px; line-height: 1.4; margin: 0;}
+.showcase.side-by-side { flex-direction: row; }
+.showcase.side-by-side figcaption { padding-left: 1em; }
 .showcase img { width: 100%; }
 .before-after { font-size: 20px; text-align: center; line-height: 1.5; }
 .before-after code { padding: 0 1ex; font-weight: bold; }


### PR DESCRIPTION
Herbie 2.3 is coming up, and this PR adds release notes, covering:

- Work on the core, especially the reconstruction phase and removing alt picking
- Work on performance, especially batchification of everything in sight
- Work on arrays, Rival 3, egglog

A great year of Herbie! Congrats all!