### PR TITLE
Rename `batch` to `block` throughout Herbie

### DIFF
--- a/infra/analyze-rules.rkt
+++ b/infra/analyze-rules.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "../src/core/egg-herbie.rkt"
-         "../src/syntax/batch.rkt"
+         "../src/syntax/block.rkt"
          "../src/syntax/types.rkt"
          "../src/syntax/load-platform.rkt"
          "../src/syntax/platform.rkt"
@@ -33,11 +33,11 @@
   (for ([test (in-list tests)]
         [i (in-naturals)])
     (printf "Processing test ~a/~a: ~a\n" (+ i 1) (length tests) (test-name test))
-    (define-values (batch brfs) (progs->batch (list (test-spec test)) #:ctx (test-context test)))
+    (define-values (block vs) (progs->block (list (test-spec test)) #:ctx (test-context test)))
 
     (for ([iter (in-range (*iters*))])
       (define-values (initial-size final-size sorted-results)
-        (egraph-analyze-rewrite-impact batch brfs (test-context test) iter))
+        (egraph-analyze-rewrite-impact block vs (test-context test) iter))
 
       (vector-set! iter-sizes iter (cons final-size (vector-ref iter-sizes iter)))
       (for ([(rule delta) (in-dict sorted-results)])

--- a/infra/coverage.rkt
+++ b/infra/coverage.rkt
@@ -23,7 +23,7 @@
 ;; These core test modules were probed individually and completed cleanly
 ;; in the merged tutorial run, so include them by default.
 (define stable-rackunit-coverage-files
-  '("src/core/arrays.rkt" "src/core/batch-reduce.rkt"
+  '("src/core/arrays.rkt" "src/core/reduce.rkt"
                           "src/core/egg-herbie.rkt"
                           "src/core/egglog-herbie-tests.rkt"
                           "src/core/prove-rules.rkt"

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -10,7 +10,7 @@
          "../syntax/sugar.rkt"
          "../syntax/types.rkt"
          "../syntax/load-platform.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "../core/localize.rkt"
          "../core/alternative.rkt"
          "../core/compiler.rkt"
@@ -137,10 +137,10 @@
   (random) ;; Tick the random number generator, for backwards compatibility
   (define specification (test-spec test))
   (define precondition (test-pre test))
-  (define-values (batch brfs) (progs->batch (list specification) #:ctx (*context*)))
+  (define-values (block vs) (progs->block (list specification) #:ctx (*context*)))
   (define sample
     (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
-      (sample-points precondition batch brfs (list (context-repr (*context*))))))
+      (sample-points precondition block vs (list (context-repr (*context*))))))
   (apply mk-pcontext sample))
 
 ;;

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -8,20 +8,20 @@
          "../syntax/types.rkt"
          "../syntax/syntax.rkt"
          "../syntax/platform.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "points.rkt"
          "programs.rkt")
 
-(provide (contract-out (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
+(provide (contract-out (make-alt-table (block? pcontext? alt? . -> . alt-table?))
                        (atab-active-alts (alt-table? . -> . (listof alt?)))
                        (atab-all-alts (alt-table? . -> . (listof alt?)))
                        (atab-not-done-alts (alt-table? . -> . (listof alt?)))
-                       (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
+                       (atab-eval-altns (alt-table? block? (listof alt?) . -> . (values any/c any/c)))
                        (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
                        (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
                        (atab-completed? (alt-table? . -> . boolean?))
                        (atab-min-errors (alt-table? . -> . flvector?))
-                       (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
+                       (alt-block-costs (block? . -> . (val? . -> . real?)))))
 
 ;; Public API
 
@@ -37,21 +37,21 @@
        [(< x y) (cons y (sorted-index-union xs ys*))]
        [else (cons x (sorted-index-union xs* ys*))])]))
 
-(define (alt-batch-costs batch)
+(define (alt-block-costs block)
   (define active-platform (*active-platform*))
-  (define (node-cost brf)
-    (match (deref brf)
-      [(? literal?) (platform-repr-cost active-platform (batch-repr-of brf))]
+  (define (node-cost v)
+    (match (val-def v)
+      [(? literal?) (platform-repr-cost active-platform (block-repr-of v))]
       [(? symbol?) 0]
       [(? number?) 0] ; specs
       [(approx _ _) 0]
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
       [(list impl args ...) (impl-info impl 'cost)]))
   (define (sum-set nodes)
-    (for/sum ([idx (in-list nodes)]) (node-cost (batchref batch idx))))
-  (define (node-reachable-mask brf recurse)
-    (define node (deref brf))
-    (define idx (batchref-idx brf))
+    (for/sum ([idx (in-list nodes)]) (node-cost (val block idx))))
+  (define (node-reachable-mask v recurse)
+    (define node (val-def v))
+    (define idx (val-idx v))
     (define self-set (list idx))
     (match node
       [(? number?) '()] ; specs
@@ -61,27 +61,27 @@
        (for/fold ([nodes self-set]) ([arg (in-list args)])
          (sorted-index-union nodes (recurse arg)))]
       [_ self-set]))
-  (define reachable-mask (batch-recurse batch node-reachable-mask))
-  (define (dag-cost brf recurse)
-    (define node (deref brf))
+  (define reachable-mask (block-recurse block node-reachable-mask))
+  (define (dag-cost v recurse)
+    (define node (val-def v))
     (match node
       [(? number?) 0] ; specs
       [(approx _ impl) (recurse impl)]
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
-      [(list impl args ...) (sum-set (reachable-mask brf))]
-      [_ (node-cost brf)]))
-  (define (tree-cost brf recurse)
-    (match (deref brf)
+      [(list impl args ...) (sum-set (reachable-mask v))]
+      [_ (node-cost v)]))
+  (define (tree-cost v recurse)
+    (match (val-def v)
       [(? number?) 0] ; specs
       [(approx _ impl) (recurse impl)]
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
-      [(list impl args ...) (+ (node-cost brf) (for/sum ([arg (in-list args)]) (recurse arg)))]
-      [_ (node-cost brf)]))
-  (batch-recurse batch (if (flag-set? 'reduce 'dag-cost) dag-cost tree-cost)))
+      [(list impl args ...) (+ (node-cost v) (for/sum ([arg (in-list args)]) (recurse arg)))]
+      [_ (node-cost v)]))
+  (block-recurse block (if (flag-set? 'reduce 'dag-cost) dag-cost tree-cost)))
 
-(define (make-alt-table batch pcontext initial-alt)
-  (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
-  (define errs (first (batch-errors batch (list (alt-expr initial-alt)) pcontext)))
+(define (make-alt-table block pcontext initial-alt)
+  (define cost ((alt-block-costs block) (alt-expr initial-alt)))
+  (define errs (first (block-errors block (list (alt-expr initial-alt)) pcontext)))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
                (list (pareto-point cost err (list initial-alt))))
@@ -209,10 +209,10 @@
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
-(define (atab-eval-altns atab batch altns)
-  (define brfs (map alt-expr altns))
-  (define errss (batch-errors batch brfs (alt-table-pcontext atab)))
-  (define costs (map (alt-batch-costs batch) brfs))
+(define (atab-eval-altns atab block altns)
+  (define vs (map alt-expr altns))
+  (define errss (block-errors block vs (alt-table-pcontext atab)))
+  (define costs (map (alt-block-costs block) vs))
   (values errss costs))
 
 (define (atab-add-altns atab altns errss costs)
@@ -245,8 +245,8 @@
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f
-     (define brf (alt-expr altn))
-     (define max-valid-bits (representation-total-bits (batch-repr-of brf)))
+     (define v (alt-expr altn))
+     (define max-valid-bits (representation-total-bits (block-repr-of v)))
      (define point-idx->alts*
        (for/vector #:length (vector-length point-idx->alts)
                    ([pcurve (in-vector point-idx->alts)]

--- a/src/core/alternative.rkt
+++ b/src/core/alternative.rkt
@@ -1,13 +1,13 @@
 #lang racket
 
 (require "../syntax/platform.rkt"
-         "../syntax/batch.rkt")
+         "../syntax/block.rkt")
 (provide (struct-out alt)
          (struct-out sp)
          make-alt
          alt-cost
          alt-map
-         unbatchify-alts)
+         unblockify-alts)
 
 ;; A splitpoint (sp a b pt) means we should use alt a if b < pt
 ;; The last splitpoint uses +nan.0 for pt and represents the "else"
@@ -27,16 +27,16 @@
 (define (alt-map f altn)
   (f (struct-copy alt altn [prevs (map (curry alt-map f) (alt-prevs altn))])))
 
-;; Converts batchrefs of altns into expressions, assuming that batchrefs refer to batch
-(define (unbatchify-alts batch altns spec-batch)
-  (define spec-f (batch-exprs spec-batch))
-  (define exprs (batch-exprs batch #:spec-f spec-f))
+;; Converts vals of altns into expressions, assuming that vals refer to block
+(define (unblockify-alts block altns spec-block)
+  (define spec-f (block-exprs spec-block))
+  (define exprs (block-exprs block #:spec-f spec-f))
   (define (unmunge-event event)
     (match event
-      [(list 'evaluate (? batchref? start-expr)) (list 'evaluate (exprs start-expr))]
-      [(list 'taylor (? batchref? start-expr) name var order)
+      [(list 'evaluate (? val? start-expr)) (list 'evaluate (exprs start-expr))]
+      [(list 'taylor (? val? start-expr) name var order)
        (list 'taylor (exprs start-expr) name var order)]
-      [(list 'rr (? batchref? start-expr) (? batchref? end-expr) input proof)
+      [(list 'rr (? val? start-expr) (? val? end-expr) input proof)
        (define proof* (and proof (map exprs proof)))
        (list 'rr (exprs start-expr) (exprs end-expr) input proof*)]
       [(list 'regimes splitpoints)
@@ -47,7 +47,7 @@
   (define (unmunge altn)
     (define expr (alt-expr altn))
     (define expr*
-      (if (batchref? expr)
+      (if (val? expr)
           (exprs expr)
           expr))
     (define event* (unmunge-event (alt-event altn)))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -12,7 +12,7 @@
          "../syntax/types.rkt"
          "../syntax/syntax.rkt"
          "../syntax/platform.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "compiler.rkt"
          "regimes.rkt"
          "../syntax/rival.rkt"
@@ -27,33 +27,33 @@
 (module+ test
   (require rackunit))
 
-(define (finish-combine-alts batch alts brf splitindices splitpoints)
-  (define splitpoints* (append splitpoints (list (sp (si-cidx (last splitindices)) brf +nan.0))))
-  (define brf*
-    (for/fold ([brf (alt-expr (list-ref alts (sp-cidx (last splitpoints*))))])
+(define (finish-combine-alts block alts v splitindices splitpoints)
+  (define splitpoints* (append splitpoints (list (sp (si-cidx (last splitindices)) v +nan.0))))
+  (define v*
+    (for/fold ([v (alt-expr (list-ref alts (sp-cidx (last splitpoints*))))])
               ([splitpoint (cdr (reverse splitpoints*))])
-      (define repr (batch-repr-of (sp-bexpr splitpoint)))
+      (define repr (block-repr-of (sp-bexpr splitpoint)))
       (define if-impl (get-fpcore-impl 'if '() (list (get-representation 'bool) repr repr)))
       (define <=-impl (get-fpcore-impl '<= '() (list repr repr)))
-      (define lit-brf
-        (batch-add! batch
+      (define lit-v
+        (block-add! block
                     (literal (repr->real (sp-point splitpoint) repr) (representation-name repr))))
-      (define cmp-brf (batch-add! batch (list <=-impl (sp-bexpr splitpoint) lit-brf)))
-      (batch-add! batch (list if-impl cmp-brf (alt-expr (list-ref alts (sp-cidx splitpoint))) brf))))
+      (define cmp-v (block-add! block (list <=-impl (sp-bexpr splitpoint) lit-v)))
+      (block-add! block (list if-impl cmp-v (alt-expr (list-ref alts (sp-cidx splitpoint))) v))))
 
   ;; We don't want unused alts in our history!
   (define-values (alts* splitpoints**) (remove-unused-alts alts splitpoints*))
-  (alt brf* (list 'regimes splitpoints**) alts*))
+  (alt v* (list 'regimes splitpoints**) alts*))
 
-(define (combine-alts batch best-option)
-  (match-define (option splitindices alts pts brf) best-option)
-  (define splitpoints (sindices->spoints/left batch pts brf splitindices))
-  (finish-combine-alts batch alts brf splitindices splitpoints))
+(define (combine-alts block best-option)
+  (match-define (option splitindices alts pts v) best-option)
+  (define splitpoints (sindices->spoints/left block pts v splitindices))
+  (finish-combine-alts block alts v splitindices splitpoints))
 
-(define (combine-alts/binary batch best-option start-prog pcontext)
-  (match-define (option splitindices alts pts brf) best-option)
-  (define splitpoints (sindices->spoints/binary batch pts brf alts splitindices start-prog pcontext))
-  (finish-combine-alts batch alts brf splitindices splitpoints))
+(define (combine-alts/binary block best-option start-prog pcontext)
+  (match-define (option splitindices alts pts v) best-option)
+  (define splitpoints (sindices->spoints/binary block pts v alts splitindices start-prog pcontext))
+  (finish-combine-alts block alts v splitindices splitpoints))
 
 (define (remove-unused-alts alts splitpoints)
   (for/fold ([alts* '()]
@@ -90,24 +90,24 @@
         (timeline-push! 'stop "predicate-same" 1)
         (values p1 p2)])]))
 
-(define (extract-subexpression batch brf pattern-brf batch* var-brf)
-  (define pattern-idx (batchref-idx pattern-brf))
-  (define var (deref var-brf))
-  (define free-vars (batch-free-vars batch))
-  (define vars* (set-subtract (list->set (batch-vars batch)) (free-vars pattern-brf)))
+(define (extract-subexpression block v pattern-v block* var-v)
+  (define pattern-idx (val-idx pattern-v))
+  (define var (val-def var-v))
+  (define free-vars (block-free-vars block))
+  (define vars* (set-subtract (list->set (block-vars block)) (free-vars pattern-v)))
   (define copy
-    (batch-recurse
-     batch
-     (λ (brf recurse)
+    (block-recurse
+     block
+     (λ (v recurse)
        (cond
-         [(= (batchref-idx brf) pattern-idx) var-brf]
-         [else (batch-push! batch* (expr-recurse (deref brf) (compose batchref-idx recurse)))]))))
-  (define body-brf (copy brf))
-  (define free-vars* (batch-free-vars batch*))
-  (and (subset? (free-vars* body-brf) (set-add vars* var)) body-brf))
+         [(= (val-idx v) pattern-idx) var-v]
+         [else (block-push! block* (expr-recurse (val-def v) (compose val-idx recurse)))]))))
+  (define body-v (copy v))
+  (define free-vars* (block-free-vars block*))
+  (and (subset? (free-vars* body-v) (set-add vars* var)) body-v))
 
-(define (deterministic-branch-var batch)
-  (define used-vars (list->set (batch-vars batch)))
+(define (deterministic-branch-var block)
+  (define used-vars (list->set (block-vars block)))
   (let loop ([n 0])
     (define var (string->symbol (format "branch-~a" n)))
     (if (set-member? used-vars var)
@@ -122,12 +122,12 @@
   ; Since the sampler does not call rival-analyze, the hint is set to #f
   (define (new-sampler)
     (values (vector-append (vector val) (random-ref pts)) #f))
-  (define-values (results _) (batch-prepare-points evaluator new-sampler))
+  (define-values (results _) (block-prepare-points evaluator new-sampler))
   (apply mk-pcontext results))
 
 (define/reset *prepend-arguement-cache* (make-hash))
-(define (cache-get-prepend v brf macro)
-  (define key (cons brf v))
+(define (cache-get-prepend v key-v macro)
+  (define key (cons key-v v))
   (hash-ref! (*prepend-arguement-cache*) key (lambda () (macro v))))
 
 ;; Accepts a list of sindices in one indexed form and returns the
@@ -135,10 +135,10 @@
 ;; float form always come from the range [f(idx1), f(idx2)). If the
 ;; float form of a split is f(idx2), or entirely outside that range,
 ;; problems may arise.
-(define/contract (sindices->spoints/left batch points brf sindices)
-  (-> batch? (listof vector?) batchref? (listof si?) (listof sp?))
-  (define repr (batch-repr-of brf))
-  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
+(define/contract (sindices->spoints/left block points v sindices)
+  (-> block? (listof vector?) val? (listof si?) (listof sp?))
+  (define repr (block-repr-of v))
+  (define eval-expr (compose (curryr vector-ref 0) (compile-block block (list v))))
 
   (define (left-point p1 p2)
     (define left ((representation-repr->bf repr) p1))
@@ -162,43 +162,43 @@
     (timeline-stop!)
 
     (timeline-push! 'method "left-value")
-    (sp (si-cidx si1) brf split-at)))
+    (sp (si-cidx si1) v split-at)))
 
-(define/contract (sindices->spoints/binary batch points brf alts sindices start-prog pcontext)
-  (-> batch? (listof vector?) batchref? (listof alt?) (listof si?) any/c pcontext? (listof sp?))
-  (define repr (batch-repr-of brf))
+(define/contract (sindices->spoints/binary block points target-v alts sindices start-prog pcontext)
+  (-> block? (listof vector?) val? (listof alt?) (listof si?) any/c pcontext? (listof sp?))
+  (define repr (block-repr-of target-v))
   (define ulps (repr-ulps repr))
-  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
-  (define brf-node (deref brf))
+  (define eval-expr (compose (curryr vector-ref 0) (compile-block block (list target-v))))
+  (define v-node (val-def target-v))
   (define var
-    (if (symbol? brf-node)
-        brf-node
-        (deterministic-branch-var batch)))
-  (define-values (batch* var-brf) (batch-empty-extend batch var repr))
+    (if (symbol? v-node)
+        v-node
+        (deterministic-branch-var block)))
+  (define-values (block* var-v) (block-empty-extend block var repr))
   (define progs
     (for/list ([alt (in-list alts)])
-      (extract-subexpression batch (alt-expr alt) brf batch* var-brf)))
-  (define start-prog-sub (extract-subexpression batch start-prog brf batch* var-brf))
+      (extract-subexpression block (alt-expr alt) target-v block* var-v)))
+  (define start-prog-sub (extract-subexpression block start-prog target-v block* var-v))
   (unless (and start-prog-sub (andmap identity progs))
     (raise-user-error
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
-  (define spec-batch (batch-empty (context (batch-vars batch*) #f (batch-var-reprs batch*))))
-  (define spec-brfs (batch-to-spec! batch* spec-batch (list start-prog-sub)))
-  (define start-real-compiler (make-real-compiler spec-batch spec-brfs (list repr)))
+  (define spec-block (block-empty (context (block-vars block*) #f (block-var-reprs block*))))
+  (define spec-vs (block-to-spec! block* spec-block (list start-prog-sub)))
+  (define start-real-compiler (make-real-compiler spec-block spec-vs (list repr)))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))
 
   (define (find-split si1 si2 p1 p2)
-    (define brf1 (list-ref progs (si-cidx si1)))
-    (define brf2 (list-ref progs (si-cidx si2)))
-    (define eval-errors (compile-batch batch* (list brf1 brf2)))
-    (define score-ulps (repr-ulps (batch-repr-of brf1)))
+    (define v1 (list-ref progs (si-cidx si1)))
+    (define v2 (list-ref progs (si-cidx si2)))
+    (define eval-errors (compile-block block* (list v1 v2)))
+    (define score-ulps (repr-ulps (block-repr-of v1)))
     (define (pred v)
       (define pctx
         (parameterize ([*num-points* (*binary-search-test-points*)])
-          (cache-get-prepend v brf prepend-macro)))
+          (cache-get-prepend v target-v prepend-macro)))
       (for/sum ([(pt ex) (in-pcontext pctx)])
                (match-define (vector out1 out2) (eval-errors pt))
                (- (ulps->bits (score-ulps out1 ex)) (ulps->bits (score-ulps out2 ex)))))
@@ -215,7 +215,7 @@
     (timeline-stop!)
 
     (timeline-push! 'method "binary-search")
-    (sp (si-cidx si1) brf split-at)))
+    (sp (si-cidx si1) target-v split-at)))
 
 (define (regimes-pcontext-masks pcontext splitpoints alts ctx)
   (define num-alts (length alts))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -7,10 +7,10 @@
          "../utils/timeline.rkt"
          "../utils/common.rkt"
          "../utils/dvector.rkt"
-         "../syntax/batch.rkt")
+         "../syntax/block.rkt")
 
 (provide compile-progs
-         compile-batch
+         compile-block
          compile-prog)
 
 ;; Interpreter taking a narrow IR
@@ -46,12 +46,12 @@
                 (vector-ref regs arg))))]))
 
 ;; This function:
-;;   1) copies only nodes associated with provided brfs - so, gets rid of useless nodes
+;;   1) copies only nodes associated with provided vs - so, gets rid of useless nodes
 ;;   2) rewrites these nodes as fl-instructions
-(define (batch-for-compiler batch brfs vars args vregs)
-  (define out (make-dvector (batch-length batch)))
-  (define (compile-node brf recurse)
-    (match (deref brf)
+(define (block-for-compiler block vs vars args vregs)
+  (define out (make-dvector (block-length block)))
+  (define (compile-node v recurse)
+    (match (val-def v)
       [(approx _ impl) (recurse impl)] ;; do not push, it is already compiled
       [(? symbol? n)
        (define idx (index-of vars n))
@@ -60,30 +60,30 @@
        (dvector-add! out (make-thunk (const (real->repr value repr)) '() vregs))]
       [(list op args ...)
        (dvector-add! out (make-thunk (impl-info op 'fl) (map recurse args) vregs))]))
-  (define roots (map (batch-recurse batch compile-node) brfs))
+  (define roots (map (block-recurse block compile-node) vs))
   (values (dvector->vector out) roots))
 
-(define (batch-tree-size batch brfs)
-  (define (tree-size brf recurse)
-    (define args (reap [sow] (expr-recurse (deref brf) sow)))
+(define (block-tree-size block vs)
+  (define (tree-size v recurse)
+    (define args (reap [sow] (expr-recurse (val-def v) sow)))
     (apply + 1 (map recurse args)))
-  (apply + (map (batch-recurse batch tree-size) brfs)))
+  (apply + (map (block-recurse block tree-size) vs)))
 
 ;; Compiles a program of operator implementations into a procedure
 ;; that evaluates the program on a single input of representation values
 ;; returning representation values.
 ;; Translates a Herbie IR into a vector of thunks.
 (define (compile-progs exprs ctx)
-  (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
-  (compile-batch batch brfs))
+  (define-values (block vs) (progs->block exprs #:ctx ctx))
+  (compile-block block vs))
 
-(define (compile-batch batch brfs)
-  (define vars (batch-vars batch))
+(define (compile-block block vs)
+  (define vars (block-vars block))
   (define args (make-vector (length vars)))
-  (define vregs (make-vector (batch-length batch)))
-  (define-values (thunks roots) (batch-for-compiler batch brfs vars args vregs))
+  (define vregs (make-vector (block-length block)))
+  (define-values (thunks roots) (block-for-compiler block vs vars args vregs))
   (define rootvec (list->vector roots))
-  (timeline-push! 'compiler (batch-tree-size batch brfs) (vector-length thunks))
+  (timeline-push! 'compiler (block-tree-size block vs) (vector-length thunks))
   (make-progs-interpreter thunks rootvec args vregs))
 
 ;; Like `compile-progs`, but a single prog.

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "../core/alternative.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "../syntax/platform.rkt"
          "programs.rkt"
          "egg-herbie.rkt"
@@ -10,35 +10,35 @@
 
 (provide add-derivations)
 
-(define (copy-proof-specs spec-batch expr)
+(define (copy-proof-specs spec-block expr)
   (match expr
-    [(approx spec impl) (approx (batch-add! spec-batch spec) (copy-proof-specs spec-batch impl))]
-    [(list op args ...) (cons op (map (curry copy-proof-specs spec-batch) args))]
+    [(approx spec impl) (approx (block-add! spec-block spec) (copy-proof-specs spec-block impl))]
+    [(list op args ...) (cons op (map (curry copy-proof-specs spec-block) args))]
     [_ expr]))
 
-(define (canonicalize-proof batch spec-batch prog-brf proof start-brf)
+(define (canonicalize-proof block spec-block prog-v proof start-v)
   ;; Proofs are on subexpressions; lift to full expression
-  ;; Returns a list of batchrefs instead of expressions
+  ;; Returns a list of vals instead of expressions
   (and proof
        (for/list ([step (in-list proof)])
-         (define step-brf (batch-add! batch (copy-proof-specs spec-batch step)))
-         (batch-replace-subexpr batch prog-brf start-brf step-brf))))
+         (define step-v (block-add! block (copy-proof-specs spec-block step)))
+         (block-replace-subexpr block prog-v start-v step-v))))
 
 ;; Adds proof information to alternatives.
-;; start-expr and end-expr are batchrefs
+;; start-expr and end-expr are vals
 (define (add-derivations-to altn)
   (match altn
     ; recursive rewrite or simplify, both using egg
-    ; start-brf and end-brf are batchrefs for the subexpressions that were transformed
-    [(alt expr (list 'rr start-brf end-brf (? egg-runner? runner) #f) `(,prev))
-     (define batch (batchref-batch expr))
-     (define spec-batch (egg-runner-batch runner))
+    ; start-v and end-v are vals for the subexpressions that were transformed
+    [(alt expr (list 'rr start-v end-v (? egg-runner? runner) #f) `(,prev))
+     (define block (val-block expr))
+     (define spec-block (egg-runner-block runner))
      (define-values (proof-start proof-end)
-       (apply values (batch-to-spec! batch spec-batch (list start-brf end-brf))))
+       (apply values (block-to-spec! block spec-block (list start-v end-v))))
      (define proof
        (and (not (flag-set? 'generate 'egglog)) (egraph-prove runner proof-start proof-end)))
-     (define proof* (canonicalize-proof batch spec-batch (alt-expr altn) proof start-brf))
-     (alt expr `(rr ,start-brf ,end-brf ,runner ,proof*) (list prev))]
+     (define proof* (canonicalize-proof block spec-block (alt-expr altn) proof start-v))
+     (alt expr `(rr ,start-v ,end-v ,runner ,proof*) (list prev))]
 
     ; everything else
     [_ altn]))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -18,7 +18,7 @@
          "../syntax/platform-state.rkt"
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "programs.rkt"
          "rules.rkt")
 
@@ -52,7 +52,7 @@
 ;; - EgraphIter: struct defined in egg-herbie
 
 ; Adds expressions returning the root ids
-(define (egraph-add-exprs ptr batch brfs ctx)
+(define (egraph-add-exprs ptr block vs ctx)
 
   ; pre-allocated id vectors for all the common cases
   (define 0-vec (make-u32vector 0))
@@ -86,10 +86,10 @@
       [(? (disjoin symbol? number?) x) (egraph_add_node ptr (~s x) 0-vec)]))
 
   (define add-to-egraph
-    (batch-recurse
-     batch
-     (λ (brf recurse)
-       (define node (deref brf))
+    (block-recurse
+     block
+     (λ (v recurse)
+       (define node (val-def v))
        (match node
          [(literal v _) (insert-node! v)]
          [(? number?) (insert-node! node)]
@@ -97,10 +97,10 @@
          [(approx spec impl) (insert-node! (list '$approx (recurse spec) (recurse impl)))]
          [(list op (app recurse args) ...) (insert-node! (cons op args))]))))
 
-  (for/list ([brf (in-list brfs)])
-    (define brf-id (add-to-egraph brf)) ; remapping of brf
-    (egraph_add_root ptr brf-id)
-    brf-id))
+  (for/list ([v (in-list vs)])
+    (define v-id (add-to-egraph v)) ; remapping of v
+    (egraph_add_root ptr v-id)
+    v-id))
 
 ;; runs rules on an egraph (optional iteration limit)
 (define (egraph-run ptr ffi-rules node-limit iter-limit scheduler)
@@ -128,8 +128,8 @@
   eclass)
 
 (define (egraph-expr-equal? ptr expr goal ctx)
-  (define-values (batch brfs) (progs->batch (list expr goal) #:ctx ctx))
-  (match-define (list id1 id2) (egraph-add-exprs ptr batch brfs ctx))
+  (define-values (block vs) (progs->block (list expr goal) #:ctx ctx))
+  (match-define (list id1 id2) (egraph-add-exprs ptr block vs ctx))
   (= id1 id2))
 
 ;; returns a flattened list of terms or #f if it failed to expand the proof due to budget
@@ -851,7 +851,7 @@
 ;; Extraction is partial, that is, the result of the extraction
 ;; procedure is `#f` if extraction finds no well-typed program
 ;; at a particular id with a particular output type.
-(define ((typed-egg-batch-extractor batch-extract-to) regraph)
+(define ((typed-egg-block-extractor block-extract-to) regraph)
   (define eclasses (regraph-eclasses regraph))
   (define types (regraph-types regraph))
   (define n (vector-length eclasses))
@@ -911,11 +911,11 @@
   (regraph-analyze regraph eclass-set-cost! #:analysis costs)
 
   (define ctx (regraph-ctx regraph))
-  (define-values (add-id add-enode) (egg-nodes->batch costs batch-extract-to ctx))
-  ;; These functions provide a setup to extract nodes into batch-extract-to from nodes
+  (define-values (add-id add-enode) (egg-nodes->block costs block-extract-to ctx))
+  ;; These functions provide a setup to extract nodes into block-extract-to from nodes
   (list add-id add-enode))
 
-(define (egg-nodes->batch egg-nodes batch ctx)
+(define (egg-nodes->block egg-nodes block ctx)
   (define (eggref id)
     (cdr (vector-ref egg-nodes id)))
 
@@ -937,23 +937,23 @@
            (if (representation? type)
                (representation-type type)
                type))
-         (approx (batchref-idx (add-id spec spec-type)) (batchref-idx (add-id impl type)))]
+         (approx (val-idx (add-id spec spec-type)) (val-idx (add-id impl type)))]
         [(list impl args ...)
          (define args*
            (for/list ([arg-id (in-list args)]
                       [arg-type (in-list (if (representation? type)
                                              (impl-info impl 'itype)
                                              (operator-info impl 'itype)))])
-             (batchref-idx (add-id arg-id arg-type))))
+             (val-idx (add-id arg-id arg-type))))
          (cons impl args*)]))
-    (batchref-idx (batch-push! batch enode*)))
+    (val-idx (block-push! block enode*)))
 
   (define (add-id id type)
     (define key (cons id type))
     (define idx (hash-ref! memo key (λ () (add-enode (eggref id) type))))
-    (batchref batch idx))
+    (val block idx))
 
-  (values add-id (λ (enode type) (batchref batch (add-enode enode type)))))
+  (values add-id (λ (enode type) (val block (add-enode enode type)))))
 
 ;; Is fractional with odd denominator.
 (define (fraction-with-odd-denominator? frac)
@@ -1058,7 +1058,7 @@
 
      (remove-duplicates (for/list ([enode (vector-ref eclasses id*)])
                           (extract-enode enode type))
-                        #:key batchref-idx)]
+                        #:key val-idx)]
     [else (list)]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1082,9 +1082,9 @@
   (timeline-push! 'stop (~a (egraph_get_stop_reason egg-graph)) 1)
   (values egg-graph iteration-data))
 
-(define (egraph-analyze-rewrite-impact batch brfs ctx iter)
+(define (egraph-analyze-rewrite-impact block vs ctx iter)
   (define egg-graph (egraph_create))
-  (egraph-add-exprs egg-graph batch brfs ctx)
+  (egraph-add-exprs egg-graph block vs ctx)
   (define-values (egg-graph0 _0) (egraph-run-rules egg-graph '()))
   (define-values (egg-graph1 _1)
     (if (> iter 0)
@@ -1104,12 +1104,12 @@
       (iteration-data-num-nodes (last (if (empty? iter-data6) iter-data3 iter-data6)))))
   (values initial-size final-size results))
 
-(define (egraph-run-schedule batch brfs schedule ctx)
+(define (egraph-run-schedule block vs schedule ctx)
   ; allocate the e-graph
   (define egg-graph (egraph_create))
 
   ; insert expressions into the e-graph
-  (define root-ids (egraph-add-exprs egg-graph batch brfs ctx))
+  (define root-ids (egraph-add-exprs egg-graph block vs ctx))
   (define-values (egg-graph0 rebuild-data) (egraph-run-rules egg-graph '()))
 
   (define (rewrite-node-limit initial-size)
@@ -1164,12 +1164,12 @@
 ;;  - `make-egraph`: constructs an egraph and runs rules on it
 ;;  - `egraph-equal?`: test if two expressions are equal
 ;;  - `egraph-prove`: return a proof that two expressions are equal
-;;  - `egraph-best`: return a batch with the best versions of another batch
-;;  - `egraph-variations`: return a batch with all versions of another batch
+;;  - `egraph-best`: return a block with the best versions of another block
+;;  - `egraph-variations`: return a block with all versions of another block
 
 ;; Herbie's version of an egg runner.
 ;; Defines parameters for running rewrite rules with egg
-(struct egg-runner (batch schedule ctx new-roots egg-graph)
+(struct egg-runner (block schedule ctx new-roots egg-graph)
   #:transparent ; for equality
   #:methods gen:custom-write ; for abbreviated printing
   [(define (write-proc alt port mode)
@@ -1182,7 +1182,7 @@
 ;;  - `rewrite`: run rewrite rules up to node limit with backoff scheduler
 ;;  - `unsound`: run sound-removal rules for 1 iteration with simple scheduler
 ;;  - `lower`: run lowering rules for 1 iteration with simple scheduler
-(define (make-egraph batch brfs schedule ctx)
+(define (make-egraph block vs schedule ctx)
   (define (oops! fmt . args)
     (apply error 'verify-schedule! fmt args))
   ; verify the schedule
@@ -1190,10 +1190,10 @@
     (unless (memq step '(lift lower unsound rewrite))
       (oops! "unknown schedule step `~a`" step)))
 
-  (define-values (root-ids egg-graph) (egraph-run-schedule batch brfs schedule ctx))
+  (define-values (root-ids egg-graph) (egraph-run-schedule block vs schedule ctx))
 
   ; make the runner
-  (egg-runner batch schedule ctx root-ids egg-graph))
+  (egg-runner block schedule ctx root-ids egg-graph))
 
 (module+ test
   (require "../syntax/load-platform.rkt")
@@ -1201,8 +1201,8 @@
     (activate-platform! "c")
     (define rebuild-ctx (context '(x y) <binary64> (list <binary64> <binary64>)))
     (define expr '(+ (/ 1 2) (* x y)))
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx rebuild-ctx))
-    (define runner (make-egraph batch brfs '() rebuild-ctx))
+    (define-values (block vs) (progs->block (list expr) #:ctx rebuild-ctx))
+    (define runner (make-egraph block vs '() rebuild-ctx))
     (define egg-graph (egg-runner-egg-graph runner))
     (define eclasses (u32vector->list (egraph_get_eclasses egg-graph)))
 
@@ -1241,13 +1241,13 @@
   (define root-ids (egg-runner-new-roots runner))
   (= (list-ref root-ids idx1) (list-ref root-ids idx2)))
 
-(define (egraph-prove runner start-brf end-brf)
+(define (egraph-prove runner start-v end-v)
   (define ctx (egg-runner-ctx runner))
   (define egg-graph (egg-runner-egg-graph runner))
-  (define batch (egg-runner-batch runner))
-  (define exprs (batch-exprs batch))
-  (define start (exprs start-brf))
-  (define end (exprs end-brf))
+  (define block (egg-runner-block runner))
+  (define exprs (block-exprs block))
+  (define start (exprs start-v))
+  (define end (exprs end-v))
 
   (unless (egraph-expr-equal? egg-graph start end ctx)
     (error 'egraph-prove "cannot prove ~a is equal to ~a; not equal" start end))
@@ -1256,7 +1256,7 @@
     (error 'egraph-prove "proof extraction failed between`~a` and `~a`" start end))
   proof)
 
-(define (egraph-best runner batch reprs)
+(define (egraph-best runner block reprs)
   (define ctx (egg-runner-ctx runner))
   (define root-ids (egg-runner-new-roots runner))
   (define egg-graph (egg-runner-egg-graph runner))
@@ -1269,14 +1269,14 @@
      (when (flag-set? 'dump 'egg)
        (regraph-dump regraph root-ids reprs))
 
-     (define extract-id ((typed-egg-batch-extractor batch) regraph))
+     (define extract-id ((typed-egg-block-extractor block) regraph))
 
-     ; (Listof (Listof batchref))
+     ; (Listof (Listof val))
      (for/list ([id (in-list root-ids)]
                 [repr (in-list reprs)])
        (regraph-extract-best regraph extract-id id repr))]))
 
-(define (egraph-variations runner batch reprs)
+(define (egraph-variations runner block reprs)
   (define ctx (egg-runner-ctx runner))
   (define root-ids (egg-runner-new-roots runner))
   (define egg-graph (egg-runner-egg-graph runner))
@@ -1289,22 +1289,22 @@
      (when (flag-set? 'dump 'egg)
        (regraph-dump regraph root-ids reprs))
 
-     (define extract-id ((typed-egg-batch-extractor batch) regraph))
+     (define extract-id ((typed-egg-block-extractor block) regraph))
 
-     ; (Listof (Listof batchref))
+     ; (Listof (Listof val))
      (for/list ([id (in-list root-ids)]
                 [repr (in-list reprs)])
        (regraph-extract-variants regraph extract-id id repr))]))
 
 (define (deduplicate-exprs exprs ctxs)
   (define ctx (contexts-union ctxs))
-  (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
-  (define reprs (make-list (length brfs) (context-repr ctx)))
-  (define runner (make-egraph batch brfs '(rewrite lower) ctx))
-  (define batchrefss (egraph-best runner batch reprs))
-  (define batch-pull (batch-exprs batch))
+  (define-values (block vs) (progs->block exprs #:ctx ctx))
+  (define reprs (make-list (length vs) (context-repr ctx)))
+  (define runner (make-egraph block vs '(rewrite lower) ctx))
+  (define valss (egraph-best runner block reprs))
+  (define block-pull (block-exprs block))
   (for/list ([orig-expr (in-list exprs)]
-             [refs (in-list batchrefss)])
+             [refs (in-list valss)])
     (if (empty? refs)
         orig-expr
-        (batch-pull (first refs)))))
+        (block-pull (first refs)))))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -320,7 +320,7 @@
            "egglog-herbie.rkt"
            "programs.rkt"
            "../syntax/types.rkt"
-           "../syntax/batch.rkt"
+           "../syntax/block.rkt"
            "rules.rkt"
            "../config.rkt"
            "../syntax/platform.rkt"
@@ -329,28 +329,28 @@
   (activate-platform! "c")
   (define ctx (context '(x eps) <binary64> (make-list 2 <binary64>)))
 
-  (define-values (batch brfs)
-    (progs->batch (list '(- (sin (+ x eps)) (sin x)) '(sin (+ x eps)) '(+ x eps) 'x 'eps '(sin x))
+  (define-values (block vs)
+    (progs->block (list '(- (sin (+ x eps)) (sin x)) '(sin (+ x eps)) '(+ x eps) 'x 'eps '(sin x))
                   #:ctx ctx))
 
-  (define reprs (make-list (length brfs) <binary64>))
+  (define reprs (make-list (length vs) <binary64>))
 
   (define schedule '(rewrite lower))
 
   (when (find-executable-path "egglog")
-    (void (run-egglog (make-egglog-runner batch brfs schedule ctx) batch reprs #:extract 1000000))))
+    (void (run-egglog (make-egglog-runner block vs schedule ctx) block reprs #:extract 1000000))))
 
 (module+ test
   (require rackunit)
   (when (find-executable-path "egglog")
     (let ()
       (define ctx (context '(x y) <binary64> (make-list 2 <binary64>)))
-      (define-values (batch brfs) (progs->batch (list '(+ x y)) #:ctx ctx))
-      (batch-add! batch '(* x y))
+      (define-values (block vs) (progs->block (list '(+ x y)) #:ctx ctx))
+      (block-add! block '(* x y))
 
       (define subproc (create-new-egglog-subprocess #f))
       (prelude subproc)
-      (define-values (all-bindings root-constructors) (egglog-add-exprs batch brfs subproc))
+      (define-values (all-bindings root-constructors) (egglog-add-exprs block vs subproc))
       (egglog-subprocess-close subproc)
 
       (check-equal? (length root-constructors) 1)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -8,7 +8,7 @@
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "../config.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "../utils/common.rkt"
          "egglog-subprocess.rkt")
 
@@ -71,7 +71,7 @@
 
 ;; Herbie's version of an egglog runner.
 ;; Defines parameters for running rewrite rules with egglog
-(struct egglog-runner (batch brfs schedule ctx)
+(struct egglog-runner (block vs schedule ctx)
   #:transparent ; for equality
   #:methods gen:custom-write ; for abbreviated printing
   [(define (write-proc alt port mode)
@@ -84,7 +84,7 @@
 ;;  - `rewrite`: run rewrite rules up to node limit with backoff scheduler
 ;;  - `unsound`: run sound-removal rules for 1 iteration with simple scheduler
 ;;  - `lower`: run lowering rules for 1 iteration with simple scheduler
-(define (make-egglog-runner batch brfs schedule ctx)
+(define (make-egglog-runner block vs schedule ctx)
   (define (oops! fmt . args)
     (apply error 'verify-schedule! fmt args))
   ; verify the schedule
@@ -93,16 +93,16 @@
       (oops! "unknown schedule step `~a`" step)))
 
   ; make the runner
-  (egglog-runner batch brfs schedule ctx))
+  (egglog-runner block vs schedule ctx))
 
 ;; Runs egglog using an egglog runner by extracting multiple variants
 (define (run-egglog runner
-                    output-batch
+                    output-block
                     reprs
                     [label #f]
                     #:extract extract) ; multi expression extraction
-  (define insert-batch (egglog-runner-batch runner))
-  (define insert-brfs (egglog-runner-brfs runner))
+  (define insert-block (egglog-runner-block runner))
+  (define insert-vs (egglog-runner-vs runner))
   (define schedule (egglog-runner-schedule runner))
   (define pform (*active-platform*))
 
@@ -156,7 +156,7 @@
   ;; of a rule and make them accessible through their unique constructor. Therefore, we must
   ;; keep track of the mapping between each binding and its corresponding constructor.
 
-  (define-values (all-bindings extract-bindings) (egglog-add-exprs insert-batch insert-brfs subproc))
+  (define-values (all-bindings extract-bindings) (egglog-add-exprs insert-block insert-vs subproc))
 
   (egglog-send subproc
                `(ruleset run-extract-commands)
@@ -193,7 +193,7 @@
 
   (for/list ([variants (in-list herbie-exprss)])
     (for/list ([v (in-list variants)])
-      (batch-add! output-batch v))))
+      (block-add! output-block v))))
 
 ;; Egglog requires integer costs, but Herbie uses floating-point costs.
 ;; Scale by 1000 to convert Herbie's float costs to Egglog's integer costs.
@@ -410,7 +410,7 @@
               :ruleset
               ,tag)))
 
-(define (egglog-add-exprs batch brfs subproc)
+(define (egglog-add-exprs block vs subproc)
   (define bindings (make-hash))
   (define (var-binding var)
     (string->symbol (format "?s~a" var)))
@@ -425,16 +425,16 @@
     (hash-set! bindings binding node)
     binding)
 
-  (define root-mask (make-vector (batch-length batch) #f))
-  (define reachable-brfs '())
+  (define root-mask (make-vector (block-length block) #f))
+  (define reachable-vs '())
 
-  (for ([brf (in-list brfs)])
-    (vector-set! root-mask (batchref-idx brf) #t))
+  (for ([v (in-list vs)])
+    (vector-set! root-mask (val-idx v) #t))
   (define add-to-egglog
-    (batch-recurse batch
-                   (lambda (brf recurse)
-                     (define n (batchref-idx brf))
-                     (define node (deref brf))
+    (block-recurse block
+                   (lambda (v recurse)
+                     (define n (val-idx v))
+                     (define node (val-def v))
                      (define root? (vector-ref root-mask n))
                      (define node*
                        (match node
@@ -444,18 +444,18 @@
                           `(,(hash-ref (id->e1) impl) ,@(for/list ([arg (in-list args)])
                                                           (recurse arg)))]))
 
-                     (set! reachable-brfs (cons brf reachable-brfs))
+                     (set! reachable-vs (cons v reachable-vs))
                      (if node*
                          (insert-node! node* n root?)
                          (var-binding node)))))
 
   (define root-bindings
-    (for/list ([brf (in-list brfs)])
-      (add-to-egglog brf)))
+    (for/list ([v (in-list vs)])
+      (add-to-egglog v)))
 
   ; Var-lowering-rules
-  (for ([var (in-list (batch-vars batch))]
-        [repr (in-list (batch-var-reprs batch))])
+  (for ([var (in-list (block-vars block))]
+        [repr (in-list (block-var-reprs block))])
     (egglog-send subproc
                  `(rule ((= e (Var ,(symbol->string var))))
                         ((union (do-lower e ,(egglog-repr-token repr))
@@ -464,8 +464,8 @@
                         lower)))
 
   ; Var-lifting-rules
-  (for ([var (in-list (batch-vars batch))]
-        [repr (in-list (batch-var-reprs batch))])
+  (for ([var (in-list (block-vars block))]
+        [repr (in-list (block-var-reprs block))])
     (egglog-send subproc
                  `(rule ((= e (,(typed-var-id (representation-name repr)) ,(symbol->string var))))
                         ((union (do-lift e) (Var ,(symbol->string var))))
@@ -478,7 +478,7 @@
   (define constructor-num 1)
 
   ; ; Var-spec-bindings
-  (for ([var (in-list (batch-vars batch))])
+  (for ([var (in-list (block-vars block))])
     ; Get the binding names for the program
     (define binding-name (string->symbol (format "?s~a" var)))
     (define constructor-name (string->symbol (format "const~a" constructor-num)))
@@ -497,9 +497,9 @@
     (set! constructor-num (add1 constructor-num)))
 
   ; Binding Exprs
-  (for ([brf (in-list (reverse reachable-brfs))]
-        #:unless (symbol? (deref brf)))
-    (define n (batchref-idx brf))
+  (for ([v (in-list (reverse reachable-vs))]
+        #:unless (symbol? (val-def v)))
+    (define n (val-idx v))
 
     (define binding-name
       (if (vector-ref root-mask n)

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -9,7 +9,7 @@
          "../syntax/types.rkt"
          "../syntax/syntax.rkt"
          "../syntax/platform.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "localize.rkt"
          "points.rkt"
          "programs.rkt"
@@ -72,10 +72,10 @@
 
   (define repr-hash (make-immutable-hash (map cons subexprs reprs)))
 
-  (define-values (batch brfs) (progs->batch spec-list #:ctx ctx))
+  (define-values (block vs) (progs->block spec-list #:ctx ctx))
   (define subexprs-fn
     (parameterize ([*max-mpfr-prec* 128])
-      (eval-progs-real batch brfs reprs)))
+      (eval-progs-real block vs reprs)))
   (values subexprs repr-hash subexprs-fn))
 
 (define (predict-errors ctx pctx subexprs-list repr-hash subexprs-fn)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -9,7 +9,7 @@
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
          "../syntax/platform.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "compiler.rkt"
          "points.rkt"
          "programs.rkt"
@@ -24,8 +24,8 @@
          eval-progs-real
          local-error-as-tree)
 
-(define (eval-progs-real batch brfs reprs)
-  (define compiler (make-real-compiler batch brfs reprs))
+(define (eval-progs-real block vs reprs)
+  (define compiler (make-real-compiler block vs reprs))
   (define bad-pt
     (for/list ([repr (in-list reprs)])
       ((representation-bf->repr repr) +nan.bf)))
@@ -65,25 +65,25 @@
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
   (define ulps-list (map repr-ulps reprs-list))
-  (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
-  (define roots (list->vector (map batchref-idx brfs)))
+  (define-values (expr-block vs) (progs->block exprs-list #:ctx ctx))
+  (define roots (list->vector (map val-idx vs)))
 
-  (define-values (spec-batch spec-brfs) (progs->batch (map prog->spec exprs-list) #:ctx ctx))
-  (define subexprs-fn (eval-progs-real spec-batch spec-brfs reprs-list))
+  (define-values (spec-block spec-vs) (progs->block (map prog->spec exprs-list) #:ctx ctx))
+  (define subexprs-fn (eval-progs-real spec-block spec-vs reprs-list))
 
   (define errs (make-matrix roots pcontext))
 
   (for ([(pt ex) (in-pcontext pcontext)]
         [pt-idx (in-naturals)])
     (define exacts (list->vector (subexprs-fn pt)))
-    (define (get-exact brf)
-      (vector-ref exacts (vector-member (batchref-idx brf) roots)))
+    (define (get-exact v)
+      (vector-ref exacts (vector-member (val-idx v) roots)))
     (for ([expr (in-list exprs-list)]
-          [brf brfs]
+          [v vs]
           [ulps (in-list ulps-list)]
           [exact (in-vector exacts)]
           [expr-idx (in-naturals)])
-      (define err (local-error exact (deref brf) ulps get-exact))
+      (define err (local-error exact (val-def v) ulps get-exact))
       (vector-set! (vector-ref errs expr-idx) pt-idx err)))
 
   (define n 0)
@@ -115,8 +115,8 @@
   (define spec-list (map prog->spec exprs-list))
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
   (define ulps-list (map repr-ulps reprs-list))
-  (define-values (spec-batch spec-brfs) (progs->batch spec-list #:ctx ctx))
-  (define subexprs-fn (eval-progs-real spec-batch spec-brfs reprs-list))
+  (define-values (spec-block spec-vs) (progs->block spec-list #:ctx ctx))
+  (define subexprs-fn (eval-progs-real spec-block spec-vs reprs-list))
 
   ;; And the absolute difference between the two
   (define exact-var-names
@@ -135,12 +135,11 @@
         ['bool 0] ; We can't subtract booleans so ignore them
         ['real `(fabs (- ,spec ,var))]
         [_ 0])))
-  (define-values (compare-batch compare-brfs) (progs->batch compare-specs #:ctx delta-ctx))
-  (define delta-fn
-    (eval-progs-real compare-batch compare-brfs (map (const <binary64>) compare-specs)))
+  (define-values (compare-block compare-vs) (progs->block compare-specs #:ctx delta-ctx))
+  (define delta-fn (eval-progs-real compare-block compare-vs (map (const <binary64>) compare-specs)))
 
-  (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
-  (define roots (list->vector (map batchref-idx brfs)))
+  (define-values (expr-block vs) (progs->block exprs-list #:ctx ctx))
+  (define roots (list->vector (map val-idx vs)))
 
   (define ulp-errs (make-matrix roots pcontext))
   (define exacts-out (make-matrix roots pcontext))
@@ -151,20 +150,20 @@
         [pt-idx (in-naturals)])
 
     (define exacts (list->vector (subexprs-fn pt)))
-    (define (get-exact brf)
-      (vector-ref exacts (vector-member (batchref-idx brf) roots)))
+    (define (get-exact v)
+      (vector-ref exacts (vector-member (val-idx v) roots)))
 
     (define actuals (actual-value-fn pt))
     (define pt* (vector-append pt (remove-infinities actuals reprs-list)))
     (define deltas (list->vector (delta-fn pt*)))
 
     (for ([ulps (in-list ulps-list)]
-          [brf brfs]
+          [v vs]
           [exact (in-vector exacts)]
           [actual (in-vector actuals)]
           [delta (in-vector deltas)]
           [expr-idx (in-naturals)])
-      (define ulp-err (local-error exact (deref brf) ulps get-exact))
+      (define ulp-err (local-error exact (val-def v) ulps get-exact))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref approx-out expr-idx) pt-idx actual)
       (vector-set! (vector-ref ulp-errs expr-idx) pt-idx ulp-err)

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -9,7 +9,7 @@
          "../syntax/types.rkt"
          "alt-table.rkt"
          "bsearch.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "derivations.rkt"
          "patch.rkt"
          "points.rkt"
@@ -17,7 +17,7 @@
          "preprocess.rkt"
          "programs.rkt"
          "regimes.rkt"
-         "batch-reduce.rkt")
+         "reduce.rkt")
 
 (provide run-improve!)
 
@@ -32,11 +32,11 @@
 (define/reset ^table^ #f)
 
 ;; Starting program for the current run
-(define *start-brf* (make-parameter #f))
+(define *start-v* (make-parameter #f))
 (define *pcontext* (make-parameter #f))
 (define *preprocessing* (make-parameter '()))
 
-(define *global-batch* (make-parameter #f))
+(define *global-block* (make-parameter #f))
 
 ;; These high-level functions give the high-level workflow of Herbie:
 ;; - Initial steps: explain, preprocessing, initialize the alt table
@@ -44,55 +44,55 @@
 ;; - Final steps: regimes, derivations, and remove preprocessing
 
 (define (run-improve! initial specification context pcontext)
-  (parameterize ([*global-batch* (batch-empty context)])
-    (define global-spec-batch (batch-empty context))
-    (define specification-brf (batch-add! global-spec-batch specification))
-    (define initial-brf
+  (parameterize ([*global-block* (block-empty context)])
+    (define global-spec-block (block-empty context))
+    (define specification-v (block-add! global-spec-block specification))
+    (define initial-v
       (match initial
-        [(approx _ impl) (batch-add! (*global-batch*) (approx specification-brf impl))]
-        [_ (batch-add! (*global-batch*) initial)]))
+        [(approx _ impl) (block-add! (*global-block*) (approx specification-v impl))]
+        [_ (block-add! (*global-block*) initial)]))
     (timeline-event! 'preprocess)
     (define preprocessing
       (if (flag-set? 'setup 'preprocess)
-          (find-preprocessing global-spec-batch specification-brf context)
+          (find-preprocessing global-spec-block specification-v context)
           '()))
     (timeline-push! 'symmetry (map ~a preprocessing))
     (define pcontext* (preprocess-pcontext context pcontext preprocessing))
     (*pcontext* pcontext*)
 
-    (define spec-reducer (batch-reduce global-spec-batch))
+    (define spec-reducer (block-reduce global-spec-block))
 
     (*preprocessing* preprocessing)
-    (*start-brf* initial-brf)
-    (define start-alt (alt initial-brf 'start '()))
-    (^table^ (make-alt-table (*global-batch*) pcontext start-alt))
+    (*start-v* initial-v)
+    (define start-alt (alt initial-v 'start '()))
+    (^table^ (make-alt-table (*global-block*) pcontext start-alt))
 
     (for ([_ (in-range (*num-iterations*))]
           #:break (atab-completed? (^table^)))
-      (run-iteration! global-spec-batch spec-reducer))
-    (define alternatives (extract! global-spec-batch))
+      (run-iteration! global-spec-block spec-reducer))
+    (define alternatives (extract! global-spec-block))
     (timeline-event! 'preprocess)
     (for/list ([altn alternatives])
       (define expr (alt-expr altn))
       (define expr* (compile-useful-preprocessing expr context pcontext (*preprocessing*)))
       (alt expr* 'add-preprocessing (list altn)))))
 
-(define (extract! spec-batch)
-  (timeline-push-alts! '() spec-batch)
+(define (extract! spec-block)
+  (timeline-push-alts! '() spec-block)
   (define all-alts (atab-all-alts (^table^)))
-  (define joined-alts (make-regime! (*global-batch*) all-alts (*start-brf*) spec-batch))
+  (define joined-alts (make-regime! (*global-block*) all-alts (*start-v*) spec-block))
   (define annotated-alts (add-derivations! joined-alts))
-  (define scores (batch-errors (*global-batch*) (map alt-expr annotated-alts) (*pcontext*)))
-  (define sorted-alts (map car (sort-alts (*global-batch*) annotated-alts scores)))
-  (define unbatched-alts (unbatchify-alts (*global-batch*) sorted-alts spec-batch))
+  (define scores (block-errors (*global-block*) (map alt-expr annotated-alts) (*pcontext*)))
+  (define sorted-alts (map car (sort-alts (*global-block*) annotated-alts scores)))
+  (define unblocked-alts (unblockify-alts (*global-block*) sorted-alts spec-block))
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
-  unbatched-alts)
+  unblocked-alts)
 
 ;; The rest of the file is various helper / glue functions used by
 ;; Herbie. These often wrap other Herbie components, but add logging
 ;; and timeline data.
 
-(define (dump-intermediates! batch altns spec-batch)
+(define (dump-intermediates! block altns spec-block)
   (define dump-dir "dump-intermediates")
   (unless (directory-exists? dump-dir)
     (make-directory dump-dir))
@@ -100,25 +100,25 @@
     (for/first ([i (in-naturals)]
                 #:unless (file-exists? (build-path dump-dir (format "~a.rktd" i))))
       (build-path dump-dir (format "~a.rktd" i))))
-  (define spec-f (batch-exprs spec-batch))
-  (define exprs (batch-exprs batch #:spec-f spec-f))
+  (define spec-f (block-exprs spec-block))
+  (define exprs (block-exprs block #:spec-f spec-f))
   (call-with-output-file name
                          #:exists 'replace
                          (lambda (out)
                            (for ([altn (in-list altns)])
                              (writeln (exprs (alt-expr altn)) out)))))
 
-(define (batch-score-alts altns)
-  (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*))))
+(define (block-score-alts altns)
+  (map errors-score (block-errors (*global-block*) (map alt-expr altns) (*pcontext*))))
 
-(define (timeline-push-alts! next-alts spec-batch)
+(define (timeline-push-alts! next-alts spec-block)
   (define pending-alts (atab-not-done-alts (^table^)))
   (define active-alts (atab-active-alts (^table^)))
-  (define scores (batch-score-alts active-alts))
-  (define batch-jsexpr (batch->jsexpr (*global-batch*) spec-batch (map alt-expr active-alts)))
-  (define roots (hash-ref batch-jsexpr 'roots))
+  (define scores (block-score-alts active-alts))
+  (define block-jsexpr (block->jsexpr (*global-block*) spec-block (map alt-expr active-alts)))
+  (define roots (hash-ref block-jsexpr 'roots))
   (define repr (context-repr (*context*)))
-  (timeline-push! 'batch batch-jsexpr)
+  (timeline-push! 'block block-jsexpr)
   (for ([alt (in-list active-alts)]
         [score (in-list scores)]
         [root (in-list roots)])
@@ -148,9 +148,9 @@
   (timeline-event! 'reconstruct)
 
   (define (group-equivalent-alts alts)
-    (define fn (compile-batch (*global-batch*) (map alt-expr alts)))
+    (define fn (compile-block (*global-block*) (map alt-expr alts)))
     (define signatures (make-vector (length alts) '()))
-    (define batch-cost (alt-batch-costs (*global-batch*)))
+    (define block-cost (alt-block-costs (*global-block*)))
 
     (for ([pt (in-vector (pcontext-points (*pcontext*)))])
       (define outs (fn pt))
@@ -159,8 +159,8 @@
         (vector-set! signatures idx (cons out (vector-ref signatures idx)))))
 
     (define (best-alt alt1 alt2)
-      (define cost1 (batch-cost (alt-expr alt1)))
-      (define cost2 (batch-cost (alt-expr alt2)))
+      (define cost1 (block-cost (alt-expr alt1)))
+      (define cost2 (block-cost (alt-expr alt2)))
       (if (or (< cost1 cost2) (and (= cost1 cost2) (expr<? (alt-expr alt1) (alt-expr alt2))))
           alt1
           alt2))
@@ -179,7 +179,7 @@
       (unless (set-member? seen cur)
         (set-add! seen cur)
         (for-each recurse! (vector-ref parents cur))))
-    (recurse! (batchref-idx root))
+    (recurse! (val-idx root))
     seen)
 
   (define (reconstruct-alt altn orig can-refer)
@@ -193,22 +193,22 @@
              [(list 'evaluate) (list 'evaluate start-expr)]
              [(list 'taylor name var order) (list 'taylor start-expr name var order)]
              [(list 'rr input proof) (list 'rr (alt-expr prev) cur-expr input proof)]))
-         (define expr* (batch-replace-subexpr batch (alt-expr orig) start-expr cur-expr can-refer))
+         (define expr* (block-replace-subexpr block (alt-expr orig) start-expr cur-expr can-refer))
          (values (alt expr* event* (list prev-altn)) start-expr)]))
     (define-values (result-alt _) (loop altn))
     result-alt)
 
-  (define batch (*global-batch*))
-  (define parents (make-vector (batch-length batch) '()))
-  (define (walk-body brf recurse)
-    (define idx (batchref-idx brf))
-    (expr-recurse (deref brf)
+  (define block (*global-block*))
+  (define parents (make-vector (block-length block) '()))
+  (define (walk-body v recurse)
+    (define idx (val-idx v))
+    (expr-recurse (val-def v)
                   (lambda (child)
-                    (define child-idx (batchref-idx child))
+                    (define child-idx (val-idx child))
                     (vector-set! parents child-idx (cons idx (vector-ref parents child-idx)))
                     (recurse child)))
     (void))
-  (for-each (batch-recurse batch walk-body) (map alt-expr starting-alts))
+  (for-each (block-recurse block walk-body) (map alt-expr starting-alts))
   (define new-alts* (group-equivalent-alts new-alts))
   (timeline-push! 'count (length new-alts) (length new-alts*))
   (define grouped-alts (group-by get-starting-expr new-alts*))
@@ -218,20 +218,20 @@
                [can-refer (in-value (compute-referrers parents (get-starting-expr (car start-alts))))]
                [altn (in-list start-alts)]
                [full-altn (in-list starting-alts)]
-               #:when (set-member? can-refer (batchref-idx (alt-expr full-altn))))
+               #:when (set-member? can-refer (val-idx (alt-expr full-altn))))
      (reconstruct-alt altn full-altn can-refer))
-   #:key (compose batchref-idx alt-expr)))
+   #:key (compose val-idx alt-expr)))
 
 ;; Finish iteration
-(define (finalize-iter! picked-alts patched spec-batch)
+(define (finalize-iter! picked-alts patched spec-block)
   (when (flag-set? 'dump 'intermediates)
-    (dump-intermediates! (*global-batch*) patched spec-batch))
+    (dump-intermediates! (*global-block*) patched spec-block))
   (timeline-event! 'eval)
   (define orig-all-alts (atab-active-alts (^table^)))
   (define orig-fresh-alts (atab-not-done-alts (^table^)))
   (define orig-done-alts (set-subtract orig-all-alts (atab-not-done-alts (^table^))))
 
-  (define-values (errss costs) (atab-eval-altns (^table^) (*global-batch*) patched))
+  (define-values (errss costs) (atab-eval-altns (^table^) (*global-block*) patched))
   (timeline-event! 'prune)
   (^table^ (atab-add-altns (^table^) patched errss costs))
   (define final-fresh-set (list->seteq (atab-not-done-alts (^table^))))
@@ -253,7 +253,7 @@
           'picked
           (list (length picked-alts) (set-intersect-size picked-alts final-done-set))))
   (timeline-push! 'kept data)
-  (define free-vars (batch-free-vars (*global-batch*)))
+  (define free-vars (block-free-vars (*global-block*)))
   (for ([altn (in-list patched)])
     (match (taylor-record altn)
       [(alt _ `(taylor ,start-expr ,transform ,var ,order) prevs)
@@ -262,57 +262,57 @@
        (timeline-push! 'taylor-count (~a transform) order nvars 1 (if kept? 1 0))]
       [#f (void)]))
 
-  (define repr (batch-repr-of (*start-brf*)))
+  (define repr (block-repr-of (*start-v*)))
   (timeline-push! 'min-error
                   (errors-score (atab-min-errors (^table^)))
                   (format "~a" (representation-name repr)))
   (void))
 
-(define (run-iteration! global-spec-batch spec-reducer)
+(define (run-iteration! global-spec-block spec-reducer)
   (define pending-alts (atab-not-done-alts (^table^)))
-  (timeline-push-alts! pending-alts global-spec-batch)
+  (timeline-push-alts! pending-alts global-spec-block)
   (^table^ (atab-set-picked (^table^) pending-alts))
 
-  (define brfs (map alt-expr pending-alts))
-  (define brfs* (batch-reachable (*global-batch*) brfs #:condition node-is-impl?))
+  (define vs (map alt-expr pending-alts))
+  (define vs* (block-reachable (*global-block*) vs #:condition node-is-impl?))
 
-  (define results (generate-candidates (*global-batch*) brfs* global-spec-batch spec-reducer))
+  (define results (generate-candidates (*global-block*) vs* global-spec-block spec-reducer))
   (define patched (reconstruct! pending-alts results))
-  (finalize-iter! pending-alts patched global-spec-batch)
+  (finalize-iter! pending-alts patched global-spec-block)
   (void))
 
-(define (make-regime! batch alts start-prog spec-batch)
-  (define repr (batch-repr-of start-prog))
-  (define alt-costs (alt-batch-costs batch))
+(define (make-regime! block alts start-prog spec-block)
+  (define repr (block-repr-of start-prog))
+  (define alt-costs (alt-block-costs block))
 
   (cond
     [(and (flag-set? 'reduce 'regimes)
           (> (length alts) 1)
           (equal? (representation-type repr) 'real)
-          (not (null? (batch-vars batch)))
+          (not (null? (block-vars block)))
           (get-fpcore-impl 'if '() (list <bool> repr repr))
           (get-fpcore-impl '<= '() (list repr repr)))
      (define opts
-       (pareto-regimes batch
+       (pareto-regimes block
                        (sort alts < #:key (compose alt-costs alt-expr))
                        start-prog
                        (*pcontext*)
-                       spec-batch))
+                       spec-block))
      (for/list ([opt (in-list opts)])
-       (match-define (option splitindices opt-alts _ brf) opt)
+       (match-define (option splitindices opt-alts _ v) opt)
        (timeline-event! 'bsearch)
        (define use-binary?
          (and (flag-set? 'reduce 'binary-search)
               (> (length splitindices) 1)
-              (critical-subexpression? batch start-prog brf)
+              (critical-subexpression? block start-prog v)
               (for/and ([alt (in-list opt-alts)])
-                (critical-subexpression? batch (alt-expr alt) brf))))
+                (critical-subexpression? block (alt-expr alt) v))))
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
-         [use-binary? (combine-alts/binary batch opt start-prog (*pcontext*))]
-         [else (combine-alts batch opt)]))]
+         [use-binary? (combine-alts/binary block opt start-prog (*pcontext*))]
+         [else (combine-alts block opt)]))]
     [else
-     (define scores (batch-score-alts alts))
+     (define scores (block-score-alts alts))
      (list (cdr (argmin car (map (λ (a s) (cons s a)) alts scores))))]))
 
 (define (add-derivations! alts)
@@ -322,9 +322,9 @@
      (add-derivations alts)]
     [else alts]))
 
-(define (sort-alts batch alts errss)
+(define (sort-alts block alts errss)
   ;; sort everything by error + cost
-  (define alt-costs (alt-batch-costs batch))
+  (define alt-costs (alt-block-costs block))
   (define alts-to-be-sorted (map cons alts errss))
   (sort alts-to-be-sorted
         (lambda (x y)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -7,7 +7,7 @@
          "../utils/common.rkt"
          "../syntax/float.rkt"
          "../utils/timeline.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "egg-herbie.rkt"
          "egglog-herbie.rkt"
          "programs.rkt"
@@ -32,67 +32,67 @@
 
 (struct taylor-approx (spec repr impl-spec name var order prev) #:transparent)
 
-(define (taylor-alts altns global-batch spec-batch reducer)
+(define (taylor-alts altns global-block spec-block reducer)
   (define vars
-    (for/list ([var (in-list (batch-vars global-batch))]
-               [repr (in-list (batch-var-reprs global-batch))]
+    (for/list ([var (in-list (block-vars global-block))]
+               [repr (in-list (block-var-reprs global-block))]
                #:when (equal? (representation-type repr) 'real))
       var))
-  (define brfs (map alt-expr altns))
-  (define reprs (map batch-repr-of brfs))
+  (define vs (map alt-expr altns))
+  (define reprs (map block-repr-of vs))
   ;; Specs
-  (define spec-brfs (batch-to-spec! global-batch spec-batch brfs))
-  (define free-vars (map (batch-free-vars spec-batch) spec-brfs))
+  (define spec-vs (block-to-spec! global-block spec-block vs))
+  (define free-vars (map (block-free-vars spec-block) spec-vs))
 
   (reap [sow]
-        (parameterize ([reduce reducer] ;; reduces over spec-batch
-                       [add (λ (x) (batch-add! spec-batch x))]) ;; adds to spec-batch
+        (parameterize ([reduce reducer] ;; reduces over spec-block
+                       [add (λ (x) (block-add! spec-block x))]) ;; adds to spec-block
           ;; Zero expansion
-          (for ([spec-brf (in-list spec-brfs)]
+          (for ([spec-v (in-list spec-vs)]
                 [repr (in-list reprs)]
                 [altn (in-list altns)]
                 #:when (equal? (representation-type repr) 'real))
-            (define genexpr0 (batch-add! spec-batch 0))
-            (sow (taylor-approx spec-brf repr genexpr0 'zero 'undef-var -1 altn)))
+            (define genexpr0 (block-add! spec-block 0))
+            (sow (taylor-approx spec-v repr genexpr0 'zero 'undef-var -1 altn)))
 
           ;; Taylor expansions
           ;; List<List<(cons offset coeffs)>>
-          (define taylor-coeffs (taylor-coefficients spec-batch spec-brfs vars transforms-to-try))
+          (define taylor-coeffs (taylor-coefficients spec-block spec-vs vars transforms-to-try))
           (define idx 0)
           (for* ([var (in-list vars)]
                  [transform-type transforms-to-try])
             (match-define (list name f finv) transform-type)
             (define timeline-stop! (timeline-start! 'series (~a var) (~a name)))
             (define taylor-coeffs* (list-ref taylor-coeffs idx))
-            (define genexprs (approximate taylor-coeffs* spec-batch var #:transform (cons f finv)))
+            (define genexprs (approximate taylor-coeffs* spec-block var #:transform (cons f finv)))
             (for ([genexpr (in-list genexprs)]
-                  [spec-brf (in-list spec-brfs)]
+                  [spec-v (in-list spec-vs)]
                   [repr (in-list reprs)]
                   [altn (in-list altns)]
                   [fv (in-list free-vars)]
                   #:when (set-member? fv var)) ;; check whether var exists in expr at all
               (for ([i (in-range (*taylor-order-limit*))])
-                (sow (taylor-approx spec-brf repr (genexpr) name var i altn))))
+                (sow (taylor-approx spec-v repr (genexpr) name var i altn))))
             (set! idx (add1 idx))
             (timeline-stop!)))))
 
-(define (run-taylor altns global-batch spec-batch reducer)
+(define (run-taylor altns global-block spec-block reducer)
   (timeline-event! 'series)
   (define (taylor-key x)
     (taylor-approx-impl-spec x))
   (define (approx-key x)
-    (approx-impl (deref (alt-expr x))))
+    (approx-impl (val-def (alt-expr x))))
 
   (define approxs
-    (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key taylor-key))
+    (remove-duplicates (taylor-alts altns global-block spec-block reducer) #:key taylor-key))
   (define approxs*
-    (remove-duplicates (run-lowering approxs global-batch spec-batch) #:key approx-key))
-  (timeline-push! 'inputs (batch->jsexpr global-batch spec-batch (map alt-expr altns)))
-  (timeline-push! 'outputs (batch->jsexpr global-batch spec-batch (map alt-expr approxs*)))
+    (remove-duplicates (run-lowering approxs global-block spec-block) #:key approx-key))
+  (timeline-push! 'inputs (block->jsexpr global-block spec-block (map alt-expr altns)))
+  (timeline-push! 'outputs (block->jsexpr global-block spec-block (map alt-expr approxs*)))
   (timeline-push! 'count (length altns) (length approxs*))
   approxs*)
 
-(define (run-lowering taylors global-batch spec-batch)
+(define (run-lowering taylors global-block spec-block)
   (define schedule '(lower))
 
   ; run egg
@@ -109,52 +109,52 @@
 
   (define runner
     (cond
-      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-batch impl-specs schedule (*context*))]
-      [else (make-egraph spec-batch impl-specs schedule (*context*))]))
+      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-block impl-specs schedule (*context*))]
+      [else (make-egraph spec-block impl-specs schedule (*context*))]))
 
-  (define batchrefss
+  (define valss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog runner global-batch reprs 'taylor #:extract 1)
-        (egraph-best runner global-batch reprs)))
+        (run-egglog runner global-block reprs 'taylor #:extract 1)
+        (egraph-best runner global-block reprs)))
 
   ; apply changelists
   (reap [sow]
-        (for ([batchrefs (in-list batchrefss)]
+        (for ([vals (in-list valss)]
               [spec (in-list specs)]
               [name (in-list names)]
               [var (in-list vars)]
               [order (in-list orders)]
               [prev (in-list prevs)])
-          (for ([batchref* (in-list batchrefs)])
-            (define brf (batch-add! global-batch (approx spec batchref*)))
-            (define taylor-altn (alt brf `(taylor ,name ,var ,order) (list prev)))
-            (sow (alt brf (list 'rr runner #f) (list taylor-altn)))))))
+          (for ([val* (in-list vals)])
+            (define v (block-add! global-block (approx spec val*)))
+            (define taylor-altn (alt v `(taylor ,name ,var ,order) (list prev)))
+            (sow (alt v (list 'rr runner #f) (list taylor-altn)))))))
 
-(define (run-evaluate altns global-batch spec-batch)
+(define (run-evaluate altns global-block spec-block)
   (timeline-event! 'sample)
-  (define all-brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch spec-batch all-brfs))
-  (define constant-batch (batch-empty (context '() #f '())))
-  (define copy-constant (batch-copy-only! constant-batch spec-batch))
-  (define constant-brfs (map copy-constant spec-brfs))
-  (define free-vars (batch-free-vars constant-batch))
+  (define all-vs (map alt-expr altns))
+  (define spec-vs (block-to-spec! global-block spec-block all-vs))
+  (define constant-block (block-empty (context '() #f '())))
+  (define copy-constant (block-copy-only! constant-block spec-block))
+  (define constant-vs (map copy-constant spec-vs))
+  (define free-vars (block-free-vars constant-block))
   (define real-pairs
     (for/list ([altn (in-list altns)]
-               [constant-brf (in-list constant-brfs)]
-               #:when (set-empty? (free-vars constant-brf))
-               #:unless (literal? (deref (alt-expr altn)))
-               #:when (equal? (representation-type (batch-repr-of (alt-expr altn))) 'real))
-      (cons altn constant-brf)))
+               [constant-v (in-list constant-vs)]
+               #:when (set-empty? (free-vars constant-v))
+               #:unless (literal? (val-def (alt-expr altn)))
+               #:when (equal? (representation-type (block-repr-of (alt-expr altn))) 'real))
+      (cons altn constant-v)))
   (define real-altns (map car real-pairs))
-  (define real-spec-brfs (map cdr real-pairs))
+  (define real-spec-vs (map cdr real-pairs))
 
-  (define brfs (map alt-expr real-altns))
-  (define reprs (map batch-repr-of brfs))
+  (define vs (map alt-expr real-altns))
+  (define reprs (map block-repr-of vs))
 
   (define-values (status pts)
-    (if (null? real-spec-brfs)
+    (if (null? real-spec-vs)
         (values 'invalid #f)
-        (let ([real-compiler (make-real-compiler constant-batch real-spec-brfs reprs)])
+        (let ([real-compiler (make-real-compiler constant-block real-spec-vs reprs)])
           (real-apply real-compiler (vector)))))
   (define literals
     (for/list ([pt (in-list (if (equal? status 'valid)
@@ -168,44 +168,44 @@
     (for/list ([literal (in-list literals)]
                [altn (in-list real-altns)]
                #:when (equal? status 'valid))
-      (define brf (batch-add! global-batch literal))
-      (alt brf '(evaluate) (list altn))))
+      (define v (block-add! global-block literal))
+      (alt v '(evaluate) (list altn))))
 
-  (timeline-push! 'inputs (batch->jsexpr constant-batch constant-batch real-spec-brfs))
+  (timeline-push! 'inputs (block->jsexpr constant-block constant-block real-spec-vs))
   (timeline-push! 'outputs (map ~a literals))
   final-altns)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (run-rr altns global-batch spec-batch)
+(define (run-rr altns global-block spec-block)
   (timeline-event! 'rewrite)
 
   ; egg schedule (4-phases for mathematical rewrites, sound-X removal, and implementation selection)
   (define schedule '(rewrite unsound lower))
 
-  (define brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch spec-batch brfs))
-  (define reprs (map batch-repr-of brfs))
+  (define vs (map alt-expr altns))
+  (define spec-vs (block-to-spec! global-block spec-block vs))
+  (define reprs (map block-repr-of vs))
   (define runner
     (cond
-      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-batch spec-brfs schedule (*context*))]
-      [else (make-egraph spec-batch spec-brfs schedule (*context*))]))
+      [(flag-set? 'generate 'egglog) (make-egglog-runner spec-block spec-vs schedule (*context*))]
+      [else (make-egraph spec-block spec-vs schedule (*context*))]))
 
-  (define batchrefss
+  (define valss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog runner global-batch reprs 'rewrite #:extract 1000000) ; "infinity"
-        (egraph-variations runner global-batch reprs)))
+        (run-egglog runner global-block reprs 'rewrite #:extract 1000000) ; "infinity"
+        (egraph-variations runner global-block reprs)))
 
   ; apply changelists
   (define rewritten
     (reap [sow]
-          (for ([batchrefs (in-list batchrefss)]
+          (for ([vals (in-list valss)]
                 [altn (in-list altns)])
-            (for ([batchref* (in-list batchrefs)])
-              (sow (alt batchref* (list 'rr runner #f) (list altn)))))))
+            (for ([val* (in-list vals)])
+              (sow (alt val* (list 'rr runner #f) (list altn)))))))
 
-  (timeline-push! 'inputs (batch->jsexpr global-batch spec-batch (map alt-expr altns)))
-  (timeline-push! 'outputs (batch->jsexpr global-batch spec-batch (map alt-expr rewritten)))
+  (timeline-push! 'inputs (block->jsexpr global-block spec-block (map alt-expr altns)))
+  (timeline-push! 'outputs (block->jsexpr global-block spec-block (map alt-expr rewritten)))
   (timeline-push! 'count (length altns) (length rewritten))
 
   rewritten)
@@ -217,27 +217,27 @@
     [(list) (alt-expr altn)]
     [(list prev) (get-starting-expr prev)]))
 
-(define (generate-candidates batch brfs spec-batch reducer)
+(define (generate-candidates block vs spec-block reducer)
   ; Starting alternatives
   (define start-altns
-    (for/list ([brf brfs])
-      (alt brf 'patch '())))
+    (for/list ([v vs])
+      (alt v 'patch '())))
 
   (define evaluations
     (if (flag-set? 'generate 'evaluate)
-        (run-evaluate start-altns batch spec-batch)
+        (run-evaluate start-altns block spec-block)
         '()))
 
   ; Series expand
   (define approximations
     (if (flag-set? 'generate 'taylor)
-        (run-taylor start-altns batch spec-batch reducer)
+        (run-taylor start-altns block spec-block reducer)
         '()))
 
   ; Recursive rewrite
   (define rewritten
     (if (flag-set? 'generate 'rr)
-        (run-rr start-altns batch spec-batch)
+        (run-rr start-altns block spec-block)
         '()))
 
   (remove-duplicates (append evaluations rewritten approximations)

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -3,7 +3,7 @@
 (require math/flonum
          "../syntax/float.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "programs.rkt"
          "compiler.rkt")
 
@@ -15,7 +15,7 @@
          split-pcontext
          pcontext-length
          errors
-         batch-errors
+         block-errors
          exprs-errors
          errors-score)
 
@@ -66,10 +66,10 @@
   (define num-exprs (length exprs))
   (generate-errors fn pcontext (context-repr ctx) num-exprs))
 
-(define (batch-errors batch brfs pcontext)
-  (define fn (compile-batch batch brfs))
-  (define num-exprs (length brfs))
-  (generate-errors fn pcontext (batch-repr-of (first brfs)) num-exprs))
+(define (block-errors block vs pcontext)
+  (define fn (compile-block block vs))
+  (define num-exprs (length vs))
+  (generate-errors fn pcontext (block-repr-of (first vs)) num-exprs))
 
 (define (generate-errors fn pcontext repr num-exprs)
   (define ulps (repr-ulps repr))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -7,7 +7,7 @@
          "../utils/common.rkt"
          "../syntax/float.rkt"
          "../utils/timeline.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "egg-herbie.rkt"
          "points.rkt"
          "programs.rkt"
@@ -30,66 +30,65 @@
   (and (get-fpcore-impl '* (repr->prop repr) (list repr repr))
        (get-fpcore-impl 'copysign (repr->prop repr) (list repr repr))))
 
-(define (batch-replace-vars! batch replacements)
-  (batch-recurse
-   batch
-   (lambda (brf recurse)
-     (dict-ref replacements
-               brf
-               (lambda ()
-                 (batch-push! batch (expr-recurse (deref brf) (compose batchref-idx recurse))))))))
+(define (block-replace-vars! block replacements)
+  (block-recurse block
+                 (lambda (v recurse)
+                   (dict-ref replacements
+                             v
+                             (lambda ()
+                               (block-push! block
+                                            (expr-recurse (val-def v) (compose val-idx recurse))))))))
 
 ;; The even identities: f(x) = f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-even-identities batch spec-brf output-repr)
-  (for/list ([var (in-list (batch-vars batch))]
-             [repr (in-list (batch-var-reprs batch))]
+(define (make-even-identities block spec-v output-repr)
+  (for/list ([var (in-list (block-vars block))]
+             [repr (in-list (block-var-reprs block))]
              #:when (has-fabs-impl? repr))
-    (define var-brf (batch-add! batch var))
-    (define neg-var-brf (batch-add! batch `(neg ,var-brf)))
-    (define replace-neg ((batch-replace-vars! batch `((,var-brf . ,neg-var-brf))) spec-brf))
+    (define var-v (block-add! block var))
+    (define neg-var-v (block-add! block `(neg ,var-v)))
+    (define replace-neg ((block-replace-vars! block `((,var-v . ,neg-var-v))) spec-v))
     (cons `(abs ,var) replace-neg)))
 
 ;; The odd identities: f(x) = -f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-odd-identities batch spec-brf output-repr)
-  (for/list ([var (in-list (batch-vars batch))]
-             [repr (in-list (batch-var-reprs batch))]
+(define (make-odd-identities block spec-v output-repr)
+  (for/list ([var (in-list (block-vars block))]
+             [repr (in-list (block-var-reprs block))]
              #:when (and (has-fabs-impl? repr) (has-copysign-impl? output-repr)))
-    (define neg-spec-brf (batch-add! batch `(neg ,spec-brf)))
-    (define var-brf (batch-add! batch var))
-    (define neg-var-brf (batch-add! batch `(neg ,var-brf)))
-    (define replace-neg ((batch-replace-vars! batch `((,var-brf . ,neg-var-brf))) neg-spec-brf))
+    (define neg-spec-v (block-add! block `(neg ,spec-v)))
+    (define var-v (block-add! block var))
+    (define neg-var-v (block-add! block `(neg ,var-v)))
+    (define replace-neg ((block-replace-vars! block `((,var-v . ,neg-var-v))) neg-spec-v))
     (cons `(negabs ,var) replace-neg)))
 
 ;; Sort identities: f(a, b) = f(b, a)
-(define (make-sort-identities batch spec-brf output-repr)
-  (define pairs (combinations (batch-vars batch) 2))
-  (define reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
+(define (make-sort-identities block spec-v output-repr)
+  (define pairs (combinations (block-vars block) 2))
+  (define reprs (map cons (block-vars block) (block-var-reprs block)))
   (for/list ([pair (in-list pairs)]
              ;; Can only sort same-repr variables
              #:when (equal? (dict-ref reprs (first pair)) (dict-ref reprs (second pair)))
              #:when (has-fmin-fmax-impl? (dict-ref reprs (first pair))))
     (match-define (list a b) pair)
-    (define a-brf (batch-add! batch a))
-    (define b-brf (batch-add! batch b))
-    (define sorted-spec-brf
-      ((batch-replace-vars! batch `((,a-brf . ,b-brf) (,b-brf . ,a-brf))) spec-brf))
-    (cons `(sort ,a ,b) sorted-spec-brf)))
+    (define a-v (block-add! block a))
+    (define b-v (block-add! block b))
+    (define sorted-spec-v ((block-replace-vars! block `((,a-v . ,b-v) (,b-v . ,a-v))) spec-v))
+    (cons `(sort ,a ,b) sorted-spec-v)))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
-(define (find-preprocessing batch spec-brf ctx)
+(define (find-preprocessing block spec-v ctx)
   (define repr (context-repr ctx))
 
   ;; identities
   (define identities
-    (append (make-even-identities batch spec-brf repr)
-            (make-odd-identities batch spec-brf repr)
-            (make-sort-identities batch spec-brf repr)))
+    (append (make-even-identities block spec-v repr)
+            (make-odd-identities block spec-v repr)
+            (make-sort-identities block spec-v repr)))
 
   ;; make egg runner
-  (define brfs (cons spec-brf (map cdr identities)))
-  (define runner (make-egraph batch brfs '(rewrite) ctx))
+  (define vs (cons spec-v (map cdr identities)))
+  (define runner (make-egraph block vs '(rewrite) ctx))
 
   ;; collect equalities
   (for/list ([(ident _) (in-dict identities)]

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -4,7 +4,7 @@
          "../syntax/syntax.rkt"
          "../syntax/platform.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt")
+         "../syntax/block.rkt")
 
 (provide expr?
          expr<?
@@ -14,12 +14,12 @@
          impl-prog?
          node-is-impl?
          repr-of
-         batch-repr-of
+         block-repr-of
          get-locations
          free-variables
          replace-expression
-         batch-replace-expression!
-         batch-replace-subexpr
+         block-replace-expression!
+         block-replace-subexpr
          replace-vars)
 
 ;; Programs are just lisp lists plus atoms
@@ -41,11 +41,11 @@
     [(approx _ impl) (repr-of impl ctx)]
     [(list op args ...) (impl-info op 'otype)]))
 
-(define (batch-repr-of brf)
-  (define batch (batchref-batch brf))
-  (define var-reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
-  (let loop ([brf brf])
-    (match (deref brf)
+(define (block-repr-of v)
+  (define block (val-block v))
+  (define var-reprs (map cons (block-vars block) (block-var-reprs block)))
+  (let loop ([v v])
+    (match (val-def v)
       [(literal val precision) (get-representation precision)]
       [(? symbol? node) (dict-ref var-reprs node)]
       [(approx _ impl) (loop impl)]
@@ -97,9 +97,9 @@
 
 (define (expr-cmp a b)
   (match* (a b)
-    [((? batchref?) (? batchref?)) (expr-cmp (deref a) (deref b))]
-    [((? batchref?) _) (expr-cmp (deref a) b)]
-    [(_ (? batchref?)) (expr-cmp a (deref b))]
+    [((? val?) (? val?)) (expr-cmp (val-def a) (val-def b))]
+    [((? val?) _) (expr-cmp (val-def a) b)]
+    [(_ (? val?)) (expr-cmp a (val-def b))]
     [((? list?) (? list?))
      (define len-a (length a))
      (define len-b (length b))
@@ -187,8 +187,8 @@
       [(approx spec impl) (approx (loop spec) (loop impl))]
       [(list op args ...) (cons op (map loop args))])))
 
-(define (batch-replace-expression! batch from to)
-  (define from* (deref (batch-add! batch from))) ;; a hack on how not to use deref for "from"
+(define (block-replace-expression! block from to)
+  (define from* (val-def (block-add! block from))) ;; a hack on how not to use val-def for "from"
   (define (f node)
     (match node
       [(== from*) to]
@@ -197,48 +197,48 @@
       [(? symbol?) node]
       [(approx spec impl) (approx spec impl)]
       [(list op args ...) (cons op args)]))
-  (batch-recurse batch
-                 (λ (brf recurse)
-                   (define node (deref brf))
+  (block-recurse block
+                 (λ (v recurse)
+                   (define node (val-def v))
                    (define node* (f node))
                    (let loop ([node* node*])
                      (match node*
-                       [(? batchref? brf) (recurse brf)]
-                       [_ (batch-push! batch (expr-recurse node* (compose batchref-idx loop)))])))))
+                       [(? val? v) (recurse v)]
+                       [_ (block-push! block (expr-recurse node* (compose val-idx loop)))])))))
 
-;; Replace all occurrences of `from` with `to` in expression `expr`, returning a new batchref
+;; Replace all occurrences of `from` with `to` in expression `expr`, returning a new val
 ;; Only recurses into impl parts, not specs
-(define (batch-replace-subexpr batch expr from to [can-refer #f])
+(define (block-replace-subexpr block expr from to [can-refer #f])
   (define cache (make-hasheq))
-  (define from-idx (batchref-idx from))
-  (let loop ([brf expr])
-    (define idx (batchref-idx brf))
+  (define from-idx (val-idx from))
+  (let loop ([v expr])
+    (define idx (val-idx v))
     (cond
-      [(< idx from-idx) brf]
+      [(< idx from-idx) v]
       [(= idx from-idx) to]
-      [(and can-refer (not (set-member? can-refer idx))) brf]
+      [(and can-refer (not (set-member? can-refer idx))) v]
       [else
        (hash-ref! cache
                   idx
                   (lambda ()
-                    (match (deref brf)
+                    (match (val-def v)
                       [(approx spec impl)
                        (define impl* (loop impl))
-                       (if (= (batchref-idx impl*) (batchref-idx impl))
-                           brf
-                           (batch-push! batch (approx spec (batchref-idx impl*))))]
+                       (if (= (val-idx impl*) (val-idx impl))
+                           v
+                           (block-push! block (approx spec (val-idx impl*))))]
                       [node
                        (define unchanged? #t)
                        (define node*
                          (expr-recurse node
                                        (lambda (arg)
                                          (define arg* (loop arg))
-                                         (unless (= (batchref-idx arg*) (batchref-idx arg))
+                                         (unless (= (val-idx arg*) (val-idx arg))
                                            (set! unchanged? #f))
-                                         (batchref-idx arg*))))
+                                         (val-idx arg*))))
                        (if unchanged?
-                           brf
-                           (batch-push! batch node*))])))])))
+                           v
+                           (block-push! block node*))])))])))
 
 (module+ test
   (require rackunit)

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -1,19 +1,19 @@
 #lang racket
 
 (require "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "../utils/common.rkt"
          "programs.rkt")
 
-(provide batch-reduce)
+(provide block-reduce)
 
-(define global-batch (make-parameter #f))
+(define global-block (make-parameter #f))
 
 ;; This is a transcription of egg-herbie/src/math.rs, lines 97-149
-(define (batch-eval-application batch)
+(define (block-eval-application block)
   (define exact-value? (conjoin number? exact?))
-  (define (eval-application brf recurse)
-    (match (deref brf)
+  (define (eval-application v recurse)
+    (match (val-def v)
       [(? exact-value? val)
        val] ;; this part is not naive in rewriting. should be considered for the future
       [(list '+ (app recurse (? exact-value? as)) ...) (apply + as)]
@@ -49,119 +49,119 @@
       [(list 'exp (app recurse 0)) 1]
       [(list 'log (app recurse 1)) 0]
       [_ #f]))
-  (batch-recurse batch eval-application))
+  (block-recurse block eval-application))
 
-(define (batch-reduce batch)
+(define (block-reduce block)
   ;; Dependencies
-  (define eval-application (batch-eval-application batch))
-  (define gather-multiplicative-terms (batch-gather-multiplicative-terms batch eval-application))
+  (define eval-application (block-eval-application block))
+  (define gather-multiplicative-terms (block-gather-multiplicative-terms block eval-application))
 
   (letrec ([reduce-node
-            (batch-recurse
-             batch
-             (lambda (brf recurse)
-               (define brf* (reduce-evaluation brf))
-               (match (deref brf*)
-                 [(? number?) brf*]
-                 [(? symbol?) brf*]
+            (block-recurse
+             block
+             (lambda (v recurse)
+               (define v* (reduce-evaluation v))
+               (match (val-def v*)
+                 [(? number?) v*]
+                 [(? symbol?) v*]
                  [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))
-                  (make-addition-node (combine-aterms (gather-additive-terms brf*)))]
+                  (make-addition-node (combine-aterms (gather-additive-terms v*)))]
                  [(or `(* ,_ ...)
                       `(/ ,_ ...)
                       `(cbrt ,_)
-                      `(pow ,_ ,(app deref (? (conjoin rational? (negate even-denominator?))))))
-                  (make-multiplication-node (combine-mterms (gather-multiplicative-terms brf*)))]
-                 [(list 'exp (app deref (list '* c (app deref (list 'log x)))))
-                  (define rewrite (batch-add! batch `(pow ,x ,c)))
+                      `(pow ,_ ,(app val-def (? (conjoin rational? (negate even-denominator?))))))
+                  (make-multiplication-node (combine-mterms (gather-multiplicative-terms v*)))]
+                 [(list 'exp (app val-def (list '* c (app val-def (list 'log x)))))
+                  (define rewrite (block-add! block `(pow ,x ,c)))
                   (recurse rewrite)]
-                 [else (reduce-inverses brf*)])))]
+                 [else (reduce-inverses v*)])))]
            [gather-additive-terms
-            (batch-recurse
-             batch
-             (lambda (brf recurse)
-               (match (deref brf)
-                 [(? number? n) `((,n ,(batch-push! batch 1)))]
-                 [(? symbol?) `((1 ,brf))]
+            (block-recurse
+             block
+             (lambda (v recurse)
+               (match (val-def v)
+                 [(? number? n) `((,n ,(block-push! block 1)))]
+                 [(? symbol?) `((1 ,v))]
                  [`(+ ,args ...) (append-map recurse args)]
                  [`(neg ,arg) (map negate-term (recurse arg))]
                  [`(- ,arg ,args ...)
                   (append (recurse arg) (map negate-term (append-map recurse args)))]
                  ; Prevent fall-through to the next case
-                 [`(/ ,arg) `((1 ,brf))]
+                 [`(/ ,arg) `((1 ,v))]
                  [`(/ ,arg ,args ...)
                   (for/list ([term (recurse arg)])
-                    (list (car term) (reduce-node (batch-add! batch (list* '/ (cadr term) args)))))]
-                 [else `((1 ,brf))])))])
+                    (list (car term) (reduce-node (block-add! block (list* '/ (cadr term) args)))))]
+                 [else `((1 ,v))])))])
 
     ;; Actual code
-    (define (reduce brf recurse)
-      (parameterize ([global-batch batch])
-        (define node (deref brf))
+    (define (reduce v recurse)
+      (parameterize ([global-block block])
+        (define node (val-def v))
         (match node
-          [(? number?) brf]
-          [(? symbol?) brf]
+          [(? number?) v]
+          [(? symbol?) v]
           [`(,op ,args ...)
            (define args* (map recurse args))
-           (define brf* (batch-add! batch (list* op args*)))
-           (define val (eval-application brf*))
-           (when val ;; convert to batchref if result is not #f
-             (set! val (batch-push! batch val)))
-           (or val (reduce-node brf*))])))
-    (batch-recurse batch reduce)))
+           (define v* (block-add! block (list* op args*)))
+           (define val (eval-application v*))
+           (when val ;; convert to val if result is not #f
+             (set! val (block-push! block val)))
+           (or val (reduce-node v*))])))
+    (block-recurse block reduce)))
 
-(define (reduce-evaluation brf)
-  (define batch (batchref-batch brf))
+(define (reduce-evaluation v)
+  (define block (val-block v))
   (define (pi-multiple expr)
     (match expr
       [`(PI) 1]
-      [`(* ,(app deref (? rational? coeff)) ,(app deref '(PI))) coeff]
-      [`(* ,(app deref '(PI)) ,(app deref (? rational? coeff))) coeff]
-      [`(/ ,(app deref '(PI)) ,(app deref (? rational? denom))) (/ denom)]
+      [`(* ,(app val-def (? rational? coeff)) ,(app val-def '(PI))) coeff]
+      [`(* ,(app val-def '(PI)) ,(app val-def (? rational? coeff))) coeff]
+      [`(/ ,(app val-def '(PI)) ,(app val-def (? rational? denom))) (/ denom)]
       [_ #f]))
   (define node*
-    (match (deref brf)
-      [(list 'sin (app deref 0)) 0]
-      [(list 'cos (app deref 0)) 1]
-      [(list 'sin (app deref (app pi-multiple 1))) 0]
-      [(list 'cos (app deref (app pi-multiple 1))) -1]
-      [(list 'exp (app deref 1)) '(E)]
-      [(list 'tan (app deref 0)) 0]
-      [(list 'sinh (app deref 0)) 0]
-      [(list 'log (app deref (list 'E))) 1]
-      [(list 'exp (app deref 0)) 1]
-      [(list 'tan (app deref (app pi-multiple 1))) 0]
-      [(list 'cosh (app deref 0)) 1]
-      [(list 'cos (app deref (app pi-multiple 1/6))) '(/ (sqrt 3) 2)]
-      [(list 'tan (app deref (app pi-multiple 1/3))) '(sqrt 3)]
-      [(list 'tan (app deref (app pi-multiple 1/4))) 1]
-      [(list 'cos (app deref (app pi-multiple 1/2))) 0]
-      [(list 'tan (app deref (app pi-multiple 1/6))) '(/ 1 (sqrt 3))]
-      [(list 'sin (app deref (app pi-multiple 1/3))) '(/ (sqrt 3) 2)]
-      [(list 'sin (app deref (app pi-multiple 1/6))) 1/2]
-      [(list 'sin (app deref (app pi-multiple 1/4))) '(/ (sqrt 2) 2)]
-      [(list 'sin (app deref (app pi-multiple 1/2))) 1]
-      [(list 'cos (app deref (app pi-multiple 1/3))) 1/2]
-      [(list 'cos (app deref (app pi-multiple 1/4))) '(/ (sqrt 2) 2)]
+    (match (val-def v)
+      [(list 'sin (app val-def 0)) 0]
+      [(list 'cos (app val-def 0)) 1]
+      [(list 'sin (app val-def (app pi-multiple 1))) 0]
+      [(list 'cos (app val-def (app pi-multiple 1))) -1]
+      [(list 'exp (app val-def 1)) '(E)]
+      [(list 'tan (app val-def 0)) 0]
+      [(list 'sinh (app val-def 0)) 0]
+      [(list 'log (app val-def (list 'E))) 1]
+      [(list 'exp (app val-def 0)) 1]
+      [(list 'tan (app val-def (app pi-multiple 1))) 0]
+      [(list 'cosh (app val-def 0)) 1]
+      [(list 'cos (app val-def (app pi-multiple 1/6))) '(/ (sqrt 3) 2)]
+      [(list 'tan (app val-def (app pi-multiple 1/3))) '(sqrt 3)]
+      [(list 'tan (app val-def (app pi-multiple 1/4))) 1]
+      [(list 'cos (app val-def (app pi-multiple 1/2))) 0]
+      [(list 'tan (app val-def (app pi-multiple 1/6))) '(/ 1 (sqrt 3))]
+      [(list 'sin (app val-def (app pi-multiple 1/3))) '(/ (sqrt 3) 2)]
+      [(list 'sin (app val-def (app pi-multiple 1/6))) 1/2]
+      [(list 'sin (app val-def (app pi-multiple 1/4))) '(/ (sqrt 2) 2)]
+      [(list 'sin (app val-def (app pi-multiple 1/2))) 1]
+      [(list 'cos (app val-def (app pi-multiple 1/3))) 1/2]
+      [(list 'cos (app val-def (app pi-multiple 1/4))) '(/ (sqrt 2) 2)]
       [node node]))
-  (batch-add! batch node*))
+  (block-add! block node*))
 
-(define (reduce-inverses brf)
-  (match (deref brf)
-    [(list 'tanh (app deref (list 'atanh x))) x]
-    [(list 'cosh (app deref (list 'acosh x))) x]
-    [(list 'sinh (app deref (list 'asinh x))) x]
-    [(list 'acos (app deref (list 'cos x))) x]
-    [(list 'asin (app deref (list 'sin x))) x]
-    [(list 'atan (app deref (list 'tan x))) x]
-    [(list 'tan (app deref (list 'atan x))) x]
-    [(list 'cos (app deref (list 'acos x))) x]
-    [(list 'sin (app deref (list 'asin x))) x]
-    [(list 'pow x (app deref 1)) x]
-    [(list 'log (app deref (list 'exp x))) x]
-    [(list 'exp (app deref (list 'log x))) x]
-    [(list 'cbrt (app deref (list 'pow x (app deref 3)))) x]
-    [(list 'pow (app deref (list 'cbrt x)) (app deref 3)) x]
-    [_ brf]))
+(define (reduce-inverses v)
+  (match (val-def v)
+    [(list 'tanh (app val-def (list 'atanh x))) x]
+    [(list 'cosh (app val-def (list 'acosh x))) x]
+    [(list 'sinh (app val-def (list 'asinh x))) x]
+    [(list 'acos (app val-def (list 'cos x))) x]
+    [(list 'asin (app val-def (list 'sin x))) x]
+    [(list 'atan (app val-def (list 'tan x))) x]
+    [(list 'tan (app val-def (list 'atan x))) x]
+    [(list 'cos (app val-def (list 'acos x))) x]
+    [(list 'sin (app val-def (list 'asin x))) x]
+    [(list 'pow x (app val-def 1)) x]
+    [(list 'log (app val-def (list 'exp x))) x]
+    [(list 'exp (app val-def (list 'log x))) x]
+    [(list 'cbrt (app val-def (list 'pow x (app val-def 3)))) x]
+    [(list 'pow (app val-def (list 'cbrt x)) (app val-def 3)) x]
+    [_ v]))
 
 (define (negate-term term)
   (cons (- (car term)) (cdr term)))
@@ -169,14 +169,14 @@
 (define (even-denominator? x)
   (even? (denominator x)))
 
-(define (batch-gather-multiplicative-terms batch eval-application)
+(define (block-gather-multiplicative-terms block eval-application)
   (define (nan-term)
-    `(+nan.0 . ((1 . ,(batch-push! batch 1)))))
-  (define (gather-multiplicative-terms brf recurse)
-    (match (deref brf)
+    `(+nan.0 . ((1 . ,(block-push! block 1)))))
+  (define (gather-multiplicative-terms v recurse)
+    (match (val-def v)
       [+nan.0 (nan-term)]
       [(? number? n) (list n)]
-      [(? symbol?) `(1 . ((1 . ,brf)))]
+      [(? symbol?) `(1 . ((1 . ,v)))]
       [`(neg ,arg)
        (define terms (recurse arg))
        (if (eq? (car terms) +nan.0)
@@ -204,36 +204,36 @@
        (cond
          [(equal? (car terms) +nan.0) (nan-term)]
          [else
-          (define exact-cbrt (eval-application (batch-add! batch (list 'cbrt (car terms)))))
+          (define exact-cbrt (eval-application (block-add! block (list 'cbrt (car terms)))))
           (if exact-cbrt
               (cons exact-cbrt
                     (for/list ([term (cdr terms)])
                       (cons (/ (car term) 3) (cdr term))))
               (list* 1
-                     (cons 1 (batch-add! batch `(cbrt ,(car terms))))
+                     (cons 1 (block-add! block `(cbrt ,(car terms))))
                      (for/list ([term (cdr terms)])
                        (cons (/ (car term) 3) (cdr term)))))])]
-      [`(pow ,arg ,(app deref 0))
+      [`(pow ,arg ,(app val-def 0))
        (define terms (recurse arg))
        (if (equal? (car terms) +nan.0)
            (nan-term)
            `(1 . ()))]
-      [`(pow ,arg ,(app deref (? (conjoin rational? (negate even-denominator?)) a)))
+      [`(pow ,arg ,(app val-def (? (conjoin rational? (negate even-denominator?)) a)))
        (define terms (recurse arg))
        (define exact-pow
          (match (car terms)
            [+nan.0 +nan.0]
-           [x (eval-application (batch-add! batch (list 'pow x a)))]))
+           [x (eval-application (block-add! block (list 'pow x a)))]))
        (if exact-pow
            (cons exact-pow
                  (for/list ([term (cdr terms)])
                    (cons (* a (car term)) (cdr term))))
            (list* 1
-                  (cons a (batch-push! batch (car terms)))
+                  (cons a (block-push! block (car terms)))
                   (for/list ([term (cdr terms)])
                     (cons (* a (car term)) (cdr term)))))]
-      [_ `(1 . ((1 . ,brf)))]))
-  (batch-recurse batch gather-multiplicative-terms))
+      [_ `(1 . ((1 . ,v)))]))
+  (block-recurse block gather-multiplicative-terms))
 
 (define (combine-aterms terms)
   (define h (make-hash))
@@ -261,37 +261,38 @@
 (define (aterm->expr term)
   (match term
     [`(1 . ,x) x]
-    [`(,x . ,(app deref 1)) (batch-push! (global-batch) x)]
-    [`(-1 . ,x) (batch-add! (global-batch) `(neg ,x))]
-    [`(,coeff . ,x) (batch-add! (global-batch) `(* ,coeff ,x))]))
+    [`(,x . ,(app val-def 1)) (block-push! (global-block) x)]
+    [`(-1 . ,x) (block-add! (global-block) `(neg ,x))]
+    [`(,coeff . ,x) (block-add! (global-block) `(* ,coeff ,x))]))
 
 (define (make-addition-node terms)
   (define-values (pos neg) (partition (λ (x) (and (real? (car x)) (positive? (car x)))) terms))
   (cond
-    [(and (null? pos) (null? neg)) (batch-push! (global-batch) 0)]
-    [(null? pos) (batch-add! (global-batch) `(neg ,(make-addition-node* (map negate-term neg))))]
+    [(and (null? pos) (null? neg)) (block-push! (global-block) 0)]
+    [(null? pos) (block-add! (global-block) `(neg ,(make-addition-node* (map negate-term neg))))]
     [(null? neg) (make-addition-node* pos)]
     [else
-     (batch-add! (global-batch)
+     (block-add! (global-block)
                  `(- ,(make-addition-node* pos) ,(make-addition-node* (map negate-term neg))))]))
 
 (define (make-addition-node* terms)
   (match terms
-    ['() (batch-push! (global-batch) 0)]
+    ['() (block-push! (global-block) 0)]
     [`(,term) (aterm->expr term)]
     [`(,term ,terms ...)
-     (batch-add! (global-batch) `(+ ,(aterm->expr term) ,(make-addition-node terms)))]))
+     (block-add! (global-block) `(+ ,(aterm->expr term) ,(make-addition-node terms)))]))
 
 (define (make-multiplication-node term)
   (match (cons (car term) (make-multiplication-subnode (cdr term)))
-    [(cons +nan.0 e) (batch-push! (global-batch) '(NAN))]
-    [(cons 0 e) (batch-push! (global-batch) 0)]
-    [(cons 1 '()) (batch-push! (global-batch) 1)]
+    [(cons +nan.0 e) (block-push! (global-block) '(NAN))]
+    [(cons 0 e) (block-push! (global-block) 0)]
+    [(cons 1 '()) (block-push! (global-block) 1)]
     [(cons 1 e) e]
-    [(cons a (app deref 1)) (batch-push! (global-batch) a)]
-    [(cons a (app deref (list '/ (app deref 1) denom))) (batch-add! (global-batch) `(/ ,a ,denom))]
-    [(cons a '()) (batch-push! (global-batch) a)]
-    [(cons a e) (batch-add! (global-batch) `(* ,a ,e))]))
+    [(cons a (app val-def 1)) (block-push! (global-block) a)]
+    [(cons a (app val-def (list '/ (app val-def 1) denom)))
+     (block-add! (global-block) `(/ ,a ,denom))]
+    [(cons a '()) (block-push! (global-block) a)]
+    [(cons a e) (block-add! (global-block) `(* ,a ,e))]))
 
 (define (make-multiplication-subnode terms)
   (make-multiplication-subsubsubnode
@@ -300,49 +301,49 @@
 (define (make-multiplication-subsubnode terms)
   (define-values (pos neg) (partition (compose positive? car) terms))
   (cond
-    [(and (null? pos) (null? neg)) (batch-push! (global-batch) 1)]
+    [(and (null? pos) (null? neg)) (block-push! (global-block) 1)]
     [(null? pos)
-     (batch-add! (global-batch) `(/ 1 ,(make-multiplication-subsubsubnode (map negate-term neg))))]
+     (block-add! (global-block) `(/ 1 ,(make-multiplication-subsubsubnode (map negate-term neg))))]
     [(null? neg) (make-multiplication-subsubsubnode pos)]
     [else
-     (batch-add! (global-batch)
+     (block-add! (global-block)
                  `(/ ,(make-multiplication-subsubsubnode pos)
                      ,(make-multiplication-subsubsubnode (map negate-term neg))))]))
 
 (define (make-multiplication-subsubsubnode terms)
   (match terms
-    ['() (batch-push! (global-batch) 1)]
+    ['() (block-push! (global-block) 1)]
     [`(,term) (mterm->expr term)]
     [`(,term ,terms ...)
-     (batch-add! (global-batch)
+     (block-add! (global-block)
                  `(* ,(mterm->expr term) ,(make-multiplication-subsubsubnode terms)))]))
 
 (define (mterm->expr term)
   (match term
     [(cons (? exact-integer? power) x)
      (cond
-       [(zero? power) (batch-push! (global-batch) 1)]
+       [(zero? power) (block-push! (global-block) 1)]
        [(= power 1) x]
-       [(negative? power) (batch-add! (global-batch) `(/ 1 ,(mterm->expr (cons (- power) x))))]
+       [(negative? power) (block-add! (global-block) `(/ 1 ,(mterm->expr (cons (- power) x))))]
        [(even? power)
         (define factor (mterm->expr (cons (/ power 2) x)))
-        (batch-add! (global-batch) `(* ,factor ,factor))]
-       [else (batch-add! (global-batch) `(* ,x ,(mterm->expr (cons (sub1 power) x))))])]
+        (block-add! (global-block) `(* ,factor ,factor))]
+       [else (block-add! (global-block) `(* ,x ,(mterm->expr (cons (sub1 power) x))))])]
     [(cons (? rational? power) x)
      (match (denominator power)
-       [2 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(sqrt ,x))))]
-       [3 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(cbrt ,x))))]
-       [_ (batch-add! (global-batch) `(pow ,x ,power))])]
-    [(cons power x) (batch-add! (global-batch) `(pow ,x ,power))]))
+       [2 (mterm->expr (cons (numerator power) (block-add! (global-block) `(sqrt ,x))))]
+       [3 (mterm->expr (cons (numerator power) (block-add! (global-block) `(cbrt ,x))))]
+       [_ (block-add! (global-block) `(pow ,x ,power))])]
+    [(cons power x) (block-add! (global-block) `(pow ,x ,power))]))
 
 (module+ test
   (require rackunit)
-  (define batch (batch-empty (context '() #f '())))
-  (define evaluator (batch-eval-application batch))
+  (define block (block-empty (context '() #f '())))
+  (define evaluator (block-eval-application block))
   (define (evaluator-results expr)
-    (evaluator (batch-add! batch expr)))
+    (evaluator (block-add! block expr)))
 
-  ;; Checks for batch-eval-application
+  ;; Checks for block-eval-application
   (check-equal? (evaluator-results '(+ 1 1)) 2)
   (check-equal? (evaluator-results '(+)) 0)
   (check-equal? (evaluator-results '(/ 1 0)) #f) ; Not valid
@@ -350,17 +351,17 @@
   (check-equal? (evaluator-results '(log 1)) 0)
   (check-equal? (evaluator-results '(exp 2)) #f) ; Not exact
 
-  ;; Checks for batch-reduce-evaluation
+  ;; Checks for block-reduce-evaluation
   (define (reducer-results expr)
-    ((batch-exprs batch) (reduce-evaluation (batch-add! batch expr))))
+    ((block-exprs block) (reduce-evaluation (block-add! block expr))))
   (check-equal? (reducer-results '(cos (/ (PI) 6))) '(/ (sqrt 3) 2))
   (check-equal? (reducer-results '(sin (/ (PI) 4))) '(/ (sqrt 2) 2))
   (check-equal? (reducer-results '(cos (PI))) -1)
   (check-equal? (reducer-results '(exp 1)) '(E))
 
-  ;; Checks for batch-reduce-inverses
+  ;; Checks for block-reduce-inverses
   (define (inverse-reducer-results expr)
-    ((batch-exprs batch) (reduce-inverses (batch-add! batch expr))))
+    ((block-exprs block) (reduce-inverses (block-add! block expr))))
   (check-equal? (inverse-reducer-results '(cosh (acosh x))) 'x)
   (check-equal? (inverse-reducer-results '(tanh (atanh x))) 'x)
   (check-equal? (inverse-reducer-results '(sinh (asinh x))) 'x)
@@ -377,10 +378,10 @@
   (check-equal? (inverse-reducer-results '(cbrt (pow x 3))) 'x)
   (check-equal? (inverse-reducer-results '(pow (cbrt x) 3)) 'x)
 
-  ;; Checks for batch-reduce
-  (define reduce (batch-reduce batch))
+  ;; Checks for block-reduce
+  (define reduce (block-reduce block))
   (define (reduce-results expr)
-    ((batch-exprs batch) (reduce (batch-add! batch expr))))
+    ((block-exprs block) (reduce (block-add! block expr))))
   (check-equal? '(- (* (+ 1 x) (+ 1 x)) 1) (reduce-results '(- (* (+ x 1) (+ x 1)) 1)))
   (check-equal? '(neg (* 2 (/ 1 x))) (reduce-results '(+ (/ 1 (neg x)) (/ 1 (neg x)))))
   (check-equal? '(- (* (- 1 (/ 1 x)) (- 1 (/ 1 x))) 1)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -16,7 +16,7 @@
          "../syntax/syntax.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "compiler.rkt"
          "points.rkt"
          "programs.rkt")
@@ -35,8 +35,8 @@
       (context (free-variables expr)
                <binary64>
                (make-list (length (free-variables expr)) <binary64>)))
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
-    (critical-subexpression? batch (first brfs) (batch-add! batch subexpr))))
+    (define-values (block vs) (progs->block (list expr) #:ctx ctx))
+    (critical-subexpression? block (first vs) (block-add! block subexpr))))
 
 (struct option (split-indices alts pts expr)
   #:transparent
@@ -44,39 +44,39 @@
   [(define (write-proc opt port mode)
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
-;; CONSIDER: move start-prog and the "branch-brfs" computation into caller.
-(define (pareto-regimes batch sorted start-prog pcontext spec-batch)
+;; CONSIDER: move start-prog and the "branch-vs" computation into caller.
+(define (pareto-regimes block sorted start-prog pcontext spec-block)
   (timeline-event! 'regimes)
   (define alts-vec (list->vector sorted))
   (define alt-count (vector-length alts-vec))
-  (define err-cols (batch-errors batch (map alt-expr sorted) pcontext))
-  (define (real-brf? brf)
-    (equal? (representation-type (batch-repr-of brf)) 'real))
-  (define branch-brfs
-    (filter real-brf?
+  (define err-cols (block-errors block (map alt-expr sorted) pcontext))
+  (define (real-v? v)
+    (equal? (representation-type (block-repr-of v)) 'real))
+  (define branch-vs
+    (filter real-v?
             (if (flag-set? 'reduce 'branch-expressions)
-                (critical-subexpressions batch start-prog)
-                (map (curry batch-add! batch) (batch-vars batch)))))
+                (critical-subexpressions block start-prog)
+                (map (curry block-add! block) (block-vars block)))))
 
-  (define brf-vals (brf-values* batch branch-brfs pcontext))
+  (define v-vals (v-values* block branch-vs pcontext))
   (define pts-vec (pcontext-points pcontext))
 
   ;; For timeline
-  (define batch-jsexpr (batch->jsexpr batch spec-batch (append (map alt-expr sorted) branch-brfs)))
-  (timeline-push! 'batch batch-jsexpr)
-  (define branch-roots (drop (hash-ref batch-jsexpr 'roots) alt-count))
-  (define branch-root-map (make-immutable-hash (map cons branch-brfs branch-roots)))
+  (define block-jsexpr (block->jsexpr block spec-block (append (map alt-expr sorted) branch-vs)))
+  (timeline-push! 'block block-jsexpr)
+  (define branch-roots (drop (hash-ref block-jsexpr 'roots) alt-count))
+  (define branch-root-map (make-immutable-hash (map cons branch-vs branch-roots)))
 
   (define option-curves
-    (for/list ([brf (in-list branch-brfs)]
-               [brf-vals-vec (in-list brf-vals)])
-      (define timeline-stop! (timeline-start! 'times (batch->jsexpr batch spec-batch (list brf))))
-      (define repr (batch-repr-of brf))
-      (define curve (branch-options batch alts-vec err-cols pts-vec brf brf-vals-vec repr))
+    (for/list ([v (in-list branch-vs)]
+               [v-vals-vec (in-list v-vals)])
+      (define timeline-stop! (timeline-start! 'times (block->jsexpr block spec-block (list v))))
+      (define repr (block-repr-of v))
+      (define curve (branch-options block alts-vec err-cols pts-vec v v-vals-vec repr))
       (define last-point (last curve))
       (timeline-stop!)
       (timeline-push! 'branch
-                      (hash-ref branch-root-map brf)
+                      (hash-ref branch-root-map v)
                       (- (pareto-point-error last-point)
                          (length (option-split-indices (pareto-point-data last-point))))
                       (length (option-split-indices (pareto-point-data last-point)))
@@ -87,11 +87,11 @@
       (pareto-union curve branch-curve #:combine (lambda (old _new) old))))
 
   ;; Timeline
-  (timeline-push! 'inputs (batch->jsexpr batch spec-batch (map alt-expr sorted)))
+  (timeline-push! 'inputs (block->jsexpr block spec-block (map alt-expr sorted)))
   (timeline-push!
    'outputs
-   (batch->jsexpr batch
-                  spec-batch
+   (block->jsexpr block
+                  spec-block
                   (remove-duplicates
                    (for*/list ([ppt (in-list combined-option-curve)]
                                [sidx (in-list (option-split-indices (pareto-point-data ppt)))])
@@ -105,59 +105,59 @@
                     (baseline-errors-score err-cols (pareto-point-cost ppt)))
     opt))
 
-(define (critical-subexpression? batch root-brf sub-brf)
-  (set-member? (critical-subexpressions batch root-brf) sub-brf))
+(define (critical-subexpression? block root-v sub-v)
+  (set-member? (critical-subexpressions block root-v) sub-v))
 
-(define (critical-subexpressions batch root-brf)
-  (define var-brfs (map (curry batch-add! batch) (batch-vars batch)))
-  (define free-vars (batch-free-vars batch))
-  (define dom-parent (build-dominator-tree batch root-brf))
-  (define (dominates? parent-brf child-brf)
+(define (critical-subexpressions block root-v)
+  (define var-vs (map (curry block-add! block) (block-vars block)))
+  (define free-vars (block-free-vars block))
+  (define dom-parent (build-dominator-tree block root-v))
+  (define (dominates? parent-v child-v)
     (cond
-      [(equal? parent-brf child-brf) #t]
-      [(equal? child-brf root-brf) #f]
-      [else (dominates? parent-brf (dom-parent child-brf))]))
-  (define (extractable? brf)
-    (for/and ([var (in-set (free-vars brf))])
-      (dominates? brf (batch-add! batch var))))
+      [(equal? parent-v child-v) #t]
+      [(equal? child-v root-v) #f]
+      [else (dominates? parent-v (dom-parent child-v))]))
+  (define (extractable? v)
+    (for/and ([var (in-set (free-vars v))])
+      (dominates? v (block-add! block var))))
   (reap [sow]
-        (define seen-brfs (mutable-set root-brf))
-        (sow root-brf)
-        (for ([brf (in-list var-brfs)])
-          (when (dom-parent brf)
-            (let loop ([brf brf])
-              (unless (set-member? seen-brfs brf)
-                (set-add! seen-brfs brf)
-                (when (extractable? brf)
-                  (sow brf))
-                (loop (dom-parent brf))))))))
+        (define seen-vs (mutable-set root-v))
+        (sow root-v)
+        (for ([v (in-list var-vs)])
+          (when (dom-parent v)
+            (let loop ([v v])
+              (unless (set-member? seen-vs v)
+                (set-add! seen-vs v)
+                (when (extractable? v)
+                  (sow v))
+                (loop (dom-parent v))))))))
 
-(define (build-dominator-tree batch root-brf)
-  (define reachable-brfs (reverse (batch-reachable batch (list root-brf))))
-  (define dom-parents (make-vector (batch-length batch) #f))
-  (define (dom-parent brf)
-    (vector-ref dom-parents (batchref-idx brf)))
-  (define (update-child! brf child-brf)
-    (define old-parent (dom-parent child-brf))
+(define (build-dominator-tree block root-v)
+  (define reachable-vs (reverse (block-reachable block (list root-v))))
+  (define dom-parents (make-vector (block-length block) #f))
+  (define (dom-parent v)
+    (vector-ref dom-parents (val-idx v)))
+  (define (update-child! v child-v)
+    (define old-parent (dom-parent child-v))
     (define new-parent
       (if old-parent
-          (dominator-lca brf old-parent dom-parent)
-          brf))
-    (vector-set! dom-parents (batchref-idx child-brf) new-parent))
-  (vector-set! dom-parents (batchref-idx root-brf) root-brf)
-  (for ([brf (in-list reachable-brfs)])
-    (expr-recurse (deref brf) (lambda (child) (update-child! brf child))))
+          (dominator-lca v old-parent dom-parent)
+          v))
+    (vector-set! dom-parents (val-idx child-v) new-parent))
+  (vector-set! dom-parents (val-idx root-v) root-v)
+  (for ([v (in-list reachable-vs)])
+    (expr-recurse (val-def v) (lambda (child) (update-child! v child))))
   dom-parent)
 
-(define (dominator-lca brf1 brf2 dom-parent)
-  (let loop ([brf1 brf1]
-             [brf2 brf2])
-    (define idx1 (batchref-idx brf1))
-    (define idx2 (batchref-idx brf2))
+(define (dominator-lca v1 v2 dom-parent)
+  (let loop ([v1 v1]
+             [v2 v2])
+    (define idx1 (val-idx v1))
+    (define idx2 (val-idx v2))
     (cond
-      [(= idx1 idx2) brf1]
-      [(< idx1 idx2) (loop (dom-parent brf1) brf2)]
-      [else (loop brf1 (dom-parent brf2))])))
+      [(= idx1 idx2) v1]
+      [(< idx1 idx2) (loop (dom-parent v1) v2)]
+      [else (loop v1 (dom-parent v2))])))
 
 (define (baseline-errors-score err-cols count)
   (for/fold ([best +inf.0]) ([err-col (in-list (take err-cols count))])
@@ -170,9 +170,9 @@
                 (min best-err (flvector-ref err-col point-idx))))
      num-points))
 
-(define (brf-values* batch brfs pcontext)
-  (define count (length brfs))
-  (define fn (compile-batch batch brfs))
+(define (v-values* block vs pcontext)
+  (define count (length vs))
+  (define fn (compile-block block vs))
   (define num-points (pcontext-length pcontext))
   (define vals (build-vector count (lambda (_) (make-vector num-points))))
   (for ([pt (in-vector (pcontext-points pcontext))]
@@ -182,11 +182,10 @@
       (vector-set! (vector-ref vals i) p out)))
   (vector->list vals))
 
-(define (branch-options batch alts-vec err-cols pts-vec brf brf-vals-vec repr)
+(define (branch-options block alts-vec err-cols pts-vec v v-vals-vec repr)
   (define sorted-indices
-    (vector-sort (build-vector (vector-length brf-vals-vec) values)
-                 (lambda (i j)
-                   (</total (vector-ref brf-vals-vec i) (vector-ref brf-vals-vec j) repr))))
+    (vector-sort (build-vector (vector-length v-vals-vec) values)
+                 (lambda (i j) (</total (vector-ref v-vals-vec i) (vector-ref v-vals-vec j) repr))))
   (define pts*
     (for/list ([i (in-vector sorted-indices)])
       (vector-ref pts-vec i)))
@@ -194,7 +193,7 @@
     (cons #f
           (for/list ([idx (in-vector sorted-indices 1)]
                      [prev-idx (in-vector sorted-indices 0)])
-            (</total (vector-ref brf-vals-vec prev-idx) (vector-ref brf-vals-vec idx) repr))))
+            (</total (vector-ref v-vals-vec prev-idx) (vector-ref v-vals-vec idx) repr))))
 
   (define-values (splitss scores) (infer-option-prefixes err-cols sorted-indices can-split?))
 
@@ -203,7 +202,7 @@
       (define split-indices (vector-ref splitss (sub1 count)))
       (define alts (vector->list (vector-take alts-vec count)))
       (define error (+ (/ (flvector-ref scores (sub1 count)) (vector-length sorted-indices)) 1))
-      (pareto-point count error (option split-indices alts pts* brf))))
+      (pareto-point count error (option split-indices alts pts* v))))
   (for/fold ([curve '()]) ([point (in-list points)])
     (pareto-union curve (list point) #:combine (lambda (old _new) old))))
 
@@ -218,29 +217,23 @@
   (define pts-vec (pcontext-points pctx))
 
   (define (test-regimes expr goal)
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
-    (define brf (car brfs))
-    (define brf-vals (car (brf-values* batch (list brf) pctx)))
+    (define-values (block vs) (progs->block (list expr) #:ctx ctx))
+    (define v (car vs))
+    (define v-vals (car (v-values* block (list v) pctx)))
     (check
      (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y))
      (pareto-point-data
-      (first
-       (branch-options batch (list->vector alts) err-cols pts-vec brf brf-vals (batch-repr-of brf))))
+      (first (branch-options block (list->vector alts) err-cols pts-vec v v-vals (block-repr-of v))))
      goal))
 
   (define (test-regimes/prefixes expr goals)
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
-    (define brf (car brfs))
-    (define brf-vals (car (brf-values* batch (list brf) pctx)))
+    (define-values (block vs) (progs->block (list expr) #:ctx ctx))
+    (define v (car vs))
+    (define v-vals (car (v-values* block (list v) pctx)))
     (define options
       (map pareto-point-data
-           (reverse (branch-options batch
-                                    (list->vector alts)
-                                    err-cols
-                                    pts-vec
-                                    brf
-                                    brf-vals
-                                    (batch-repr-of brf)))))
+           (reverse
+            (branch-options block (list->vector alts) err-cols pts-vec v v-vals (block-repr-of v)))))
     (for ([goal (in-list goals)]
           [opt (in-list options)])
       (check (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y)) opt goal)))
@@ -267,14 +260,14 @@
 
   (let ()
     (define xy-ctx (context '(x y) <binary64> (list <binary64> <binary64>)))
-    (define-values (batch brfs) (progs->batch (list 'x) #:ctx xy-ctx))
-    (check-true (critical-subexpression? batch (first brfs) (batch-add! batch 'x)))
-    (check-false (critical-subexpression? batch (first brfs) (batch-add! batch 'y))))
+    (define-values (block vs) (progs->block (list 'x) #:ctx xy-ctx))
+    (check-true (critical-subexpression? block (first vs) (block-add! block 'x)))
+    (check-false (critical-subexpression? block (first vs) (block-add! block 'y))))
 
   (let ()
     (define xyz-ctx (context '(x y z) <binary64> (list <binary64> <binary64> <binary64>)))
-    (define-values (batch brfs) (progs->batch (list '(* (+ x y) (/ x z))) #:ctx xyz-ctx))
-    (check-false (critical-subexpression? batch (first brfs) (batch-add! batch '(+ x y)))))
+    (define-values (block vs) (progs->block (list '(* (+ x y) (/ x z))) #:ctx xyz-ctx))
+    (check-false (critical-subexpression? block (first vs) (block-add! block '(+ x y)))))
 
   (let ()
     (define vec2-ctx
@@ -285,8 +278,8 @@
     (define dot-product
       '(+.f64 (*.f64 (ref.f64 a #s(literal 0 binary64)) (ref.f64 b #s(literal 0 binary64)))
               (*.f64 (ref.f64 a #s(literal 1 binary64)) (ref.f64 b #s(literal 1 binary64)))))
-    (define-values (batch brfs) (progs->batch (list dot-product) #:ctx vec2-ctx))
-    (check-true (set-member? (critical-subexpressions batch (first brfs)) (first brfs)))))
+    (define-values (block vs) (progs->block (list dot-product) #:ctx vec2-ctx))
+    (check-true (set-member? (critical-subexpressions block (first vs)) (first vs)))))
 
 (define (valid-splitindices? can-split? split-indices)
   (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -7,11 +7,11 @@
          "../syntax/float.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "searchreals.rkt"
          "../syntax/rival.rkt")
 
-(provide batch-prepare-points
+(provide block-prepare-points
          sample-points)
 
 ;; Part 1: use FPBench's condition->range-table to create initial hyperrects
@@ -120,7 +120,7 @@
 ;; Returns an evaluator for a list of expressions.
 ;; Part 3: compute exact values using Rival's algorithm
 
-(define (batch-prepare-points compiler sampler)
+(define (block-prepare-points compiler sampler)
   ;; If we're using the bf fallback, start at the max precision
   (define outcomes (make-hash))
   (define vars (real-compiler-vars compiler))
@@ -180,12 +180,12 @@
   (for/fold ([t1 (hash-remove (hash-remove t1 'unknown) 'valid)]) ([(k v) (in-hash t2)])
     (hash-set t1 k (+ (hash-ref t1 k 0) (* (/ v t2-total) t1-base)))))
 
-(define (sample-points pre batch brfs reprs)
+(define (sample-points pre block vs reprs)
   (timeline-event! 'analyze)
-  (define compiler (make-real-compiler batch brfs reprs #:pre pre))
+  (define compiler (make-real-compiler block vs reprs #:pre pre))
   (define-values (sampler table) (make-sampler compiler))
   (timeline-event! 'sample)
-  (define-values (results table2) (batch-prepare-points compiler sampler))
+  (define-values (results table2) (block-prepare-points compiler sampler))
   (define total (apply + (hash-values table2)))
   (when (> (hash-ref table2 'infinite 0.0) (* 0.2 total))
     (warn 'inf-points

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -5,7 +5,7 @@
          "../utils/dvector.rkt"
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "programs.rkt")
 
 (provide approximate
@@ -22,22 +22,22 @@
 (define (adder x)
   ((add) x))
 
-(define (taylor-coefficients batch brfs vars transforms-to-try)
-  (define expander (expand-taylor! batch))
+(define (taylor-coefficients block vs vars transforms-to-try)
+  (define expander (expand-taylor! block))
   (for*/list ([var (in-list vars)]
-              #:do [(define taylorer (taylor var batch))]
+              #:do [(define taylorer (taylor var block))]
               [transform-type transforms-to-try])
     (match-define (list name f finv) transform-type)
-    (define replacer (batch-replace-expression! batch var (f var)))
-    (for/list ([brf (in-list brfs)])
-      (taylorer (expander (reducer (replacer brf)))))))
+    (define replacer (block-replace-expression! block var (f var)))
+    (for/list ([v (in-list vs)])
+      (taylorer (expander (reducer (replacer v)))))))
 
 (define (approximate taylor-approxs
-                     batch
+                     block
                      var
                      #:transform [tform (cons identity identity)]
                      #:iters [iters 5])
-  (define replacer (batch-replace-expression! batch var ((cdr tform) var)))
+  (define replacer (block-replace-expression! block var ((cdr tform) var)))
   (for/list ([ta taylor-approxs])
     (define offset (series-offset ta))
     (define i 0)
@@ -46,7 +46,7 @@
     (define (next [iter 0])
       (define coeff (reducer (replacer (series-ref ta i))))
       (set! i (+ i 1))
-      (match (deref coeff)
+      (match (val-def coeff)
         [0
          (if (< iter iters)
              (next (+ iter 1))
@@ -57,15 +57,15 @@
     next))
 
 ;; Our Taylor expander prefers sin, cos, exp, log, neg over trig, htrig, pow, and subtraction
-(define (expand-taylor! input-batch)
+(define (expand-taylor! input-block)
   (define (f node)
     (match node
       [(list '- ref1 ref2) `(+ ,ref1 (neg ,ref2))]
-      [(list 'pow base (app deref 1/2)) `(sqrt ,base)]
-      [(list 'pow base (app deref 1/3)) `(cbrt ,base)]
-      [(list 'pow base (app deref 2/3)) `(cbrt (* ,base ,base))]
+      [(list 'pow base (app val-def 1/2)) `(sqrt ,base)]
+      [(list 'pow base (app val-def 1/3)) `(cbrt ,base)]
+      [(list 'pow base (app val-def 2/3)) `(cbrt (* ,base ,base))]
       [(list 'pow base power)
-       #:when (exact-integer? (deref power))
+       #:when (exact-integer? (val-def power))
        `(pow ,base ,power)]
       [(list 'pow base power) `(exp (* ,power (log ,base)))]
       [(list 'tan arg) `(/ (sin ,arg) (cos ,arg))]
@@ -76,15 +76,14 @@
       [(list 'acosh arg) `(log (+ ,arg (sqrt (+ (* ,arg ,arg) -1))))]
       [(list 'atanh arg) `(* 1/2 (log (/ (+ 1 ,arg) (+ 1 (neg ,arg)))))]
       [_ node]))
-  (batch-recurse
-   input-batch
-   (λ (brf recurse)
-     (define node (deref brf))
-     (define node* (f node))
-     (let loop ([node* node*])
-       (match node*
-         [(? batchref? brf) (recurse brf)]
-         [_ (batch-push! input-batch (expr-recurse node* (compose batchref-idx loop)))])))))
+  (block-recurse input-block
+                 (λ (v recurse)
+                   (define node (val-def v))
+                   (define node* (f node))
+                   (let loop ([node* node*])
+                     (match node*
+                       [(? val? v) (recurse v)]
+                       [_ (block-push! input-block (expr-recurse node* (compose val-idx loop)))])))))
 
 ; Tests for expand-taylor
 (module+ test
@@ -92,9 +91,9 @@
   (define taylor-test-ctx (context '(x) <binary64> (list <binary64>)))
 
   (define (test-expand-taylor expr)
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx taylor-test-ctx))
-    (define brf* ((expand-taylor! batch) (car brfs)))
-    ((batch-exprs batch) brf*))
+    (define-values (block vs) (progs->block (list expr) #:ctx taylor-test-ctx))
+    (define v* ((expand-taylor! block) (car vs)))
+    ((block-exprs block) v*))
 
   (check-equal? '(* 1/2 (log (/ (+ 1 x) (+ 1 (neg x))))) (test-expand-taylor '(atanh x)))
   (check-equal? '(log (+ x (sqrt (+ (* x x) -1)))) (test-expand-taylor '(acosh x)))
@@ -154,36 +153,36 @@
                               [v (in-list (map (curry cons i) (n-sum-to (- n 1) (- k i))))])
                     v)]))))
 
-(define (taylor var expr-batch)
+(define (taylor var expr-block)
   "Return a pair (e, n), such that expr ~= e var^n"
-  (batch-recurse
-   expr-batch
-   (lambda (brf recurse)
-     (define node (deref brf))
+  (block-recurse
+   expr-block
+   (lambda (v recurse)
+     (define node (val-def v))
      (match node
        [(? (curry equal? var)) (taylor-exact (adder 0) (adder 1))]
-       [(? number?) (taylor-exact brf)]
-       [(? symbol?) (taylor-exact brf)]
-       [`(,const) (taylor-exact brf)]
+       [(? number?) (taylor-exact v)]
+       [(? symbol?) (taylor-exact v)]
+       [`(,const) (taylor-exact v)]
        [`(+ ,arg1 ,arg2) (taylor-add (recurse arg1) (recurse arg2))]
        [`(neg ,arg) (taylor-negate (recurse arg))]
        [`(* ,left ,right) (taylor-mult (recurse left) (recurse right))]
        [`(/ ,num ,den)
-        #:when (equal? (deref num) 1)
+        #:when (equal? (val-def num) 1)
         (taylor-invert (recurse den))]
        [`(/ ,num ,den) (taylor-quotient (recurse num) (recurse den))]
        [`(sqrt ,arg) (taylor-sqrt var (recurse arg))]
        [`(cbrt ,arg) (taylor-cbrt var (recurse arg))]
-       [`(fabs ,arg) (or (taylor-fabs var (recurse arg)) (taylor-exact brf))]
+       [`(fabs ,arg) (or (taylor-fabs var (recurse arg)) (taylor-exact v))]
        [`(exp ,arg)
         (define arg* (normalize-series (recurse arg)))
         (if (positive? (series-offset arg*))
-            (taylor-exact brf)
+            (taylor-exact v)
             (taylor-exp (zero-series arg*)))]
        [`(sin ,arg)
         (define arg* (normalize-series (recurse arg)))
         (cond
-          [(positive? (series-offset arg*)) (taylor-exact brf)]
+          [(positive? (series-offset arg*)) (taylor-exact v)]
           [(= (series-offset arg*) 0)
            ; Our taylor-sin function assumes that a0 is 0,
            ; because that way it is especially simple. We correct for this here
@@ -196,7 +195,7 @@
        [`(cos ,arg)
         (define arg* (normalize-series (recurse arg)))
         (cond
-          [(positive? (series-offset arg*)) (taylor-exact brf)]
+          [(positive? (series-offset arg*)) (taylor-exact v)]
           [(= (series-offset arg*) 0)
            ; Our taylor-cos function assumes that a0 is 0,
            ; because that way it is especially simple. We correct for this here
@@ -208,9 +207,9 @@
           [else (taylor-cos (zero-series arg*))])]
        [`(log ,arg) (taylor-log var (recurse arg))]
        [`(pow ,base ,power)
-        #:when (exact-integer? (deref power))
-        (taylor-pow (normalize-series (recurse base)) (deref power))]
-       [_ (taylor-exact brf)]))))
+        #:when (exact-integer? (val-def power))
+        (taylor-pow (normalize-series (recurse base)) (val-def power))]
+       [_ (taylor-exact v)]))))
 
 ; A taylor series is represented by a struct containing a coefficient builder,
 ; a cache of computed coefficients, and an integer offset to the exponent
@@ -220,20 +219,20 @@
 (struct series (offset f cache) #:transparent)
 
 (define (taylor-exact . terms)
-  ;(->* () #:rest (listof batchref?) term?)
+  ;(->* () #:rest (listof val?) term?)
   (define items (list->vector (map reducer terms)))
   (define len (vector-length items))
   (make-series 0
                (λ (f n)
                  (if (< n len)
-                     (deref (vector-ref items n))
+                     (val-def (vector-ref items n))
                      0))))
 
 (define (first-nonzero-exp f)
-  ;(-> (-> number? batchref?) number?)
+  ;(-> (-> number? val?) number?)
   "Returns n, where (series n) != 0, but (series n) = 0 for all smaller n"
   (let loop ([n 0])
-    (if (and (equal? (deref (f n)) 0) (< n 20))
+    (if (and (equal? (val-def (f n)) 0) (< n 20))
         (loop (+ n 1))
         n)))
 
@@ -281,8 +280,8 @@
   (make-series (+ (series-offset left) (series-offset right))
                (λ (f n)
                  (make-sum (for/list ([i (in-range (+ n 1))]
-                                      #:unless (or (equal? (deref (series-ref left i)) 0)
-                                                   (equal? (deref (series-ref right (- n i))) 0)))
+                                      #:unless (or (equal? (val-def (series-ref left i)) 0)
+                                                   (equal? (val-def (series-ref right (- n i))) 0)))
                              (list '* (series-ref left i) (series-ref right (- n i))))))))
 
 (define (normalize-series s)
@@ -294,10 +293,10 @@
   (define slack (first-nonzero-exp coeffs))
   (if (zero? slack)
       s
-      (make-series (- offset slack) (λ (f n) (deref (series-ref s (+ n slack)))))))
+      (make-series (- offset slack) (λ (f n) (val-def (series-ref s (+ n slack)))))))
 
 (define ((zero-series s) n)
-  ;(-> series? (-> number? batchref?))
+  ;(-> series? (-> number? val?))
   (if (< n (- (series-offset s)))
       (adder 0)
       (series-ref s (+ n (series-offset s)))))
@@ -359,7 +358,7 @@
              [_ (coeffs (+ (- i n) (modulo offset n)))]))
          (dvector-set! cache i res))
        (dvector-ref cache i))
-     (make-series offset* (λ (f i) (deref (coeffs* i))))]))
+     (make-series offset* (λ (f i) (val-def (coeffs* i))))]))
 
 (define (taylor-sqrt var num)
   ;(-> symbol? term? term?)
@@ -406,7 +405,7 @@
 (define (taylor-fabs var term)
   (define normalized (normalize-series term))
   (define offset (series-offset normalized))
-  (define a0 (deref (series-ref normalized 0)))
+  (define a0 (val-def (series-ref normalized 0)))
   (cond
     [(or (not (number? a0)) (zero? a0)) #f]
     [(and (even? offset) (negative? a0)) (taylor-negate normalized)]
@@ -450,7 +449,7 @@
                    (sow (cons head pt))))))]))
 
 (define (taylor-exp coeffs)
-  ;(-> (-> number? batchref?) term?)
+  ;(-> (-> number? val?) term?)
   (make-series 0
                (λ (f n)
                  (cond
@@ -460,7 +459,7 @@
                     (define nums
                       (for/list ([i (in-range 1 (+ n 1))]
                                  [coeff (in-vector coeffs*)]
-                                 #:unless (equal? (deref coeff) 0))
+                                 #:unless (equal? (val-def coeff) 0))
                         i))
                     `(* (exp ,(coeffs 0))
                         (+ ,@(for/list ([p (in-list (all-partitions n (sort nums >)))])
@@ -469,7 +468,7 @@
                                            ,(factorial count)))))))]))))
 
 (define (taylor-sin coeffs)
-  ;(-> (-> number? batchref?) term?)
+  ;(-> (-> number? val?) term?)
   (make-series 0
                (λ (f n)
                  (cond
@@ -479,7 +478,7 @@
                     (define nums
                       (for/list ([i (in-range 1 (+ n 1))]
                                  [coeff (in-vector coeffs*)]
-                                 #:unless (equal? (deref coeff) 0))
+                                 #:unless (equal? (val-def coeff) 0))
                         i))
                     `(+ ,@(for/list ([p (in-list (all-partitions n (sort nums >)))])
                             (if (= (modulo (apply + (map car p)) 2) 1)
@@ -490,7 +489,7 @@
                                 0)))]))))
 
 (define (taylor-cos coeffs)
-  ;(-> (-> number? batchref?) term?)
+  ;(-> (-> number? val?) term?)
   (make-series 0
                (λ (f n)
                  (cond
@@ -500,7 +499,7 @@
                     (define nums
                       (for/list ([i (in-range 1 (+ n 1))]
                                  [coeff (in-vector coeffs*)]
-                                 #:unless (equal? (deref coeff) 0))
+                                 #:unless (equal? (val-def coeff) 0))
                         i))
                     `(+ ,@(for/list ([p (in-list (all-partitions n (sort nums >)))])
                             (if (= (modulo (apply + (map car p)) 2) 0)
@@ -549,7 +548,7 @@
   (define normalized (normalize-series arg))
   (define shift (series-offset normalized))
   (define coeffs (series-function normalized))
-  (define negate? (and (number? (deref (coeffs 0))) (not (positive? (deref (coeffs 0))))))
+  (define negate? (and (number? (val-def (coeffs 0))) (not (positive? (val-def (coeffs 0))))))
   (define (maybe-negate x)
     (if negate?
         `(neg ,x)
@@ -569,7 +568,7 @@
                                    #:unless (for/or ([i (in-naturals 1)]
                                                      [p (in-list ps)]
                                                      #:when (not (= p 0)))
-                                              (equal? (deref (vector-ref coeffs* (sub1 i))) 0)))
+                                              (equal? (val-def (vector-ref coeffs* (sub1 i))) 0)))
                           `(* ,coeff
                               (/ (* ,@(for/list ([i (in-naturals 1)]
                                                  [p (in-list ps)])
@@ -591,23 +590,23 @@
 
 (module+ test
   (require rackunit)
-  (define-values (batch brfs) (progs->batch (list '(pow x 1.0)) #:ctx taylor-test-ctx))
-  (parameterize ([reduce (batch-reduce batch)]
-                 [add (λ (x) (batch-add! batch x))])
-    (define brfs* (map (expand-taylor! batch) brfs))
-    (define brf (car brfs*))
-    (check-pred exact-integer? (series-offset ((taylor 'x batch) brf)))))
+  (define-values (block vs) (progs->block (list '(pow x 1.0)) #:ctx taylor-test-ctx))
+  (parameterize ([reduce (block-reduce block)]
+                 [add (λ (x) (block-add! block x))])
+    (define vs* (map (expand-taylor! block) vs))
+    (define v (car vs*))
+    (check-pred exact-integer? (series-offset ((taylor 'x block) v)))))
 
 (module+ test
-  (require "batch-reduce.rkt")
+  (require "reduce.rkt")
   (define (coeffs expr #:n [n 7])
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx taylor-test-ctx))
-    (parameterize ([reduce (batch-reduce batch)]
-                   [add (λ (x) (batch-add! batch x))])
-      (define brfs* (map (expand-taylor! batch) brfs))
-      (define brf (car brfs*))
-      (define fn (zero-series ((taylor 'x batch) brf)))
-      (map (batch-exprs batch) (build-list n fn))))
+    (define-values (block vs) (progs->block (list expr) #:ctx taylor-test-ctx))
+    (parameterize ([reduce (block-reduce block)]
+                   [add (λ (x) (block-add! block x))])
+      (define vs* (map (expand-taylor! block) vs))
+      (define v (car vs*))
+      (define fn (zero-series ((taylor 'x block) v)))
+      (map (block-exprs block) (build-list n fn))))
   (check-equal? (coeffs '(sin x)) '(0 1 0 -1/6 0 1/120 0))
   (check-equal? (coeffs '(sqrt (+ 1 x))) '(1 1/2 -1/8 1/16 -5/128 7/256 -21/1024))
   (check-equal? (coeffs '(cbrt (+ 1 x))) '(1 1/3 -1/9 5/81 -10/243 22/729 -154/6561))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -4,7 +4,7 @@
 (require "../utils/common.rkt"
          "../syntax/float.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt"
+         "../syntax/block.rkt"
          "../syntax/rival.rkt"
          "rules.rkt"
          "programs.rkt"
@@ -37,11 +37,11 @@
   (define ctx (env->ctx p1 p2))
   (define ulps (repr-ulps double-repr))
 
-  (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2)) #:ctx ctx))
+  (define-values (block vs) (progs->block (list p1 (drop-sound p2)) #:ctx ctx))
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (sample-points '(TRUE) batch brfs (make-list 2 double-repr))))
+      (sample-points '(TRUE) block vs (make-list 2 double-repr))))
 
   (for ([pt (in-list pts)]
         [v1 (in-list exs1)]

--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -282,7 +282,7 @@ function paretoUnionBalanced(curves) {
     return level[0] || [];
 }
 
-// Merge shifted frontiers in small balanced batches. This keeps the
+// Merge shifted frontiers in small balanced blockes. This keeps the
 // large-large unions that are fast for JS without retaining every
 // shifted frontier at once.
 function paretoCombineTwo(combined, frontier) {

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -9,7 +9,7 @@
          "../syntax/types.rkt"
          "../syntax/float.rkt"
          "../config.rkt"
-         "../syntax/batch.rkt")
+         "../syntax/block.rkt")
 (provide make-timeline)
 
 (define timeline-phase? (hash/c symbol? any/c))
@@ -68,12 +68,12 @@
             ,@(dict-call curr render-phase-egraph 'egraph)
             ,@(dict-call curr render-phase-stop 'stop)
             ,@(dict-call curr render-phase-counts 'count)
-            ,@(dict-call curr render-phase-alts/shared 'alts 'batch)
+            ,@(dict-call curr render-phase-alts/shared 'alts 'block)
             ,@(dict-call curr render-phase-inputs 'inputs 'outputs)
             ,@(dict-call curr render-phase-times 'times)
             ,@(dict-call curr render-phase-series 'series)
             ,@(dict-call curr render-phase-bstep 'bstep)
-            ,@(dict-call curr render-phase-branches 'branch 'batch)
+            ,@(dict-call curr render-phase-branches 'branch 'block)
             ,@(dict-call curr render-phase-sampling 'sampling)
             ,@(dict-call curr (curryr simple-render-phase "Symmetry") 'symmetry)
             ,@(dict-call curr render-phase-outcomes 'outcomes)
@@ -328,9 +328,9 @@
                       (match-define (list inputs outputs) rec)
                       `(dd ,(~r inputs #:group-sep " ") " → " ,(~r outputs #:group-sep " ")))))
 
-(define (render-phase-alts/shared alts shared-batch)
-  (match-define (list (? hash? shared-batch*)) shared-batch)
-  (define nodes (hash-ref shared-batch* 'nodes))
+(define (render-phase-alts/shared alts shared-block)
+  (match-define (list (? hash? shared-block*)) shared-block)
+  (define nodes (hash-ref shared-block* 'nodes))
   (define (single-root-jsexpr root)
     (hash 'nodes nodes 'roots (list root)))
   `((dt "Alt Table")
@@ -346,7 +346,7 @@
                                   ["done" `(td (span ([title "Selected in a prior iteration"]) "✓"))]
                                   ["fresh" `(td)])
                                (td ,(format-accuracy score repr #:unit "%") "")
-                               (td (pre ,(jsexpr->batch-exprs (single-root-jsexpr root)))))))))))
+                               (td (pre ,(jsexpr->block-exprs (single-root-jsexpr root)))))))))))
 
 (define (render-phase-times times)
   (define hist-id (make-id))
@@ -359,8 +359,8 @@
         (table ((class "times"))
                ,@(for/list ([rec (in-list (sort times > #:key first))]
                             [_ (in-range 5)])
-                   (match-define (list time batch-jsexpr) rec)
-                   `(tr (td ,(format-time time)) (td (pre ,(jsexpr->batch-exprs batch-jsexpr)))))))))
+                   (match-define (list time block-jsexpr) rec)
+                   `(tr (td ,(format-time time)) (td (pre ,(jsexpr->block-exprs block-jsexpr)))))))))
 
 (define (render-phase-series times)
   (define hist-id (make-id))
@@ -390,10 +390,10 @@
                            ,(format-percent (- size compiled) size)
                            " saved)"))))
 
-(define (render-phase-branches branches shared-batch)
-  (match-define (list (? hash? shared-batch*)) shared-batch)
+(define (render-phase-branches branches shared-block)
+  (match-define (list (? hash? shared-block*)) shared-block)
   (define (single-root-jsexpr root)
-    (hash 'nodes (hash-ref shared-batch* 'nodes) 'roots (list root)))
+    (hash 'nodes (hash-ref shared-block* 'nodes) 'roots (list root)))
   `((dt "Results")
     (dd (table ((class "times"))
                (thead (tr (th "Accuracy") (th "Segments") (th "Branch")))
@@ -402,7 +402,7 @@
                    (define repr (get-representation (read (open-input-string repr-name))))
                    `(tr (td ,(format-accuracy score repr #:unit "%") "")
                         (td ,(~a splits))
-                        (td (pre ,(jsexpr->batch-exprs (single-root-jsexpr branch-root))))))))))
+                        (td (pre ,(jsexpr->block-exprs (single-root-jsexpr branch-root))))))))))
 
 (define (render-phase-outcomes outcomes)
   `((dt "Samples") (dd (table ((class "times"))
@@ -413,12 +413,12 @@
                                        (td ,(~a precision))
                                        (td ,(~a category))))))))
 
-(define (batch-jsexpr? x)
+(define (block-jsexpr? x)
   (and (hash? x) (hash-has-key? x 'nodes)))
 
 (define (jsexpr->exprs x)
-  (if (batch-jsexpr? x)
-      (jsexpr->batch-exprs x)
+  (if (block-jsexpr? x)
+      (jsexpr->block-exprs x)
       (string-join (map ~a x) "\n")))
 
 (define (render-phase-inputs inputs outputs)

--- a/src/syntax/block.rkt
+++ b/src/syntax/block.rkt
@@ -5,46 +5,46 @@
          "../utils/common.rkt"
          "../utils/dvector.rkt")
 
-(provide progs->batch ; List<Expr> -> (Batch, List<Batchref>)
+(provide progs->block ; List<Expr> -> (Block, List<Val>)
 
          expr-recurse
          expr-recurse-spec
-         (struct-out batch)
-         batch-empty ; Batch
-         batch-empty-extend
-         batch-push!
-         batch-add! ; Batch -> (or Expr Batchref Expr<Batchref>) -> Batchref
-         batch-copy-only!
-         batch-length ; Batch -> Integer
-         batch-free-vars ; Batch -> (Batchref -> Set<Var>)
-         in-batch ; Batch -> Sequence<Node>
-         batch-reachable ; Batch -> List<Batchref> -> (Node -> Boolean) -> List<Batchref>
-         batch-exprs
-         batch-recurse
-         batch->jsexpr
-         jsexpr->batch-exprs
+         (struct-out block)
+         block-empty ; Block
+         block-empty-extend
+         block-push!
+         block-add! ; Block -> (or Expr Val Expr<Val>) -> Val
+         block-copy-only!
+         block-length ; Block -> Integer
+         block-free-vars ; Block -> (Val -> Set<Var>)
+         in-block ; Block -> Sequence<Node>
+         block-reachable ; Block -> List<Val> -> (Node -> Boolean) -> List<Val>
+         block-exprs
+         block-recurse
+         block->jsexpr
+         jsexpr->block-exprs
 
-         (struct-out batchref)
-         deref) ; Batchref -> Expr
+         (struct-out val)
+         val-def) ; Val -> Expr
 
-;; Batches store these recursive structures, flattened
-(struct batch ([nodes #:mutable] [index #:mutable] vars var-reprs))
+;; Blocks store these recursive structures, flattened
+(struct block ([nodes #:mutable] [index #:mutable] vars var-reprs))
 
-(struct batchref (batch idx) #:transparent)
+(struct val (block idx) #:transparent)
 
-;; --------------------------------- CORE BATCH FUNCTION ------------------------------------
+;; --------------------------------- CORE BLOCK FUNCTION ------------------------------------
 
-(define (batch-empty ctx)
+(define (block-empty ctx)
   (match-define (context vars _ var-reprs) ctx)
-  (batch (make-dvector) (make-hash) vars var-reprs))
+  (block (make-dvector) (make-hash) vars var-reprs))
 
-(define (batch-empty-extend b var repr)
+(define (block-empty-extend b var repr)
   (define out
-    (batch (make-dvector) (make-hash) (cons var (batch-vars b)) (cons repr (batch-var-reprs b))))
-  (values out (batch-push! out var)))
+    (block (make-dvector) (make-hash) (cons var (block-vars b)) (cons repr (block-var-reprs b))))
+  (values out (block-push! out var)))
 
-(define (in-batch batch [start 0] [end #f] [step 1])
-  (in-dvector (batch-nodes batch) start end step))
+(define (in-block block [start 0] [end #f] [step 1])
+  (in-dvector (block-nodes block) start end step))
 
 ;; This function recurses through implementation children of expressions.
 (define (expr-recurse expr f)
@@ -63,94 +63,93 @@
     [(approx spec impl) (approx (f spec) impl)]
     [_ expr]))
 
-(define (batch-length b)
-  (dvector-length (batch-nodes b)))
+(define (block-length b)
+  (dvector-length (block-nodes b)))
 
-(define (batch-push! b term)
-  (define hashcons (batch-index b))
-  (batchref b (hash-ref! hashcons term (lambda () (dvector-add! (batch-nodes b) term)))))
+(define (block-push! b term)
+  (define hashcons (block-index b))
+  (val b (hash-ref! hashcons term (lambda () (dvector-add! (block-nodes b) term)))))
 
-(define (batch-add! b expr)
+(define (block-add! b expr)
   (define (munge prog)
     (match prog
-      [(batchref b* idx*)
-       (assert-batch-brf! b prog)
+      [(val b* idx*)
+       (assert-block-v! b prog)
        idx*]
-      [_ (batchref-idx (batch-push! b (expr-recurse prog munge)))]))
-  (batchref b (munge expr)))
+      [_ (val-idx (block-push! b (expr-recurse prog munge)))]))
+  (val b (munge expr)))
 
-(define (deref x)
-  (match-define (batchref b idx) x)
-  (expr-recurse (dvector-ref (batch-nodes b) idx) (lambda (ref) (batchref b ref))))
+(define (val-def x)
+  (match-define (val b idx) x)
+  (expr-recurse (dvector-ref (block-nodes b) idx) (lambda (ref) (val b ref))))
 
-(define (progs->batch exprs #:ctx ctx)
-  (define out (batch-empty ctx))
+(define (progs->block exprs #:ctx ctx)
+  (define out (block-empty ctx))
   (for ([var (in-list (context-vars ctx))])
-    (batch-push! out var))
-  (define brfs
+    (block-push! out var))
+  (define vs
     (for/list ([expr (in-list exprs)])
-      (batch-add! out expr)))
-  (values out brfs))
+      (block-add! out expr)))
+  (values out vs))
 
-;; batch-recurse iterates only over its children
+;; block-recurse iterates only over its children
 ;; A lot of parts of Herbie rely on that
-(define (batch-recurse batch f)
-  (define out (make-dvector (batch-length batch)))
-  (define visited (make-dvector (batch-length batch) #f))
-  (λ (brf)
-    (assert-batch-brf! batch brf)
-    (let loop ([brf brf])
-      (define idx (batchref-idx brf))
+(define (block-recurse block f)
+  (define out (make-dvector (block-length block)))
+  (define visited (make-dvector (block-length block) #f))
+  (λ (v)
+    (assert-block-v! block v)
+    (let loop ([v v])
+      (define idx (val-idx v))
       (cond
         [(and (> (dvector-capacity visited) idx) (dvector-ref visited idx)) (dvector-ref out idx)]
         [else
-         (define res (f brf loop))
+         (define res (f v loop))
          (dvector-set! out idx res)
          (dvector-set! visited idx #t)
          res]))))
 
-(define (assert-batch-brf! batch . brfs)
-  (unless (andmap (compose (curry equal? batch) batchref-batch) brfs)
-    (error 'assert-batch-brf! "One of batchrefs does not belong to the provided batch")))
+(define (assert-block-v! block . vs)
+  (unless (andmap (compose (curry equal? block) val-block) vs)
+    (error 'assert-block-v! "One of vals does not belong to the provided block")))
 
-;; Function returns indices of children nodes within a batch for given roots,
+;; Function returns indices of children nodes within a block for given roots,
 ;;   where a child node is a child of a root + meets a condition - (condition node)
-(define (batch-reachable batch brfs #:condition [condition (const #t)])
+(define (block-reachable block vs #:condition [condition (const #t)])
   ; Little check
-  (apply assert-batch-brf! batch brfs)
-  (define len (batch-length batch))
+  (apply assert-block-v! block vs)
+  (define len (block-length block))
   (define child-mask (make-vector len #f))
-  (for ([brf (in-list brfs)])
-    (vector-set! child-mask (batchref-idx brf) #t))
+  (for ([v (in-list vs)])
+    (vector-set! child-mask (val-idx v) #t))
   (for ([i (in-range (sub1 len) -1 -1)]
-        [node (in-batch batch (sub1 len) -1 -1)]
+        [node (in-block block (sub1 len) -1 -1)]
         [child (in-vector child-mask (sub1 len) -1 -1)]
         #:when child)
     (cond
       [(condition node) (expr-recurse node (λ (n) (vector-set! child-mask n #t)))]
       [else (vector-set! child-mask i #f)]))
-  ; Return batchrefs of children nodes in ascending order
+  ; Return vals of children nodes in ascending order
   (for/list ([child (in-vector child-mask)]
              [i (in-naturals)]
              #:when child)
-    (batchref batch i)))
+    (val block i)))
 
-;; Function constructs a vector of expressions for the given nodes of a batch
-(define (batch-exprs batch #:spec-f [spec-f void])
-  (batch-recurse batch
-                 (lambda (brf recurse)
-                   (expr-recurse-spec spec-f (expr-recurse (deref brf) recurse)))))
+;; Function constructs a vector of expressions for the given nodes of a block
+(define (block-exprs block #:spec-f [spec-f void])
+  (block-recurse block
+                 (lambda (v recurse) (expr-recurse-spec spec-f (expr-recurse (val-def v) recurse)))))
 
-;; Function constructs a vector of expressions for the given nodes of a batch
-(define (batch-copy-only! batch batch*)
-  (batch-recurse batch*
-                 (lambda (brf recurse)
-                   (batch-push! batch (expr-recurse (deref brf) (compose batchref-idx recurse))))))
+;; Function constructs a vector of expressions for the given nodes of a block
+(define (block-copy-only! block block*)
+  (block-recurse block*
+                 (lambda (v recurse)
+                   (block-push! block (expr-recurse (val-def v) (compose val-idx recurse))))))
 
-(define (batch-free-vars batch)
-  (batch-recurse batch
-                 (lambda (brf recurse)
-                   (define node (deref brf))
+(define (block-free-vars block)
+  (block-recurse block
+                 (lambda (v recurse)
+                   (define node (val-def v))
                    (cond
                      [(symbol? node) (set node)]
                      [else
@@ -158,32 +157,32 @@
                       (expr-recurse node (lambda (i) (set-union! arg-free-vars (recurse i))))
                       arg-free-vars]))))
 
-;; Converts a batch + roots to a JSON-compatible structure
+;; Converts a block + roots to a JSON-compatible structure
 ;; Returns: (hash 'nodes [...] 'roots [idx1 idx2 ...])
 ;; Nodes are: atoms (symbols->strings, numbers) or [op-string idx1 idx2 ...]
-(define (batch->jsexpr b spec-batch brfs)
-  (define batch* (batch-empty (context (batch-vars b) #f (batch-var-reprs b))))
-  (for ([var (in-list (batch-vars b))])
-    (batch-push! batch* var))
+(define (block->jsexpr b spec-block vs)
+  (define block* (block-empty (context (block-vars b) #f (block-var-reprs b))))
+  (for ([var (in-list (block-vars b))])
+    (block-push! block* var))
   (define (add-expr expr)
-    (batch-push! batch*
-                 (expr-recurse-spec (compose batchref-idx add-expr)
-                                    (expr-recurse expr (compose batchref-idx add-expr)))))
-  (define spec-f (batch-exprs spec-batch))
-  (define exprs (batch-exprs b #:spec-f spec-f))
-  (define brfs* (map add-expr (map exprs brfs)))
+    (block-push! block*
+                 (expr-recurse-spec (compose val-idx add-expr)
+                                    (expr-recurse expr (compose val-idx add-expr)))))
+  (define spec-f (block-exprs spec-block))
+  (define exprs (block-exprs b #:spec-f spec-f))
+  (define vs* (map add-expr (map exprs vs)))
   (define nodes
-    (for/list ([node (in-batch batch*)])
+    (for/list ([node (in-block block*)])
       (match node
         [(? symbol?) (~a node)]
         [(? number?) (~a node)]
         [(approx spec impl) (list "approx" spec impl)]
         [(list op args ...) (cons (~a op) args)]
         [_ (~a node)])))
-  (hash 'nodes nodes 'roots (map batchref-idx brfs*)))
+  (hash 'nodes nodes 'roots (map val-idx vs*)))
 
-;; Converts a jsexpr batch to a single SSA-style string with O(n) size
-(define (jsexpr->batch-exprs jsexpr)
+;; Converts a jsexpr block to a single SSA-style string with O(n) size
+(define (jsexpr->block-exprs jsexpr)
   (define nodes (hash-ref jsexpr 'nodes))
   (define roots (hash-ref jsexpr 'roots))
   (define node-vec (list->vector nodes))
@@ -249,13 +248,13 @@
   (string-join (append bindings return-exprs) "\n"))
 ;; --------------------------------- TESTS ---------------------------------------
 
-; Tests for progs->batch and batch-exprs
+; Tests for progs->block and block-exprs
 (module+ test
   (require rackunit)
   (define test-empty-ctx (context '() #f '()))
   (define (test-munge-unmunge expr [expected expr] #:spec-f [spec-f (void)])
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
-    (check-equal? (list expected) (map (batch-exprs batch #:spec-f spec-f) brfs)))
+    (define-values (block vs) (progs->block (list expr) #:ctx test-empty-ctx))
+    (check-equal? (list expected) (map (block-exprs block #:spec-f spec-f) vs)))
 
   (define (f64 x)
     (literal x 'binary64))
@@ -266,37 +265,36 @@
   (test-munge-unmunge '(cbrt x))
   (test-munge-unmunge (list 'x))
   (define spec-expr '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))))
-  (define-values (spec-batch spec-brfs) (progs->batch (list spec-expr) #:ctx test-empty-ctx))
+  (define-values (spec-block spec-vs) (progs->block (list spec-expr) #:ctx test-empty-ctx))
   (define approx-expr
-    `(+.f64 (sin.f64 ,(approx (first spec-brfs)
-                              '(+.f64 ,(f64 3) (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
+    `(+.f64 (sin.f64 ,(approx (first spec-vs) '(+.f64 ,(f64 3) (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
             ,(f64 4)))
   (define expected-approx
     `(+.f64 (sin.f64 ,(approx spec-expr '(+.f64 ,(f64 3) (*.f64 ,(f64 25) (sin.f64 ,(f64 6))))))
             ,(f64 4)))
-  (test-munge-unmunge approx-expr expected-approx #:spec-f (batch-exprs spec-batch)))
+  (test-munge-unmunge approx-expr expected-approx #:spec-f (block-exprs spec-block)))
 
 ; Tests for remove-zombie-nodes
 (module+ test
   (require rackunit)
   (define (zombie-test #:specs [specs '()] #:nodes nodes #:expected expected #:roots roots)
-    (define spec-batch (batch-empty test-empty-ctx))
-    (define spec-brfs (map (curry batch-add! spec-batch) specs))
+    (define spec-block (block-empty test-empty-ctx))
+    (define spec-vs (map (curry block-add! spec-block) specs))
     (define (segregate nodes)
       (apply create-dvector
              (for/list ([node (in-dvector nodes)])
                (match node
-                 [(approx spec impl) (approx (list-ref spec-brfs spec) impl)]
+                 [(approx spec impl) (approx (list-ref spec-vs spec) impl)]
                  [_ node]))))
-    (define in-batch (batch (segregate nodes) (make-hash) '() '()))
-    (define brfs (map (curry batchref in-batch) roots))
-    (define out-batch (batch-empty test-empty-ctx))
-    (define copy-f (batch-copy-only! out-batch in-batch))
-    (define brfs* (map copy-f brfs))
-    (define spec-f (batch-exprs spec-batch))
-    (check-equal? (map (batch-exprs out-batch #:spec-f spec-f) brfs*)
-                  (map (batch-exprs in-batch #:spec-f spec-f) brfs))
-    (check-equal? (dvector->vector (batch-nodes out-batch)) (dvector->vector (segregate expected))))
+    (define in-block (block (segregate nodes) (make-hash) '() '()))
+    (define vs (map (curry val in-block) roots))
+    (define out-block (block-empty test-empty-ctx))
+    (define copy-f (block-copy-only! out-block in-block))
+    (define vs* (map copy-f vs))
+    (define spec-f (block-exprs spec-block))
+    (check-equal? (map (block-exprs out-block #:spec-f spec-f) vs*)
+                  (map (block-exprs in-block #:spec-f spec-f) vs))
+    (check-equal? (dvector->vector (block-nodes out-block)) (dvector->vector (segregate expected))))
 
   (zombie-test #:expected (create-dvector 2 0 '(sqrt 1) '(pow 0 2))
                #:nodes (create-dvector 0 1 '(sqrt 0) 2 '(pow 3 2))
@@ -321,13 +319,13 @@
                #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 0 1) '(pow 2 6))
                #:roots (list 7 3)))
 
-; Tests for batch->jsexpr and jsexpr->batch-exprs
+; Tests for block->jsexpr and jsexpr->block-exprs
 (module+ test
   (require rackunit)
   (define (test-json-tostring expr expected)
-    (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
-    (define jsexpr (batch->jsexpr batch batch brfs))
-    (define str (jsexpr->batch-exprs jsexpr))
+    (define-values (block vs) (progs->block (list expr) #:ctx test-empty-ctx))
+    (define jsexpr (block->jsexpr block block vs))
+    (define str (jsexpr->block-exprs jsexpr))
     (check-equal? str expected))
 
   ; No sharing - just the expression

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -7,7 +7,7 @@
 (require "rival.rkt"
          "../config.rkt"
          "types.rkt"
-         "batch.rkt")
+         "block.rkt")
 
 (provide from-rival
          from-ffi
@@ -33,8 +33,8 @@
                   (hash-clear! cache))))
 
 (define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
-  (define-values (batch brfs) (progs->batch (list spec) #:ctx ctx))
-  (define compiler (make-real-compiler batch brfs (list (context-repr ctx))))
+  (define-values (block vs) (progs->block (list spec) #:ctx ctx))
+  (define compiler (make-real-compiler block vs (list (context-repr ctx))))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
   (define (compute . pt)
     (define-values (_ exs) (real-apply compiler (list->vector pt)))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -9,7 +9,7 @@
          "syntax.rkt"
          "../syntax/float.rkt"
          "generators.rkt"
-         "batch.rkt")
+         "block.rkt")
 
 ;;; Platforms describe a set of representations, operator, and constants
 ;;; Herbie should use during its improvement loop. Platforms are just
@@ -35,7 +35,7 @@
          impl-exists?
          impl-info
          prog->spec
-         batch-to-spec!
+         block-to-spec!
          get-fpcore-impl
          impl->fpcore
          reset-fpcore-op-cache!
@@ -109,61 +109,61 @@
      (define env (map cons vars (map prog->spec args)))
      (pattern-substitute spec env)]))
 
-(define (batch-to-spec! in-batch out-batch brfs)
+(define (block-to-spec! in-block out-block vs)
   (define lower
-    (batch-recurse
-     in-batch
-     (lambda (brf recurse)
-       (define node (deref brf))
+    (block-recurse
+     in-block
+     (lambda (v recurse)
+       (define node (val-def v))
        (match node
-         [(? literal?) (batch-add! out-batch (literal-value node))]
-         [(? number?) (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]
-         [(? symbol?) (batch-add! out-batch node)]
+         [(? literal?) (block-add! out-block (literal-value node))]
+         [(? number?) (error 'block-to-spec! "unexpected spec node in input block: ~a" node)]
+         [(? symbol?) (block-add! out-block node)]
          [(approx spec _) spec]
          [(list (? impl-exists? impl) args ...)
           (define vars (impl-info impl 'vars))
           (define spec (impl-info impl 'spec))
           (define env (map cons vars (map recurse args)))
-          (batch-add! out-batch (pattern-substitute spec env))]
+          (block-add! out-block (pattern-substitute spec env))]
          [(list op args ...)
-          (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]))))
-  (map lower brfs))
+          (error 'block-to-spec! "unexpected spec node in input block: ~a" node)]))))
+  (map lower vs))
 
 (module+ test
   (require rackunit)
 
   (define test-empty-ctx (context '() #f '()))
 
-  (let* ([in-batch (batch-empty test-empty-ctx)]
-         [out-batch (batch-empty test-empty-ctx)]
-         [x (batch-add! in-batch 'x)]
-         [x* (first (batch-to-spec! in-batch out-batch (list x)))])
-    (check-equal? (batchref-batch x*) out-batch)
-    (check-equal? (deref x*) 'x))
+  (let* ([in-block (block-empty test-empty-ctx)]
+         [out-block (block-empty test-empty-ctx)]
+         [x (block-add! in-block 'x)]
+         [x* (first (block-to-spec! in-block out-block (list x)))])
+    (check-equal? (val-block x*) out-block)
+    (check-equal? (val-def x*) 'x))
 
-  (let* ([batch (batch-empty test-empty-ctx)]
-         [spec-batch (batch-empty test-empty-ctx)]
-         [spec (batch-add! spec-batch 'x)]
-         [impl (batch-add! batch (literal 1 'binary64))]
-         [approx-brf (batch-add! batch (approx spec impl))])
-    (check-equal? (batch-to-spec! batch spec-batch (list approx-brf)) (list spec)))
+  (let* ([block (block-empty test-empty-ctx)]
+         [spec-block (block-empty test-empty-ctx)]
+         [spec (block-add! spec-block 'x)]
+         [impl (block-add! block (literal 1 'binary64))]
+         [approx-v (block-add! block (approx spec impl))])
+    (check-equal? (block-to-spec! block spec-block (list approx-v)) (list spec)))
 
-  (let* ([in-batch (batch-empty test-empty-ctx)]
-         [out-batch (batch-empty test-empty-ctx)]
-         [spec (batch-add! out-batch 'x)]
-         [impl (batch-add! in-batch (literal 1 'binary64))]
-         [approx-brf (batch-add! in-batch (approx spec impl))]
-         [spec* (first (batch-to-spec! in-batch out-batch (list approx-brf)))])
-    (check-equal? (batchref-batch spec*) out-batch)
-    (check-equal? (deref spec*) 'x))
+  (let* ([in-block (block-empty test-empty-ctx)]
+         [out-block (block-empty test-empty-ctx)]
+         [spec (block-add! out-block 'x)]
+         [impl (block-add! in-block (literal 1 'binary64))]
+         [approx-v (block-add! in-block (approx spec impl))]
+         [spec* (first (block-to-spec! in-block out-block (list approx-v)))])
+    (check-equal? (val-block spec*) out-block)
+    (check-equal? (val-def spec*) 'x))
 
-  (let* ([in-batch (batch-empty test-empty-ctx)]
-         [out-batch (batch-empty test-empty-ctx)]
-         [num (batch-add! in-batch 1)]
-         [expr (batch-add! in-batch `(+ ,num ,num))])
+  (let* ([in-block (block-empty test-empty-ctx)]
+         [out-block (block-empty test-empty-ctx)]
+         [num (block-add! in-block 1)]
+         [expr (block-add! in-block `(+ ,num ,num))])
     (parameterize ([*active-platform* (make-empty-platform)])
-      (check-exn #rx"unexpected spec node" (λ () (batch-to-spec! in-batch out-batch (list num))))
-      (check-exn #rx"unexpected spec node" (λ () (batch-to-spec! in-batch out-batch (list expr)))))))
+      (check-exn #rx"unexpected spec node" (λ () (block-to-spec! in-block out-block (list num))))
+      (check-exn #rx"unexpected spec node" (λ () (block-to-spec! in-block out-block (list expr)))))))
 
 ;; Expression predicates ;;
 

--- a/src/syntax/rival.rkt
+++ b/src/syntax/rival.rkt
@@ -17,7 +17,7 @@
          "../syntax/float.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
-         "../syntax/batch.rkt")
+         "../syntax/block.rkt")
 
 (define (use-rival3?)
   (not (flag-set? 'setup 'rival2)))
@@ -120,11 +120,11 @@
          ival-hi
          (contract-out
           [make-real-compiler
-           (->i ([batch batch?] [brfs (listof batchref?)]
+           (->i ([block block?] [vs (listof val?)]
                                 [reprs
-                                 (brfs)
+                                 (vs)
                                  (and/c (listof representation?)
-                                        (lambda (reprs) (= (length brfs) (length reprs))))])
+                                        (lambda (reprs) (= (length vs) (length reprs))))])
                 (#:pre [pre any/c])
                 [c real-compiler?])]
           [real-apply (->* (real-compiler? vector?) (any/c) (values symbol? any/c))]
@@ -141,11 +141,11 @@
         (pre vars var-reprs exprs reprs machine dump-file assemble-point assemble-output))
 
 ;; Creates a Rival machine.
-(define (make-real-compiler batch brfs output-reprs #:pre [pre '(TRUE)])
-  (define specs (map (batch-exprs batch) brfs))
+(define (make-real-compiler block vs output-reprs #:pre [pre '(TRUE)])
+  (define specs (map (block-exprs block) vs))
   (define ctxs
     (for/list ([repr (in-list output-reprs)])
-      (context (batch-vars batch) repr (batch-var-reprs batch))))
+      (context (block-vars block) repr (block-var-reprs block))))
   (define-values (specs* ctxs* pre* assemble-point assemble-output flattened-reprs)
     (flatten-arrays-for-rival specs ctxs pre))
   (define vars (context-vars (first ctxs*)))

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -251,11 +251,11 @@
 ;; LImpl -> FPCore
 ;; Translates from LImpl to an FPCore
 
-;; TODO: this process uses a batch-like data structure
+;; TODO: this process uses a block-like data structure
 ;; but _without_ deduplication since different use sites
 ;; of a particular subexpression may have different
 ;; parent rounding contexts. Would be nice to explore
-;; if the batch data structure can be used.
+;; if the block data structure can be used.
 
 ;; Instruction vector index
 (struct index (v) #:prefab)

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -200,7 +200,7 @@
 (define-timeline accuracy [accuracy] [oracle] [baseline])
 (define-timeline count [input +] [output +])
 (define-timeline alts #:unmergable)
-(define-timeline batch #:unmergable)
+(define-timeline block #:unmergable)
 (define-timeline inputs #:unmergable)
 (define-timeline outputs #:unmergable)
 (define-timeline sampling #:custom merge-sampling-tables)


### PR DESCRIPTION
This PR renames `batch` to `block`, a la basic block, and `batchref` to `val` (with variables renamed from `brf` to `v`). The `deref` function, which takes a `val` to an instruction, is now named `val-def`, corresponding to standard compiler "use-def" terminology. The PR also renames related files. This aligns better with standard compiler terms and is a little shorter, plus (importantly) eliminates the ugly "brf" terminology.

The change was, obviously, performed by AI, which did the replacement with `sed` and then reviewed the entire diff. I did _not_ hand-review every line (that would be crazy) but I made sure line counts matched up and hand-reviewed a few random portion to make sure it looks reasonable, and of course made sure tests etc pass.