### PR TITLE
Split spec and impl branches entirely

### DIFF
--- a/src/core/alternative.rkt
+++ b/src/core/alternative.rkt
@@ -28,8 +28,9 @@
   (f (struct-copy alt altn [prevs (map (curry alt-map f) (alt-prevs altn))])))
 
 ;; Converts batchrefs of altns into expressions, assuming that batchrefs refer to batch
-(define (unbatchify-alts batch altns)
-  (define exprs (batch-exprs batch))
+(define (unbatchify-alts batch altns spec-batch)
+  (define spec-f (batch-exprs spec-batch))
+  (define exprs (batch-exprs batch #:spec-f spec-f))
   (define (unmunge-event event)
     (match event
       [(list 'evaluate (? batchref? start-expr)) (list 'evaluate (exprs start-expr))]

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -183,8 +183,9 @@
     (raise-user-error
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
-  (define spec-brfs (batch-to-spec! batch* batch* (list start-prog-sub)))
-  (define start-real-compiler (make-real-compiler batch* spec-brfs (list repr)))
+  (define spec-batch (batch-empty (context (batch-vars batch*) #f (batch-var-reprs batch*))))
+  (define spec-brfs (batch-to-spec! batch* spec-batch (list start-prog-sub)))
+  (define start-real-compiler (make-real-compiler spec-batch spec-brfs (list repr)))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -65,7 +65,7 @@
 
 (define (batch-tree-size batch brfs)
   (define (tree-size brf recurse)
-    (define args (reap [sow] (expr-recurse-impl (deref brf) sow)))
+    (define args (reap [sow] (expr-recurse (deref brf) sow)))
     (apply + 1 (map recurse args)))
   (apply + (map (batch-recurse batch tree-size) brfs)))
 

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -5,16 +5,23 @@
          "../syntax/platform.rkt"
          "programs.rkt"
          "egg-herbie.rkt"
-         "../config.rkt")
+         "../config.rkt"
+         "../syntax/syntax.rkt")
 
 (provide add-derivations)
 
-(define (canonicalize-proof batch prog-brf proof start-brf)
+(define (copy-proof-specs spec-batch expr)
+  (match expr
+    [(approx spec impl) (approx (batch-add! spec-batch spec) (copy-proof-specs spec-batch impl))]
+    [(list op args ...) (cons op (map (curry copy-proof-specs spec-batch) args))]
+    [_ expr]))
+
+(define (canonicalize-proof batch spec-batch prog-brf proof start-brf)
   ;; Proofs are on subexpressions; lift to full expression
   ;; Returns a list of batchrefs instead of expressions
   (and proof
        (for/list ([step (in-list proof)])
-         (define step-brf (batch-add! batch step))
+         (define step-brf (batch-add! batch (copy-proof-specs spec-batch step)))
          (batch-replace-subexpr batch prog-brf start-brf step-brf))))
 
 ;; Adds proof information to alternatives.
@@ -30,7 +37,7 @@
        (apply values (batch-to-spec! batch spec-batch (list start-brf end-brf))))
      (define proof
        (and (not (flag-set? 'generate 'egglog)) (egraph-prove runner proof-start proof-end)))
-     (define proof* (canonicalize-proof batch (alt-expr altn) proof start-brf))
+     (define proof* (canonicalize-proof batch spec-batch (alt-expr altn) proof start-brf))
      (alt expr `(rr ,start-brf ,end-brf ,runner ,proof*) (list prev))]
 
     ; everything else

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -24,9 +24,10 @@
     ; recursive rewrite or simplify, both using egg
     ; start-brf and end-brf are batchrefs for the subexpressions that were transformed
     [(alt expr (list 'rr start-brf end-brf (? egg-runner? runner) #f) `(,prev))
-     (define batch (egg-runner-batch runner))
+     (define batch (batchref-batch expr))
+     (define spec-batch (egg-runner-batch runner))
      (define-values (proof-start proof-end)
-       (apply values (batch-to-spec! batch batch (list start-brf end-brf))))
+       (apply values (batch-to-spec! batch spec-batch (list start-brf end-brf))))
      (define proof
        (and (not (flag-set? 'generate 'egglog)) (egraph-prove runner proof-start proof-end)))
      (define proof* (canonicalize-proof batch (alt-expr altn) proof start-brf))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -46,8 +46,11 @@
 (define (run-improve! initial specification context pcontext)
   (parameterize ([*global-batch* (batch-empty context)])
     (define global-spec-batch (batch-empty context))
-    (define initial-brf (batch-add! (*global-batch*) initial))
     (define specification-brf (batch-add! global-spec-batch specification))
+    (define initial-brf
+      (match initial
+        [(approx _ impl) (batch-add! (*global-batch*) (approx specification-brf impl))]
+        [_ (batch-add! (*global-batch*) initial)]))
     (timeline-event! 'preprocess)
     (define preprocessing
       (if (flag-set? 'setup 'preprocess)

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -67,21 +67,21 @@
     (for ([_ (in-range (*num-iterations*))]
           #:break (atab-completed? (^table^)))
       (run-iteration! global-spec-batch spec-reducer))
-    (define alternatives (extract!))
+    (define alternatives (extract! global-spec-batch))
     (timeline-event! 'preprocess)
     (for/list ([altn alternatives])
       (define expr (alt-expr altn))
       (define expr* (compile-useful-preprocessing expr context pcontext (*preprocessing*)))
       (alt expr* 'add-preprocessing (list altn)))))
 
-(define (extract!)
-  (timeline-push-alts! '())
+(define (extract! spec-batch)
+  (timeline-push-alts! '() spec-batch)
   (define all-alts (atab-all-alts (^table^)))
-  (define joined-alts (make-regime! (*global-batch*) all-alts (*start-brf*)))
+  (define joined-alts (make-regime! (*global-batch*) all-alts (*start-brf*) spec-batch))
   (define annotated-alts (add-derivations! joined-alts))
   (define scores (batch-errors (*global-batch*) (map alt-expr annotated-alts) (*pcontext*)))
   (define sorted-alts (map car (sort-alts (*global-batch*) annotated-alts scores)))
-  (define unbatched-alts (unbatchify-alts (*global-batch*) sorted-alts))
+  (define unbatched-alts (unbatchify-alts (*global-batch*) sorted-alts spec-batch))
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
   unbatched-alts)
 
@@ -89,7 +89,7 @@
 ;; Herbie. These often wrap other Herbie components, but add logging
 ;; and timeline data.
 
-(define (dump-intermediates! batch altns)
+(define (dump-intermediates! batch altns spec-batch)
   (define dump-dir "dump-intermediates")
   (unless (directory-exists? dump-dir)
     (make-directory dump-dir))
@@ -97,7 +97,8 @@
     (for/first ([i (in-naturals)]
                 #:unless (file-exists? (build-path dump-dir (format "~a.rktd" i))))
       (build-path dump-dir (format "~a.rktd" i))))
-  (define exprs (batch-exprs batch))
+  (define spec-f (batch-exprs spec-batch))
+  (define exprs (batch-exprs batch #:spec-f spec-f))
   (call-with-output-file name
                          #:exists 'replace
                          (lambda (out)
@@ -107,11 +108,11 @@
 (define (batch-score-alts altns)
   (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*))))
 
-(define (timeline-push-alts! next-alts)
+(define (timeline-push-alts! next-alts spec-batch)
   (define pending-alts (atab-not-done-alts (^table^)))
   (define active-alts (atab-active-alts (^table^)))
   (define scores (batch-score-alts active-alts))
-  (define batch-jsexpr (batch->jsexpr (*global-batch*) (map alt-expr active-alts)))
+  (define batch-jsexpr (batch->jsexpr (*global-batch*) spec-batch (map alt-expr active-alts)))
   (define roots (hash-ref batch-jsexpr 'roots))
   (define repr (context-repr (*context*)))
   (timeline-push! 'batch batch-jsexpr)
@@ -198,11 +199,11 @@
   (define parents (make-vector (batch-length batch) '()))
   (define (walk-body brf recurse)
     (define idx (batchref-idx brf))
-    (expr-recurse-impl (deref brf)
-                       (lambda (child)
-                         (define child-idx (batchref-idx child))
-                         (vector-set! parents child-idx (cons idx (vector-ref parents child-idx)))
-                         (recurse child)))
+    (expr-recurse (deref brf)
+                  (lambda (child)
+                    (define child-idx (batchref-idx child))
+                    (vector-set! parents child-idx (cons idx (vector-ref parents child-idx)))
+                    (recurse child)))
     (void))
   (for-each (batch-recurse batch walk-body) (map alt-expr starting-alts))
   (define new-alts* (group-equivalent-alts new-alts))
@@ -219,9 +220,9 @@
    #:key (compose batchref-idx alt-expr)))
 
 ;; Finish iteration
-(define (finalize-iter! picked-alts patched)
+(define (finalize-iter! picked-alts patched spec-batch)
   (when (flag-set? 'dump 'intermediates)
-    (dump-intermediates! (*global-batch*) patched))
+    (dump-intermediates! (*global-batch*) patched spec-batch))
   (timeline-event! 'eval)
   (define orig-all-alts (atab-active-alts (^table^)))
   (define orig-fresh-alts (atab-not-done-alts (^table^)))
@@ -266,7 +267,7 @@
 
 (define (run-iteration! global-spec-batch spec-reducer)
   (define pending-alts (atab-not-done-alts (^table^)))
-  (timeline-push-alts! pending-alts)
+  (timeline-push-alts! pending-alts global-spec-batch)
   (^table^ (atab-set-picked (^table^) pending-alts))
 
   (define brfs (map alt-expr pending-alts))
@@ -274,10 +275,10 @@
 
   (define results (generate-candidates (*global-batch*) brfs* global-spec-batch spec-reducer))
   (define patched (reconstruct! pending-alts results))
-  (finalize-iter! pending-alts patched)
+  (finalize-iter! pending-alts patched global-spec-batch)
   (void))
 
-(define (make-regime! batch alts start-prog)
+(define (make-regime! batch alts start-prog spec-batch)
   (define repr (batch-repr-of start-prog))
   (define alt-costs (alt-batch-costs batch))
 
@@ -292,7 +293,8 @@
        (pareto-regimes batch
                        (sort alts < #:key (compose alt-costs alt-expr))
                        start-prog
-                       (*pcontext*)))
+                       (*pcontext*)
+                       spec-batch))
      (for/list ([opt (in-list opts)])
        (match-define (option splitindices opt-alts _ brf) opt)
        (timeline-event! 'bsearch)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -42,12 +42,8 @@
   (define reprs (map batch-repr-of brfs))
   ;; Specs
   (define spec-brfs
-    (batch-to-spec! global-batch global-batch brfs)) ;; These specs will go into (approx spec impl)
-  (define free-vars (map (batch-free-vars global-batch) spec-brfs))
-  (define spec-brfs*
-    (map (batch-copy-only! spec-batch global-batch)
-         spec-brfs)) ;; copy from global-batch to spec-batch
-  (define copier (batch-copy-only! global-batch spec-batch)) ;; copy from spec-batch to global-batch
+    (map (batch-copy-only! spec-batch global-batch) (batch-to-spec! global-batch global-batch brfs)))
+  (define free-vars (map (batch-free-vars spec-batch) spec-brfs))
 
   (reap [sow]
         (parameterize ([reduce reducer] ;; reduces over spec-batch
@@ -57,12 +53,12 @@
                 [repr (in-list reprs)]
                 [altn (in-list altns)]
                 #:when (equal? (representation-type repr) 'real))
-            (define genexpr0 (batch-add! global-batch 0))
+            (define genexpr0 (batch-add! spec-batch 0))
             (sow (taylor-approx spec-brf repr genexpr0 'zero 'undef-var -1 altn)))
 
           ;; Taylor expansions
           ;; List<List<(cons offset coeffs)>>
-          (define taylor-coeffs (taylor-coefficients spec-batch spec-brfs* vars transforms-to-try))
+          (define taylor-coeffs (taylor-coefficients spec-batch spec-brfs vars transforms-to-try))
           (define idx 0)
           (for* ([var (in-list vars)]
                  [transform-type transforms-to-try])
@@ -77,9 +73,7 @@
                   [fv (in-list free-vars)]
                   #:when (set-member? fv var)) ;; check whether var exists in expr at all
               (for ([i (in-range (*taylor-order-limit*))])
-                ;; adding a new expansion to the global batch
-                (define genexpr-brf (copier (genexpr)))
-                (sow (taylor-approx spec-brf repr genexpr-brf name var i altn))))
+                (sow (taylor-approx spec-brf repr (genexpr) name var i altn))))
             (set! idx (add1 idx))
             (timeline-stop!)))))
 
@@ -92,14 +86,15 @@
 
   (define approxs
     (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key taylor-key))
-  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key approx-key))
+  (define approxs*
+    (remove-duplicates (run-lowering approxs global-batch spec-batch) #:key approx-key))
 
   (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
   (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
   (timeline-push! 'count (length altns) (length approxs*))
   approxs*)
 
-(define (run-lowering taylors global-batch)
+(define (run-lowering taylors global-batch spec-batch)
   (define schedule '(lower))
 
   ; run egg
@@ -116,9 +111,8 @@
 
   (define runner
     (cond
-      [(flag-set? 'generate 'egglog)
-       (make-egglog-runner global-batch impl-specs schedule (*context*))]
-      [else (make-egraph global-batch impl-specs schedule (*context*))]))
+      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-batch impl-specs schedule (*context*))]
+      [else (make-egraph spec-batch impl-specs schedule (*context*))]))
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
@@ -126,6 +120,7 @@
         (egraph-best runner global-batch reprs)))
 
   ; apply changelists
+  (define copy-spec-to-global (batch-copy-only! global-batch spec-batch))
   (reap [sow]
         (for ([batchrefs (in-list batchrefss)]
               [spec (in-list specs)]
@@ -134,7 +129,7 @@
               [order (in-list orders)]
               [prev (in-list prevs)])
           (for ([batchref* (in-list batchrefs)])
-            (define brf (batch-add! global-batch (approx spec batchref*)))
+            (define brf (batch-add! global-batch (approx (copy-spec-to-global spec) batchref*)))
             (define taylor-altn (alt brf `(taylor ,name ,var ,order) (list prev)))
             (sow (alt brf (list 'rr runner #f) (list taylor-altn)))))))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -41,8 +41,7 @@
   (define brfs (map alt-expr altns))
   (define reprs (map batch-repr-of brfs))
   ;; Specs
-  (define spec-brfs
-    (map (batch-copy-only! spec-batch global-batch) (batch-to-spec! global-batch global-batch brfs)))
+  (define spec-brfs (batch-to-spec! global-batch spec-batch brfs))
   (define free-vars (map (batch-free-vars spec-batch) spec-brfs))
 
   (reap [sow]
@@ -88,9 +87,8 @@
     (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key taylor-key))
   (define approxs*
     (remove-duplicates (run-lowering approxs global-batch spec-batch) #:key approx-key))
-
-  (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
-  (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
+  (timeline-push! 'inputs (batch->jsexpr global-batch spec-batch (map alt-expr altns)))
+  (timeline-push! 'outputs (batch->jsexpr global-batch spec-batch (map alt-expr approxs*)))
   (timeline-push! 'count (length altns) (length approxs*))
   approxs*)
 
@@ -120,7 +118,6 @@
         (egraph-best runner global-batch reprs)))
 
   ; apply changelists
-  (define copy-spec-to-global (batch-copy-only! global-batch spec-batch))
   (reap [sow]
         (for ([batchrefs (in-list batchrefss)]
               [spec (in-list specs)]
@@ -129,25 +126,25 @@
               [order (in-list orders)]
               [prev (in-list prevs)])
           (for ([batchref* (in-list batchrefs)])
-            (define brf (batch-add! global-batch (approx (copy-spec-to-global spec) batchref*)))
+            (define brf (batch-add! global-batch (approx spec batchref*)))
             (define taylor-altn (alt brf `(taylor ,name ,var ,order) (list prev)))
             (sow (alt brf (list 'rr runner #f) (list taylor-altn)))))))
 
-(define (run-evaluate altns global-batch)
+(define (run-evaluate altns global-batch spec-batch)
   (timeline-event! 'sample)
   (define all-brfs (map alt-expr altns))
-  (define global-spec-brfs (batch-to-spec! global-batch global-batch all-brfs))
+  (define spec-brfs (batch-to-spec! global-batch spec-batch all-brfs))
   (define constant-batch (batch-empty (context '() #f '())))
-  (define copy-constant (batch-copy-only! constant-batch global-batch))
-  (define spec-brfs (map copy-constant global-spec-brfs))
+  (define copy-constant (batch-copy-only! constant-batch spec-batch))
+  (define constant-brfs (map copy-constant spec-brfs))
   (define free-vars (batch-free-vars constant-batch))
   (define real-pairs
     (for/list ([altn (in-list altns)]
-               [spec-brf (in-list spec-brfs)]
-               #:when (set-empty? (free-vars spec-brf))
+               [constant-brf (in-list constant-brfs)]
+               #:when (set-empty? (free-vars constant-brf))
                #:unless (literal? (deref (alt-expr altn)))
                #:when (equal? (representation-type (batch-repr-of (alt-expr altn))) 'real))
-      (cons altn spec-brf)))
+      (cons altn constant-brf)))
   (define real-altns (map car real-pairs))
   (define real-spec-brfs (map cdr real-pairs))
 
@@ -174,25 +171,25 @@
       (define brf (batch-add! global-batch literal))
       (alt brf '(evaluate) (list altn))))
 
-  (timeline-push! 'inputs (batch->jsexpr constant-batch real-spec-brfs))
+  (timeline-push! 'inputs (batch->jsexpr constant-batch constant-batch real-spec-brfs))
   (timeline-push! 'outputs (map ~a literals))
   final-altns)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (run-rr altns global-batch)
+(define (run-rr altns global-batch spec-batch)
   (timeline-event! 'rewrite)
 
   ; egg schedule (4-phases for mathematical rewrites, sound-X removal, and implementation selection)
   (define schedule '(rewrite unsound lower))
 
   (define brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch global-batch brfs))
+  (define spec-brfs (batch-to-spec! global-batch spec-batch brfs))
   (define reprs (map batch-repr-of brfs))
   (define runner
     (cond
-      [(flag-set? 'generate 'egglog) (make-egglog-runner global-batch spec-brfs schedule (*context*))]
-      [else (make-egraph global-batch spec-brfs schedule (*context*))]))
+      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-batch spec-brfs schedule (*context*))]
+      [else (make-egraph spec-batch spec-brfs schedule (*context*))]))
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
@@ -207,8 +204,8 @@
             (for ([batchref* (in-list batchrefs)])
               (sow (alt batchref* (list 'rr runner #f) (list altn)))))))
 
-  (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
-  (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr rewritten)))
+  (timeline-push! 'inputs (batch->jsexpr global-batch spec-batch (map alt-expr altns)))
+  (timeline-push! 'outputs (batch->jsexpr global-batch spec-batch (map alt-expr rewritten)))
   (timeline-push! 'count (length altns) (length rewritten))
 
   rewritten)
@@ -228,7 +225,7 @@
 
   (define evaluations
     (if (flag-set? 'generate 'evaluate)
-        (run-evaluate start-altns batch)
+        (run-evaluate start-altns batch spec-batch)
         '()))
 
   ; Series expand
@@ -240,7 +237,7 @@
   ; Recursive rewrite
   (define rewritten
     (if (flag-set? 'generate 'rr)
-        (run-rr start-altns batch)
+        (run-rr start-altns batch spec-batch)
         '()))
 
   (remove-duplicates (append evaluations rewritten approximations)

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -226,7 +226,7 @@
                        (define impl* (loop impl))
                        (if (= (batchref-idx impl*) (batchref-idx impl))
                            brf
-                           (batch-push! batch (approx (batchref-idx spec) (batchref-idx impl*))))]
+                           (batch-push! batch (approx spec (batchref-idx impl*))))]
                       [node
                        (define unchanged? #t)
                        (define node*

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -45,7 +45,7 @@
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
 ;; CONSIDER: move start-prog and the "branch-brfs" computation into caller.
-(define (pareto-regimes batch sorted start-prog pcontext)
+(define (pareto-regimes batch sorted start-prog pcontext spec-batch)
   (timeline-event! 'regimes)
   (define alts-vec (list->vector sorted))
   (define alt-count (vector-length alts-vec))
@@ -62,7 +62,7 @@
   (define pts-vec (pcontext-points pcontext))
 
   ;; For timeline
-  (define batch-jsexpr (batch->jsexpr batch (append (map alt-expr sorted) branch-brfs)))
+  (define batch-jsexpr (batch->jsexpr batch spec-batch (append (map alt-expr sorted) branch-brfs)))
   (timeline-push! 'batch batch-jsexpr)
   (define branch-roots (drop (hash-ref batch-jsexpr 'roots) alt-count))
   (define branch-root-map (make-immutable-hash (map cons branch-brfs branch-roots)))
@@ -70,7 +70,7 @@
   (define option-curves
     (for/list ([brf (in-list branch-brfs)]
                [brf-vals-vec (in-list brf-vals)])
-      (define timeline-stop! (timeline-start! 'times (batch->jsexpr batch (list brf))))
+      (define timeline-stop! (timeline-start! 'times (batch->jsexpr batch spec-batch (list brf))))
       (define repr (batch-repr-of brf))
       (define curve (branch-options batch alts-vec err-cols pts-vec brf brf-vals-vec repr))
       (define last-point (last curve))
@@ -87,10 +87,11 @@
       (pareto-union curve branch-curve #:combine (lambda (old _new) old))))
 
   ;; Timeline
-  (timeline-push! 'inputs (batch->jsexpr batch (map alt-expr sorted)))
+  (timeline-push! 'inputs (batch->jsexpr batch spec-batch (map alt-expr sorted)))
   (timeline-push!
    'outputs
    (batch->jsexpr batch
+                  spec-batch
                   (remove-duplicates
                    (for*/list ([ppt (in-list combined-option-curve)]
                                [sidx (in-list (option-split-indices (pareto-point-data ppt)))])
@@ -132,7 +133,7 @@
                 (loop (dom-parent brf))))))))
 
 (define (build-dominator-tree batch root-brf)
-  (define reachable-brfs (reverse (batch-reachable/impl batch (list root-brf))))
+  (define reachable-brfs (reverse (batch-reachable batch (list root-brf))))
   (define dom-parents (make-vector (batch-length batch) #f))
   (define (dom-parent brf)
     (vector-ref dom-parents (batchref-idx brf)))
@@ -145,7 +146,7 @@
     (vector-set! dom-parents (batchref-idx child-brf) new-parent))
   (vector-set! dom-parents (batchref-idx root-brf) root-brf)
   (for ([brf (in-list reachable-brfs)])
-    (expr-recurse-impl (deref brf) (lambda (child) (update-child! brf child))))
+    (expr-recurse (deref brf) (lambda (child) (update-child! brf child))))
   dom-parent)
 
 (define (dominator-lca brf1 brf2 dom-parent)

--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -8,7 +8,7 @@
 (provide progs->batch ; List<Expr> -> (Batch, List<Batchref>)
 
          expr-recurse
-         expr-recurse-impl
+         expr-recurse-spec
          (struct-out batch)
          batch-empty ; Batch
          batch-empty-extend
@@ -19,7 +19,6 @@
          batch-free-vars ; Batch -> (Batchref -> Set<Var>)
          in-batch ; Batch -> Sequence<Node>
          batch-reachable ; Batch -> List<Batchref> -> (Node -> Boolean) -> List<Batchref>
-         batch-reachable/impl ; Batch -> List<Batchref> -> (Node -> Boolean) -> List<Batchref>
          batch-exprs
          batch-recurse
          batch->jsexpr
@@ -47,10 +46,10 @@
 (define (in-batch batch [start 0] [end #f] [step 1])
   (in-dvector (batch-nodes batch) start end step))
 
-;; This function defines the recursive structure of expressions
+;; This function recurses through implementation children of expressions.
 (define (expr-recurse expr f)
   (match expr
-    [(approx spec impl) (approx (f spec) (f impl))]
+    [(approx spec impl) (approx spec (f impl))]
     [(list op) (list op)]
     [(list op arg1) (list op (f arg1))]
     [(list op arg1 arg2) (list op (f arg1) (f arg2))]
@@ -58,10 +57,11 @@
     [(list op args ...) (cons op (map f args))]
     [_ expr]))
 
-(define (expr-recurse-impl expr f)
+;; This function recurses through the specification child of approximate expressions.
+(define (expr-recurse-spec f expr)
   (match expr
-    [(approx _ impl) (f impl)]
-    [_ (expr-recurse expr f)]))
+    [(approx spec impl) (approx (f spec) impl)]
+    [_ expr]))
 
 (define (batch-length b)
   (dvector-length (batch-nodes b)))
@@ -115,7 +115,7 @@
 
 ;; Function returns indices of children nodes within a batch for given roots,
 ;;   where a child node is a child of a root + meets a condition - (condition node)
-(define (batch-reachable* batch brfs recurse #:condition [condition (const #t)])
+(define (batch-reachable batch brfs #:condition [condition (const #t)])
   ; Little check
   (apply assert-batch-brf! batch brfs)
   (define len (batch-length batch))
@@ -127,7 +127,7 @@
         [child (in-vector child-mask (sub1 len) -1 -1)]
         #:when child)
     (cond
-      [(condition node) (recurse node (λ (n) (vector-set! child-mask n #t)))]
+      [(condition node) (expr-recurse node (λ (n) (vector-set! child-mask n #t)))]
       [else (vector-set! child-mask i #f)]))
   ; Return batchrefs of children nodes in ascending order
   (for/list ([child (in-vector child-mask)]
@@ -135,15 +135,11 @@
              #:when child)
     (batchref batch i)))
 
-(define (batch-reachable batch brfs #:condition [condition (const #t)])
-  (batch-reachable* batch brfs expr-recurse #:condition condition))
-
-(define (batch-reachable/impl batch brfs #:condition [condition (const #t)])
-  (batch-reachable* batch brfs expr-recurse-impl #:condition condition))
-
 ;; Function constructs a vector of expressions for the given nodes of a batch
-(define (batch-exprs batch)
-  (batch-recurse batch (lambda (brf recurse) (expr-recurse (deref brf) recurse))))
+(define (batch-exprs batch #:spec-f [spec-f void])
+  (batch-recurse batch
+                 (lambda (brf recurse)
+                   (expr-recurse-spec spec-f (expr-recurse (deref brf) recurse)))))
 
 ;; Function constructs a vector of expressions for the given nodes of a batch
 (define (batch-copy-only! batch batch*)
@@ -157,7 +153,6 @@
                    (define node (deref brf))
                    (cond
                      [(symbol? node) (set node)]
-                     [(approx? node) (recurse (approx-impl node))]
                      [else
                       (define arg-free-vars (mutable-set))
                       (expr-recurse node (lambda (i) (set-union! arg-free-vars (recurse i))))
@@ -166,10 +161,17 @@
 ;; Converts a batch + roots to a JSON-compatible structure
 ;; Returns: (hash 'nodes [...] 'roots [idx1 idx2 ...])
 ;; Nodes are: atoms (symbols->strings, numbers) or [op-string idx1 idx2 ...]
-(define (batch->jsexpr b brfs)
+(define (batch->jsexpr b spec-batch brfs)
   (define batch* (batch-empty (context (batch-vars b) #f (batch-var-reprs b))))
-  (define copy-f (batch-copy-only! batch* b))
-  (define brfs* (map copy-f brfs))
+  (for ([var (in-list (batch-vars b))])
+    (batch-push! batch* var))
+  (define (add-expr expr)
+    (batch-push! batch*
+                 (expr-recurse-spec (compose batchref-idx add-expr)
+                                    (expr-recurse expr (compose batchref-idx add-expr)))))
+  (define spec-f (batch-exprs spec-batch))
+  (define exprs (batch-exprs b #:spec-f spec-f))
+  (define brfs* (map add-expr (map exprs brfs)))
   (define nodes
     (for/list ([node (in-batch batch*)])
       (match node
@@ -251,9 +253,9 @@
 (module+ test
   (require rackunit)
   (define test-empty-ctx (context '() #f '()))
-  (define (test-munge-unmunge expr)
+  (define (test-munge-unmunge expr [expected expr] #:spec-f [spec-f (void)])
     (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
-    (check-equal? (list expr) (map (batch-exprs batch) brfs)))
+    (check-equal? (list expected) (map (batch-exprs batch #:spec-f spec-f) brfs)))
 
   (define (f64 x)
     (literal x 'binary64))
@@ -263,49 +265,68 @@
    '(+ 1 (neg (* 1/2 (+ (exp (/ (sin 3) (cos 3))) (/ 1 (exp (/ (sin 3) (cos 3)))))))))
   (test-munge-unmunge '(cbrt x))
   (test-munge-unmunge (list 'x))
-  (test-munge-unmunge `(+.f64 (sin.f64 ,(approx '(* 1/2 (+ (exp x) (neg (/ 1 (exp x)))))
-                                                '(+.f64 ,(f64 3)
-                                                        (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
-                              ,(f64 4))))
+  (define spec-expr '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))))
+  (define-values (spec-batch spec-brfs) (progs->batch (list spec-expr) #:ctx test-empty-ctx))
+  (define approx-expr
+    `(+.f64 (sin.f64 ,(approx (first spec-brfs)
+                              '(+.f64 ,(f64 3) (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
+            ,(f64 4)))
+  (define expected-approx
+    `(+.f64 (sin.f64 ,(approx spec-expr '(+.f64 ,(f64 3) (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
+            ,(f64 4)))
+  (test-munge-unmunge approx-expr expected-approx #:spec-f (batch-exprs spec-batch)))
 
 ; Tests for remove-zombie-nodes
 (module+ test
   (require rackunit)
-  (define (zombie-test #:nodes nodes #:roots roots)
-    (define in-batch (batch nodes (make-hash) '() '()))
+  (define (zombie-test #:specs [specs '()] #:nodes nodes #:expected expected #:roots roots)
+    (define spec-batch (batch-empty test-empty-ctx))
+    (define spec-brfs (map (curry batch-add! spec-batch) specs))
+    (define (segregate nodes)
+      (apply create-dvector
+             (for/list ([node (in-dvector nodes)])
+               (match node
+                 [(approx spec impl) (approx (list-ref spec-brfs spec) impl)]
+                 [_ node]))))
+    (define in-batch (batch (segregate nodes) (make-hash) '() '()))
     (define brfs (map (curry batchref in-batch) roots))
     (define out-batch (batch-empty test-empty-ctx))
     (define copy-f (batch-copy-only! out-batch in-batch))
     (define brfs* (map copy-f brfs))
-    (check-equal? (map (batch-exprs out-batch) brfs*) (map (batch-exprs in-batch) brfs))
-    (batch-nodes out-batch))
+    (define spec-f (batch-exprs spec-batch))
+    (check-equal? (map (batch-exprs out-batch #:spec-f spec-f) brfs*)
+                  (map (batch-exprs in-batch #:spec-f spec-f) brfs))
+    (check-equal? (dvector->vector (batch-nodes out-batch)) (dvector->vector (segregate expected))))
 
-  (check-equal? (create-dvector 2 0 '(sqrt 1) '(pow 0 2))
-                (zombie-test #:nodes (create-dvector 0 1 '(sqrt 0) 2 '(pow 3 2)) #:roots (list 4)))
-  (check-equal? (create-dvector 0 '(sqrt 0) '(exp 1))
-                (zombie-test #:nodes (create-dvector 0 6 '(pow 0 1) '(* 2 0) '(sqrt 0) '(exp 4))
-                             #:roots (list 5)))
-  (check-equal? (create-dvector 0 1/2 '(+ 0 1))
-                (zombie-test #:nodes (create-dvector 0 1/2 '(+ 0 1) '(* 2 0)) #:roots (list 2)))
+  (zombie-test #:expected (create-dvector 2 0 '(sqrt 1) '(pow 0 2))
+               #:nodes (create-dvector 0 1 '(sqrt 0) 2 '(pow 3 2))
+               #:roots (list 4))
+  (zombie-test #:expected (create-dvector 0 '(sqrt 0) '(exp 1))
+               #:nodes (create-dvector 0 6 '(pow 0 1) '(* 2 0) '(sqrt 0) '(exp 4))
+               #:roots (list 5))
+  (zombie-test #:expected (create-dvector 0 1/2 '(+ 0 1))
+               #:nodes (create-dvector 0 1/2 '(+ 0 1) '(* 2 0))
+               #:roots (list 2))
 
-  (check-equal? (create-dvector 1/2 '(exp 0) 0 (approx 1 2))
-                (zombie-test #:nodes (create-dvector 0 1/2 '(+ 0 1) '(* 2 0) '(exp 1) (approx 4 0))
-                             #:roots (list 5)))
-  (check-equal?
-   (create-dvector 1/2 'x '(* 1 1) 2 (approx 2 3) '(pow 0 4))
-   (zombie-test #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 5 1) '(pow 2 6))
-                #:roots (list 7)))
-  (check-equal?
-   (create-dvector 1/2 'x '(* 1 1) 2 (approx 2 3) '(pow 0 4) '(sqrt 3))
-   (zombie-test #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 5 1) '(pow 2 6))
-                #:roots (list 7 3))))
+  (zombie-test #:specs (list '(exp 1))
+               #:expected (create-dvector 0 (approx 0 0))
+               #:nodes (create-dvector 0 1/2 '(+ 0 1) '(* 2 0) '(exp 1) (approx 0 0))
+               #:roots (list 5))
+  (zombie-test #:specs (list '(* x x))
+               #:expected (create-dvector 1/2 2 (approx 0 1) '(pow 0 2))
+               #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 0 1) '(pow 2 6))
+               #:roots (list 7))
+  (zombie-test #:specs (list '(* x x))
+               #:expected (create-dvector 1/2 2 (approx 0 1) '(pow 0 2) '(sqrt 1))
+               #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 0 1) '(pow 2 6))
+               #:roots (list 7 3)))
 
 ; Tests for batch->jsexpr and jsexpr->batch-exprs
 (module+ test
   (require rackunit)
   (define (test-json-tostring expr expected)
     (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
-    (define jsexpr (batch->jsexpr batch brfs))
+    (define jsexpr (batch->jsexpr batch batch brfs))
     (define str (jsexpr->batch-exprs jsexpr))
     (check-equal? str expected))
 

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -110,12 +110,6 @@
      (pattern-substitute spec env)]))
 
 (define (batch-to-spec! in-batch out-batch brfs)
-  (define copy-spec-to-output (batch-copy-only! out-batch (if (empty? brfs) out-batch in-batch)))
-  (define (output-spec spec)
-    (cond
-      [(equal? (batchref-batch spec) out-batch) spec]
-      [(equal? (batchref-batch spec) in-batch) (copy-spec-to-output spec)]
-      [else (error 'batch-to-spec! "spec reference does not belong to the input or output batch")]))
   (define lower
     (batch-recurse
      in-batch
@@ -125,7 +119,7 @@
          [(? literal?) (batch-add! out-batch (literal-value node))]
          [(? number?) (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]
          [(? symbol?) (batch-add! out-batch node)]
-         [(approx spec _) (output-spec spec)]
+         [(approx spec _) spec]
          [(list (? impl-exists? impl) args ...)
           (define vars (impl-info impl 'vars))
           (define spec (impl-info impl 'spec))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -147,14 +147,15 @@
     (check-equal? (deref x*) 'x))
 
   (let* ([batch (batch-empty test-empty-ctx)]
-         [spec (batch-add! batch 'x)]
+         [spec-batch (batch-empty test-empty-ctx)]
+         [spec (batch-add! spec-batch 'x)]
          [impl (batch-add! batch (literal 1 'binary64))]
          [approx-brf (batch-add! batch (approx spec impl))])
-    (check-equal? (batch-to-spec! batch batch (list approx-brf)) (list spec)))
+    (check-equal? (batch-to-spec! batch spec-batch (list approx-brf)) (list spec)))
 
   (let* ([in-batch (batch-empty test-empty-ctx)]
          [out-batch (batch-empty test-empty-ctx)]
-         [spec (batch-add! in-batch 'x)]
+         [spec (batch-add! out-batch 'x)]
          [impl (batch-add! in-batch (literal 1 'binary64))]
          [approx-brf (batch-add! in-batch (approx spec impl))]
          [spec* (first (batch-to-spec! in-batch out-batch (list approx-brf)))])

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -110,10 +110,11 @@
      (pattern-substitute spec env)]))
 
 (define (batch-to-spec! in-batch out-batch brfs)
-  (define (check-output-spec! spec)
-    (unless (equal? (batchref-batch spec) out-batch)
-      (error 'batch-to-spec! "spec reference does not belong to the output batch"))
-    spec)
+  (define copy-spec-to-output (batch-copy-only! out-batch (if (empty? brfs) out-batch in-batch)))
+  (define (output-spec spec)
+    (if (equal? (batchref-batch spec) out-batch)
+        spec
+        (copy-spec-to-output spec)))
   (define lower
     (batch-recurse
      in-batch
@@ -123,7 +124,7 @@
          [(? literal?) (batch-add! out-batch (literal-value node))]
          [(? number?) (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]
          [(? symbol?) (batch-add! out-batch node)]
-         [(approx spec _) (check-output-spec! spec)]
+         [(approx spec _) (output-spec spec)]
          [(list (? impl-exists? impl) args ...)
           (define vars (impl-info impl 'vars))
           (define spec (impl-info impl 'spec))
@@ -155,8 +156,10 @@
          [out-batch (batch-empty test-empty-ctx)]
          [spec (batch-add! in-batch 'x)]
          [impl (batch-add! in-batch (literal 1 'binary64))]
-         [approx-brf (batch-add! in-batch (approx spec impl))])
-    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list approx-brf)))))
+         [approx-brf (batch-add! in-batch (approx spec impl))]
+         [spec* (first (batch-to-spec! in-batch out-batch (list approx-brf)))])
+    (check-equal? (batchref-batch spec*) out-batch)
+    (check-equal? (deref spec*) 'x))
 
   (let* ([in-batch (batch-empty test-empty-ctx)]
          [out-batch (batch-empty test-empty-ctx)]


### PR DESCRIPTION
This PR splits spec and impl branches throughout the entirety of Herbie, and now treats the two languages as entirely separate recursive types, so `expr-recurse` no longer recuses into the "spec" part of an `approx` node. This is a long-sought goal and makes the internals of Herbie much more strongly typed.