### PR TITLE
Install egglog with --locked and a pinned commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ egg-herbie:
 	raco pkg install ./egg-herbie
 
 egglog-herbie:
-	cargo install --git "https://github.com/egraphs-good/egglog-experimental" --branch main egglog-experimental
+	cargo install --locked --git "https://github.com/egraphs-good/egglog-experimental" --rev 6525a4867ae433a92f44ba09a9c70c85d6feeb5f egglog-experimental
 
 distribution: minimal-distribution
 	cp -r bench herbie-compiled/


### PR DESCRIPTION
## Problem

`make install` (the `egglog-herbie` target) ran:

```
cargo install --git .../egglog-experimental --branch main egglog-experimental
```

`cargo install` **ignores the checked-in `Cargo.lock` unless `--locked` is passed**, so every CI run re-resolved egglog-experimental's whole dependency tree to the newest compatible versions. One such re-resolution just broke us:

- egglog's `add_primitive` proc macro parses full Rust expressions and needs `syn`'s `full` feature.
- It never declared `full`; it only got it because `clap_derive` (via egglog's `bin` feature) asked for `syn` **with** `full` on the *same* `syn 2.x` (Cargo feature unification).
- `clap_derive` 4.6 bumped to **`syn 3.x`**, so its `full` now lands on syn 3 and egglog's `syn 2.x` lost it, giving dozens of `error: unsupported expression; enable syn's features=["full"]`.

(Failing run: #1627. This also affects `infra/nightly.sh`, which runs `make install`.)

## Fix

```
cargo install --locked --git .../egglog-experimental --rev <sha> egglog-experimental
```

- **`--locked`** → honor egglog-experimental's committed, tested lockfile instead of re-resolving. *This is the part that fixes the break.*
- **`--rev <sha>`** → pin an exact commit instead of floating `--branch main`, so the egglog version only moves when we deliberately bump the pin (good practice for reproducibility). Note: pinning the rev *without* `--locked` would **not** fix the bug, since `cargo install` would still re-resolve transitive deps.

Verified locally: the old command reproduces the failure; this one installs cleanly.

## Other install sites checked

- `.github/workflows/unit-test.yml` and `infra/nightly.sh` both install egglog via `make install`, so they inherit this fix. ✅
- `Dockerfile:11` is **separate and stale**: `cargo install egglog --version 1.0.0` installs the old `egglog` 1.0.0 from crates.io (the fallback binary in `egglog-subprocess.rkt`), not `egglog-experimental` 2.0.0. Left untouched here — flagging for a follow-up to reconcile the production image with the current egglog.

## Upstream follow-ups (companion PRs)

- egraphs-good/egglog#961 — `add_primitive` declares `syn`'s `full` feature (the actual root-cause fix) + a `--no-default-features` CI guard.
- egraphs-good/egglog-experimental#58 — a `latest-deps` CI job reproducing the lock-ignoring `cargo install` resolution so drift is caught upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)