### PR TITLE
Bring the egglog backend to performance parity with egg

### DIFF
--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -202,10 +202,9 @@
       (egglog-multi-extract subproc
                             `(multi-extract ,extract
                                             :dag
-                                            ,@(for/list ([constructor-name
-                                                          (in-list extract-bindings)]
+                                            ,@(for/list ([n (in-list extract-bindings)]
                                                          [repr (in-list reprs)])
-                                                `(do-lower (,constructor-name)
+                                                `(do-lower (herbie-const ,n)
                                                            ,(egglog-repr-token repr))))))
 
     ;; Roll the persistent subprocess back to its post-prelude state, or close
@@ -286,6 +285,7 @@
                    (Approx M MTy)
                    ,@(platform-impl-nodes pform))
         `(constructor do-lower (M String) MTy :unextractable)
+        `(constructor herbie-const (i64) M :unextractable)
         `(constructor do-lift (MTy) M :unextractable)
         `(ruleset lower)
         `(ruleset lift)
@@ -527,12 +527,28 @@
       [(list op args ...) `(,(serialize-spec-op op (length args)) ,@(map loop args))])))
 
 (define (egglog-rewrite-rules rules tag)
-  (for/list ([rule (in-list rules)]
-             #:when (not (symbol? (rule-input rule))))
-    `(rewrite ,(expr->e1-pattern (rule-input rule))
-              ,(expr->e1-pattern (rule-output rule))
-              :ruleset
-              ,tag)))
+  (apply append
+         (for/list ([rule (in-list rules)])
+           (define input (rule-input rule))
+           (define output (expr->e1-pattern (rule-output rule)))
+           (cond
+             [(symbol? input)
+              ;; A bare-variable left-hand side (e.g. pow1: a -> (pow a 1)) matches
+              ;; every e-class. egg applies such rules; egglog needs a pattern, so
+              ;; emit one rule per M constructor. Skipping them makes the two
+              ;; backends explore differently (fewer nodes per iteration, more
+              ;; iterations, ~2x wider root classes at the same node limit).
+              (for/list ([node (in-list (platform-spec-nodes))])
+                (match-define (list ctor arg-sorts ...) node)
+                (define args
+                  (for/list ([_ (in-list (takef arg-sorts (lambda (x) (not (keyword-like? x)))))]
+                             [i (in-naturals)])
+                    (string->symbol (format "?p~a" i))))
+                `(rule ((= ,input (,ctor ,@args))) ((union ,input ,output)) :ruleset ,tag))]
+             [else `((rewrite ,(expr->e1-pattern input) ,output :ruleset ,tag))]))))
+
+(define (keyword-like? x)
+  (and (symbol? x) (string-prefix? (symbol->string x) ":")))
 
 (define (egglog-add-exprs block vs subproc)
   (define bindings (make-hash))
@@ -605,18 +621,14 @@
   (for ([var (in-list (block-vars block))])
     ; Get the binding names for the program
     (define binding-name (string->symbol (format "?s~a" var)))
-    (define constructor-name (string->symbol (format "const~a" constructor-num)))
-    (hash-set! binding->constructor binding-name constructor-name)
+    (hash-set! binding->constructor binding-name constructor-num)
 
     ; Define the actual binding
     (define curr-var-spec-binding `(let ,binding-name (Var ,(symbol->string var))))
 
-    ; Send the constructor definition
-    (egglog-send subproc `(constructor ,constructor-name () M :unextractable))
-
     ; Add the binding and constructor union to all-bindings for the future rule
     (set! all-bindings (cons curr-var-spec-binding all-bindings))
-    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
+    (set! all-bindings (cons `(union (herbie-const ,constructor-num) ,binding-name) all-bindings))
 
     (set! constructor-num (add1 constructor-num)))
 
@@ -630,16 +642,13 @@
           (string->symbol (format "?r~a" n))
           (string->symbol (format "?b~a" n))))
 
-    (define constructor-name (string->symbol (format "const~a" constructor-num)))
-    (hash-set! binding->constructor binding-name constructor-name)
+    (hash-set! binding->constructor binding-name constructor-num)
 
     (define actual-binding (hash-ref bindings binding-name))
     (define curr-binding-exprs `(let ,binding-name ,actual-binding))
 
-    (egglog-send subproc `(constructor ,constructor-name () M :unextractable))
-
     (set! all-bindings (cons curr-binding-exprs all-bindings))
-    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
+    (set! all-bindings (cons `(union (herbie-const ,constructor-num) ,binding-name) all-bindings))
 
     (set! constructor-num (add1 constructor-num)))
 
@@ -654,10 +663,14 @@
   (define iter-limit (*default-egglog-iter-limit*))
 
   ;; The back-off scheduler's :node-limit keeps the e-graph within the node
-  ;; limit as it chooses matches; the :until guards with get-node-size! stop
+  ;; limit as it chooses matches; the :until guard with get-node-size! stops
   ;; the schedule once the limit is reached. Both measure e-nodes (rows of
   ;; constructor tables, excluding relations and analysis functions), matching
-  ;; what egg counts, rather than get-size!'s total table size. After each
+  ;; what egg counts, rather than get-size!'s total table size. Constant
+  ;; folding runs with the default scheduler, like egg's analysis-based
+  ;; folding: it is not rewriting to be rationed, and running it through the
+  ;; same back-off instance would advance that scheduler's iteration counter
+  ;; twice per repeat, halving ban lengths relative to egg. After each
   ;; iteration, we check for unsound merges via bad-merge-rule. The schedule
   ;; runs until:
   ;;   1. Node limit is reached (get-node-size! >= node-limit)
@@ -670,7 +683,7 @@
                  (let-scheduler bo (back-off :node-limit ,node-limit :eager-apply 1))
                  (repeat ,iter-limit
                          (seq (run-with bo ,tag :until (<= ,node-limit (get-node-size!)))
-                              (run-with bo const-fold :until (<= ,node-limit (get-node-size!)))
+                              (run const-fold)
                               (run bad-merge-rule :until (bad-merge?))))))
   (void))
 

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -107,10 +107,19 @@
   (define pform (*active-platform*))
 
   ;;;; SUBPROCESS START ;;;;
-  (define subproc (create-new-egglog-subprocess label))
-
-  ;; 1. Add the prelude - send directly to egglog.
-  (prelude subproc #:mixed-egraph? #t)
+  ;; Without dump:egglog, reuse a long-lived subprocess whose prelude and rule
+  ;; declarations are already loaded (see static-egglog-commands), and isolate
+  ;; this call with push/pop. With dump:egglog, spawn a fresh subprocess so
+  ;; every dump file is a complete, replayable session.
+  (define use-persistent? (not (flag-set? 'dump 'egglog)))
+  (define subproc
+    (cond
+      [use-persistent? (get-persistent-subprocess (static-egglog-commands pform))]
+      [else
+       (define fresh (create-new-egglog-subprocess label))
+       ;; 1. Add the prelude - send directly to egglog.
+       (prelude fresh #:mixed-egraph? #t)
+       fresh]))
 
   ;; 2. Inserting expressions into the egglog program and getting a Listof (exprs . extract bindings)
 
@@ -156,73 +165,188 @@
   ;; of a rule and make them accessible through their unique constructor. Therefore, we must
   ;; keep track of the mapping between each binding and its corresponding constructor.
 
-  (define-values (all-bindings extract-bindings) (egglog-add-exprs insert-batch insert-brfs subproc))
+  ;; If anything fails mid-call, the subprocess protocol state is unknown:
+  ;; discard the persistent subprocess so the next call starts fresh.
+  (with-handlers ([exn:fail? (lambda (e)
+                               (when use-persistent?
+                                 (discard-persistent-subprocess!))
+                               (raise e))])
+    (when use-persistent?
+      (egglog-send subproc '(push)))
 
-  (egglog-send subproc
-               `(ruleset run-extract-commands)
-               `(rule () (,@all-bindings) :ruleset run-extract-commands)
-               `(run-schedule (repeat 1 run-extract-commands)))
+    (define-values (all-bindings extract-bindings)
+      (egglog-add-exprs insert-batch insert-brfs subproc))
 
-  ;; 4. Running the schedule : having code inside to emulate egraph-run-rules
+    (egglog-send subproc
+                 `(ruleset run-extract-commands)
+                 `(rule () (,@all-bindings) :ruleset run-extract-commands)
+                 `(run-schedule (repeat 1 run-extract-commands)))
 
-  (for ([step (in-list schedule)])
-    (apply egglog-send subproc (egglog-step-commands step pform))
-    (match step
-      ['lift (egglog-send subproc '(run-schedule (saturate lift)))]
-      ['lower (egglog-send subproc '(run-schedule (saturate lower)))]
-      ['unsound (egglog-send subproc '(run-schedule (saturate unsound)))]
-      ;; Run the rewrite ruleset interleaved with const-fold until the best iteration
-      ['rewrite (egglog-unsound-detected-subprocess step subproc)]))
+    ;; 4. Running the schedule : having code inside to emulate egraph-run-rules
 
-  ;; 5. Extract using constructor names returned by egglog-add-exprs.
-  (define stdout-content
-    (egglog-multi-extract subproc
-                          `(multi-extract ,extract
-                                          ,@(for/list ([constructor-name (in-list extract-bindings)]
-                                                       [repr (in-list reprs)])
-                                              `(do-lower (,constructor-name)
-                                                         ,(egglog-repr-token repr))))))
+    (for ([step (in-list schedule)])
+      ;; The persistent subprocess already has every step's rules declared.
+      (unless use-persistent?
+        (apply egglog-send subproc (egglog-step-commands step pform)))
+      (match step
+        ['lift (egglog-send subproc '(run-schedule (saturate lift)))]
+        ['lower (egglog-send subproc '(run-schedule (saturate lower)))]
+        ['unsound (egglog-send subproc '(run-schedule (saturate unsound)))]
+        ;; Run the rewrite ruleset interleaved with const-fold until the best iteration
+        ['rewrite (egglog-unsound-detected-subprocess step subproc)]))
 
-  ;; Close everything subprocess related
-  (egglog-subprocess-close subproc)
+    ;; 5. Extract using constructor names returned by egglog-add-exprs. With
+    ;; :dag, subterms shared across variants arrive let-bound once instead of
+    ;; expanded at every use (responses shrink by an order of magnitude).
+    (define stdout-content
+      (egglog-multi-extract subproc
+                            `(multi-extract ,extract
+                                            :dag
+                                            ,@(for/list ([constructor-name
+                                                          (in-list extract-bindings)]
+                                                         [repr (in-list reprs)])
+                                                `(do-lower (,constructor-name)
+                                                           ,(egglog-repr-token repr))))))
 
-  ;; (Listof (Listof exprs))
-  (define herbie-exprss
-    (for/list ([next-expr (in-list stdout-content)])
-      (map e2->expr next-expr)))
+    ;; Roll the persistent subprocess back to its post-prelude state, or close
+    ;; everything subprocess related
+    (cond
+      [use-persistent?
+       (egglog-send subproc '(pop))
+       (set! persistent-call-in-progress? #f)]
+      [else (egglog-subprocess-close subproc)])
 
-  (for/list ([variants (in-list herbie-exprss)])
+    (match-define `(let ,dag-bindings ,dag-body) stdout-content)
+    (egglog-dag->batchrefs dag-bindings dag-body output-batch)))
+
+;; Convert the (let ((name def) ...) ((variant ...) ...)) response of
+;; (multi-extract :dag ...) into batchrefs. Shared subterms arrive as ?tN
+;; binding references; each is resolved, converted, and interned exactly
+;; once, so the total work is proportional to the response DAG rather than
+;; to the expanded variant trees.
+(define (egglog-dag->batchrefs bindings body output-batch)
+  ;; Binding name -> its definition with references resolved. Reusing the
+  ;; same pair object at every reference preserves sharing, which the
+  ;; eq?-keyed memo tables below rely on.
+  (define env (make-hasheq))
+  (define (resolve expr)
+    (match expr
+      [(? symbol?) (hash-ref env expr)]
+      [(list head args ...) (cons head (map resolve args))]
+      [_ expr]))
+  (for ([binding (in-list bindings)])
+    (match-define (list name def) binding)
+    (hash-set! env name (resolve def)))
+
+  ;; eq?-memoized counterparts of e1->expr and e2->expr: a shared node is
+  ;; converted once. Impl (MTy) terms are interned eagerly and referenced as
+  ;; batchrefs, which batch-add! accepts as children; spec (M) terms stay
+  ;; plain expressions since approx nodes store their spec unmunged.
+  (define spec-memo (make-hasheq))
+  (define impl-memo (make-hasheq))
+  (define (spec->expr expr)
+    (hash-ref! spec-memo
+               expr
+               (lambda ()
+                 (match expr
+                   [`(Num (bigrat (from-string ,n) (from-string ,d)))
+                    (/ (string->number n) (string->number d))]
+                   [`(Var ,v) (string->symbol v)]
+                   [`(,op ,args ...) `(,(hash-ref (e1->id) op) ,@(map spec->expr args))]))))
+  (define (add-impl! expr)
+    (hash-ref!
+     impl-memo
+     expr
+     (lambda ()
+       (match expr
+         [`(,(? egglog-num? num) (bigrat (from-string ,n) (from-string ,d)))
+          (batch-add! output-batch
+                      (literal (/ (string->number n) (string->number d)) (egglog-num-repr num)))]
+         [`(,(? egglog-var? var) ,v) (batch-add! output-batch (string->symbol v))]
+         ; Approx stores a spec expression in E1/M and an implementation in E2/MTy.
+         [`(Approx ,spec ,impl)
+          (batch-add! output-batch (approx (spec->expr spec) (add-impl! impl)))]
+         [`(,impl ,args ...)
+          (batch-add! output-batch `(,(hash-ref (e2->id) impl) ,@(map add-impl! args)))]))))
+
+  (for/list ([variants (in-list body)])
     (for/list ([v (in-list variants)])
-      (batch-add! output-batch v))))
+      (add-impl! (resolve v)))))
 
 ;; Egglog requires integer costs, but Herbie uses floating-point costs.
 ;; Scale by 1000 to convert Herbie's float costs to Egglog's integer costs.
 (define (normalize-cost c)
   (exact-round (* c 1000)))
 
+(define (prelude-commands pform)
+  (list `(datatype M ,@(platform-spec-nodes))
+        `(datatype MTy
+                   ,@(num-typed-nodes pform)
+                   ,@(var-typed-nodes pform)
+                   (Approx M MTy)
+                   ,@(platform-impl-nodes pform))
+        `(constructor do-lower (M String) MTy :unextractable)
+        `(constructor do-lift (MTy) M :unextractable)
+        `(ruleset lower)
+        `(ruleset lift)
+        `(ruleset unsound)
+        `(function bad-merge? () bool :merge (or old new))
+        `(ruleset bad-merge-rule)
+        `(set (bad-merge?) false)
+        `(rule ((= (Num c1) (Num c2)) (!= c1 c2)) ((set (bad-merge?) true)) :ruleset bad-merge-rule)))
+
 (define (prelude subproc #:mixed-egraph? [mixed-egraph? #t])
-  (define pform (*active-platform*))
-
-  (egglog-send subproc `(datatype M ,@(platform-spec-nodes)))
-
-  (egglog-send
-   subproc
-   `(datatype MTy
-              ,@(num-typed-nodes pform)
-              ,@(var-typed-nodes pform)
-              (Approx M MTy)
-              ,@(platform-impl-nodes pform))
-   `(constructor do-lower (M String) MTy :unextractable)
-   `(constructor do-lift (MTy) M :unextractable)
-   `(ruleset lower)
-   `(ruleset lift)
-   `(ruleset unsound)
-   `(function bad-merge? () bool :merge (or old new))
-   `(ruleset bad-merge-rule)
-   `(set (bad-merge?) false)
-   `(rule ((= (Num c1) (Num c2)) (!= c1 c2)) ((set (bad-merge?) true)) :ruleset bad-merge-rule))
-
+  (apply egglog-send subproc (prelude-commands (*active-platform*)))
   (void))
+
+;; The prelude and every step's rule declarations are identical for all calls
+;; within a run, so they can be declared once in a long-lived subprocess and
+;; each call isolated with push/pop. Rules of steps a call never runs are
+;; inert. The command list doubles as the cache key, so any change in
+;; platform or rules respawns the subprocess.
+(define (static-egglog-commands pform)
+  (append (prelude-commands pform)
+          (egglog-step-commands 'lift pform)
+          (egglog-step-commands 'lower pform)
+          (egglog-step-commands 'unsound pform)
+          (egglog-step-commands 'rewrite pform)))
+
+(define persistent-subprocess #f)
+(define persistent-subprocess-key #f)
+;; Owns the subprocess and its ports, so per-test custodians (e.g. timeouts)
+;; cannot reclaim them between calls.
+(define persistent-custodian (make-custodian))
+;; Set while a call is using the subprocess. If it is still set when the next
+;; call starts, the previous call was interrupted mid-protocol (e.g. its
+;; thread was killed by a timeout), so the subprocess state is unknown and it
+;; must be discarded.
+(define persistent-call-in-progress? #f)
+
+(define (discard-persistent-subprocess!)
+  (when persistent-subprocess
+    (with-handlers ([exn:fail? void])
+      (egglog-subprocess-close persistent-subprocess))
+    (set! persistent-subprocess #f)
+    (set! persistent-subprocess-key #f)))
+
+(define (persistent-subprocess-usable? static-commands)
+  (and persistent-subprocess
+       (not persistent-call-in-progress?)
+       (not (port-closed? (egglog-subprocess-input persistent-subprocess)))
+       (eq? (subprocess-status (egglog-subprocess-process persistent-subprocess)) 'running)
+       (equal? persistent-subprocess-key static-commands)))
+
+(define (get-persistent-subprocess static-commands)
+  (unless (persistent-subprocess-usable? static-commands)
+    (discard-persistent-subprocess!)
+    (define subproc
+      (parameterize ([current-custodian persistent-custodian])
+        (create-new-egglog-subprocess #f)))
+    (apply egglog-send subproc static-commands)
+    (set! persistent-subprocess subproc)
+    (set! persistent-subprocess-key static-commands))
+  (set! persistent-call-in-progress? #t)
+  persistent-subprocess)
 
 (define (egglog-step-commands step pform)
   (match step
@@ -529,20 +653,23 @@
   (define node-limit (*node-limit*))
   (define iter-limit (*default-egglog-iter-limit*))
 
-  ;; Use egglog's :until guard with get-size! to stop when node limit is reached.
-  ;; After each iteration, we check for unsound merges via bad-merge-rule.
-  ;; The schedule runs until:
-  ;;   1. Node limit is reached (get-size! >= node-limit)
+  ;; The back-off scheduler's :node-limit keeps the e-graph within the node
+  ;; limit as it chooses matches; the :until guards with get-node-size! stop
+  ;; the schedule once the limit is reached. Both measure e-nodes (rows of
+  ;; eq-sort tables), matching what egg counts, rather than get-size!'s total
+  ;; table size. After each iteration, we check for unsound merges via
+  ;; bad-merge-rule. The schedule runs until:
+  ;;   1. Node limit is reached (get-node-size! >= node-limit)
   ;;   2. Saturation (no more progress)
   ;;   3. Iter limit is reached
   ;;   4. Unsoundness is detected (bad-merge? becomes true)
 
   (egglog-send subproc
                `(run-schedule
-                 (let-scheduler bo (back-off))
+                 (let-scheduler bo (back-off :node-limit ,node-limit :eager-apply 1))
                  (repeat ,iter-limit
-                         (seq (run-with bo ,tag :until (<= ,node-limit (get-size!)))
-                              (run-with bo const-fold :until (<= ,node-limit (get-size!)))
+                         (seq (run-with bo ,tag :until (<= ,node-limit (get-node-size!)))
+                              (run-with bo const-fold :until (<= ,node-limit (get-node-size!)))
                               (run bad-merge-rule :until (bad-merge?))))))
   (void))
 

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -656,9 +656,10 @@
   ;; The back-off scheduler's :node-limit keeps the e-graph within the node
   ;; limit as it chooses matches; the :until guards with get-node-size! stop
   ;; the schedule once the limit is reached. Both measure e-nodes (rows of
-  ;; eq-sort tables), matching what egg counts, rather than get-size!'s total
-  ;; table size. After each iteration, we check for unsound merges via
-  ;; bad-merge-rule. The schedule runs until:
+  ;; constructor tables, excluding relations and analysis functions), matching
+  ;; what egg counts, rather than get-size!'s total table size. After each
+  ;; iteration, we check for unsound merges via bad-merge-rule. The schedule
+  ;; runs until:
   ;;   1. Node limit is reached (get-node-size! >= node-limit)
   ;;   2. Saturation (no more progress)
   ;;   3. Iter limit is reached

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -663,10 +663,12 @@
   (define iter-limit (*default-egglog-iter-limit*))
 
   ;; The back-off scheduler's :node-limit keeps the e-graph within the node
-  ;; limit as it chooses matches; the :until guard with get-node-size! stops
-  ;; the schedule once the limit is reached. Both measure e-nodes (rows of
-  ;; constructor tables, excluding relations and analysis functions), matching
-  ;; what egg counts, rather than get-size!'s total table size. Constant
+  ;; limit as it chooses matches (each rule's matches are applied before the
+  ;; next rule is consulted, so the check sees the live size); the :until
+  ;; guard with get-node-size! stops the schedule once the limit is reached.
+  ;; Both measure e-nodes (rows of constructor tables, excluding relations and
+  ;; analysis functions), matching what egg counts, rather than get-size!'s
+  ;; total table size. Constant
   ;; folding runs with the default scheduler, like egg's analysis-based
   ;; folding: it is not rewriting to be rationed, and running it through the
   ;; same back-off instance would advance that scheduler's iteration counter
@@ -680,10 +682,13 @@
 
   (egglog-send subproc
                `(run-schedule
-                 (let-scheduler bo (back-off :node-limit ,node-limit :eager-apply 1))
+                 (let-scheduler bo (back-off :node-limit ,node-limit))
                  (repeat ,iter-limit
-                         (seq (run-with bo ,tag :until (<= ,node-limit (get-node-size!)))
-                              (run const-fold)
+                         (seq (run-with bo
+                                        ,tag
+                                        :until (or (bad-merge?) (<= ,node-limit (get-node-size!))))
+                              (run bad-merge-rule :until (bad-merge?))
+                              (saturate (run const-fold :until (bad-merge?)))
                               (run bad-merge-rule :until (bad-merge?))))))
   (void))
 

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -101,6 +101,13 @@
                     reprs
                     [label #f]
                     #:extract extract) ; multi expression extraction
+  ;; With no roots there is nothing to insert or extract. Skip the subprocess
+  ;; entirely.
+  (if (null? (egglog-runner-vs runner))
+      '()
+      (run-egglog-subprocess runner output-block reprs label extract)))
+
+(define (run-egglog-subprocess runner output-block reprs label extract)
   (define insert-block (egglog-runner-block runner))
   (define insert-vs (egglog-runner-vs runner))
   (define schedule (egglog-runner-schedule runner))

--- a/src/core/egglog-subprocess.rkt
+++ b/src/core/egglog-subprocess.rkt
@@ -73,10 +73,25 @@
   (for/list ([result (in-list results)])
     (read (open-input-string result))))
 
+;; Send an extract command and read its single s-expression response directly
+;; from the subprocess port. Responses can be many megabytes, so this avoids
+;; materializing them as intermediate line strings before parsing.
 (define (egglog-multi-extract subproc extract-command)
-  (define raw-lines (first (egglog-send subproc extract-command)))
-  (define combined (string-join raw-lines " "))
-  (define parsed (read (open-input-string combined)))
-  (for/list ([result-list (in-list parsed)])
-    (for/list ([result (in-list result-list)])
-      result)))
+  (match-define (egglog-subprocess egglog-process egglog-output egglog-in err dump-file) subproc)
+
+  (when dump-file
+    (pretty-print extract-command dump-file 1)
+    (flush-output dump-file))
+
+  (writeln extract-command egglog-in)
+  (flush-output egglog-in)
+
+  (define result (read egglog-output))
+  (when (eof-object? result)
+    (error 'egglog-multi-extract "egglog subprocess closed its output"))
+  ;; Drain the rest of the response up to the (done) marker.
+  (let loop ()
+    (define line (read-line egglog-output))
+    (unless (or (eof-object? line) (equal? line "(done)"))
+      (loop)))
+  result)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -193,7 +193,7 @@
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog runner global-batch reprs 'rewrite #:extract 1000000) ; "infinity"
+        (run-egglog runner global-batch reprs 'rewrite #:extract (*egglog-variants-limit*))
         (egraph-variations runner global-batch reprs)))
 
   ; apply changelists


### PR DESCRIPTION
Draft: requires the egglog-experimental build from egraphs-good/egglog-experimental#63 (pinned to egraphs-good/egglog#1005, currently rev `924b5cd0`) on PATH. Nightly-infra note: the `egglog-herbie` Makefile target installs egglog-experimental from upstream main, which lacks `:dag` and the back-off tags this branch uses — and because Herbie blocks on egglog protocol errors, that binary turns every test into a silent 150 s timeout. Until #63 merges, the target must install from that PR's branch.

## What's added

- **Size-aware scheduling**: the rewrite schedule becomes `(back-off :node-limit ,node-limit)` with an `:until` guard on `(or (bad-merge?) (<= node-limit (get-node-size!)))`. The scheduler (egraphs-good/egglog#1005) applies each rule's chosen matches before consulting the next rule and checks the live e-node count against the limit, instead of choosing all matches against a stale size; the e-graph is rebuilt once per iteration, as in egg. Node limits count e-nodes (like egg) rather than total table rows. `bad-merge-rule` now also runs after the rewrite phase, and both the rewrite loop and constant folding stop as soon as `bad-merge?` fires, so an unsound merge halts the schedule instead of feeding further growth.
- **Same rule set and scheduling as egg**: rules with a bare-variable left-hand side (`pow1: a -> (pow a 1)`) are expanded into one rule per spec constructor instead of being dropped (egg applies them; skipping them made egglog do less per iteration, run more iterations, and extract ~2× wider root classes at the same node limit). Constant folding saturates with the default scheduler (`(saturate (run const-fold :until (bad-merge?)))`), like egg's analysis-based folding: it is not rewriting to be rationed, and running it through the back-off instance advanced that scheduler's iteration counter twice per repeat, halving ban lengths relative to egg.
- **Persistent egglog subprocess**: the prelude and all rule declarations are identical for every call in a run, so one subprocess per worker loads them once and each call is isolated with egglog `push`/`pop`. Timeout-interrupted calls are detected and the subprocess discarded; `dump:egglog` still spawns per call so dumps stay self-contained. Bindings are anchored by one indexed `herbie-const` constructor declared in the prelude instead of one `constructor` command per binding.
- **DAG extraction**: `multi-extract ... :dag` let-binds subterms shared across variants instead of expanding each variant to a tree (~12× smaller responses); the response is `read` directly from the subprocess port and interned with per-shared-subterm memoization.
- **Calls with no roots skip the subprocess**: a program with no real-typed roots (e.g. an FPCore whose output is a vector) produced a series-phase call ending in a zero-expression `multi-extract` — an egglog parse error that left Herbie blocked on a response until the per-test timeout. `run-egglog` now returns no variants without consulting the subprocess, matching the egg path. Fixes the `Return input vector` timeout in `bench/arrays.fpcore` (150 s → 0.4 s, result identical to egg).
- `*egglog-variants-limit*` is wired into `patch.rkt` (previously dead code; default keeps the hardcoded 1,000,000 — no behavior change).

## Performance (bench/numerics, seed 1, `--threads 1`)

| | wall time | rewrite phase | rewrite candidates | mean end error |
| --- | --- | --- | --- | --- |
| egglog backend, before this PR | 365.7 s | 128.3 s | — | 4 failing tests |
| + size-aware eager scheduling, persistent subprocess, `:dag` | 79.9 s | 19.3 s | 477,707 | 1.434 |
| + egg's rule set/scheduling, one rebuild per iteration | **74.3 s** | 19.7 s | 357,988 | 1.444 |
| egg backend (reference) | 60.2 s | 10.2 s | 297,539 | 1.492 |

Where the remaining single-threaded 1.24× goes (profile in the branch's `egglog-scheduler-design.md`): Herbie's `reconstruct!` scales with candidate count (egglog still returns 1.2× egg's), e-matching over egg-length bans, per-call `push`/`pop` cloning of the rule set, and the taylor-lowering path's fixed per-call cost.

## Full bench/ evaluation (seed 1, `--threads 8`, 150 s/test, 718 FPCores)

Both backends run sequentially from the same checkout on an idle 128-core machine, 2026-08-31:

| | egg | egglog | ratio |
| --- | --- | --- | --- |
| wall (8 threads) | 17m14s | **17m09s** | 1.00x |
| peak RSS | 19.3 GB | 12.1 GB | — |
| mean end error (bits, 710 paired) | 2.337 | 2.390 | — |
| timeouts (150 s) | 2 | 2 | — |
| crashes | 0 | 0 | — |

Accuracy is a wash: 51 egglog wins / 61 losses / 598 within 0.1 bits over the 710 tests both scored, with symmetric tails. Summed per-test time is 1.07× egg's — the remaining serial overhead is fully absorbed by parallelism. The failure set is now **identical** between backends: 5 pre-existing errors and the 2 expected fidget timeouts (prospero, bear), all backend-independent. The regressions in the previous version of this evaluation (1.41× wall, 45 series-phase timeouts, 4 vector-program crashes, multi-GB memory spikes on the `proj` suite) are gone with the schedule changes and the no-roots fix above.

A replication of the nightly flow (`infra/nightly.sh bench reports --threads 2`, date seed) completes all 718 tests in 26m14s of benchmarking with the same 7 backend-independent failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
