### PR TITLE
Speed up sampling with an untyped Rival bigfloat/flonum fast path

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1139,14 +1139,14 @@
            (egraph-run-rules egg-graph
                              rules
                              #:node-limit (rewrite-node-limit rewrite-initial-size))]))
-  
+
       ; get cost statistics
       (for ([iter (in-list iteration-data)]
             [i (in-naturals)])
         (define cnt (iteration-data-num-nodes iter))
         (define cost (for/sum ([id (in-list root-ids)]) (egraph_get_cost egg-graph* id i)))
         (timeline-push! 'egraph i cnt cost (iteration-data-time iter)))
-  
+
       (define rewrite-initial-size*
         (if (empty? iteration-data)
             rewrite-initial-size

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -49,7 +49,7 @@
   (let loop ([left 0]
              [right (- (vector-length vector) 1)])
     (cond
-      [(>= left right) (min left (- (vector-length vector) 1))]
+      [(= left right) left]
       [else
        (define mid (arithmetic-shift (+ left right) -1))
        (define pivot (vector-ref vector mid))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require math/bigfloat
+         (only-in math/private/bigfloat/mpfr [bigfloat->flonum direct-bigfloat->flonum])
          math/base
          math/flonum
          "../utils/errors.rkt")
@@ -123,7 +124,7 @@
 
 (define <binary64>
   (make-representation #:name 'binary64
-                       #:bf->repr bigfloat->flonum
+                       #:bf->repr direct-bigfloat->flonum
                        #:repr->bf (lambda (x)
                                     (parameterize ([bf-precision 53])
                                       (bf x)))


### PR DESCRIPTION
This uses an untyped version of `bigfloat->flonum`, which skips Typed Racket overhead.