### PR TITLE
Pin egglog-experimental commit + --locked (alternative to #1628)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ egg-herbie:
 	raco pkg install ./egg-herbie
 
 egglog-herbie:
-	cargo install --git "https://github.com/egraphs-good/egglog-experimental" --branch main egglog-experimental
+	cargo install --locked --git "https://github.com/egraphs-good/egglog-experimental" --rev 6525a4867ae433a92f44ba09a9c70c85d6feeb5f egglog-experimental
 
 distribution: minimal-distribution
 	cp -r bench herbie-compiled/


### PR DESCRIPTION
**Alternative to #1628 — pick one.**

Same root cause as #1628 (see there for the full write-up: `cargo install` ignores the lockfile and re-resolves, and `clap_derive` 4.6 → `syn 3.x` dropped the `syn/full` feature egglog was relying on).

This variant goes further than #1628 for full reproducibility:

```
cargo install --locked --git .../egglog-experimental --rev <sha> egglog-experimental
```

- `--locked` → honor egglog-experimental's committed `Cargo.lock` instead of re-resolving (fixes the break).
- `--rev <sha>` → stop floating on `--branch main`, so the egglog version only changes when we deliberately bump the pin.

Trade-off vs #1628: reproducible and immune to both upstream main moving *and* dependency drift, but requires a manual rev bump to pick up egglog updates. #1628 (just `--locked`, keep `--branch main`) still auto-follows main.

Note: pinning the rev **without** `--locked` would *not* fix the bug — `cargo install` would still re-resolve transitive deps. `--locked` is the load-bearing part; the rev pin is for reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)